### PR TITLE
Add PubSub interface to process incoming requests

### DIFF
--- a/tests/evidence.py
+++ b/tests/evidence.py
@@ -25,15 +25,15 @@ class TestTurbiniaEvidence(unittest.TestCase):
 
   def testEvidenceSerialization(self):
     """Test that evidence serializes/unserializes."""
-    e = evidence.RawDisk(
+    rawdisk = evidence.RawDisk(
         name=u'My Evidence', local_path=u'/tmp/foo', mount_path=u'/mnt/foo')
-    e_json = e.to_json()
-    self.assertTrue(isinstance(e_json, str))
+    rawdisk_json = rawdisk.to_json()
+    self.assertTrue(isinstance(rawdisk_json, str))
 
-    e_new = evidence.evidence_decode(json.loads(e_json))
-    self.assertTrue(isinstance(e_new, evidence.RawDisk))
-    self.assertEqual(e_new.name, u'My Evidence')
-    self.assertEqual(e_new.mount_path, u'/mnt/foo')
+    rawdisk_new = evidence.evidence_decode(json.loads(rawdisk_json))
+    self.assertTrue(isinstance(rawdisk_new, evidence.RawDisk))
+    self.assertEqual(rawdisk_new.name, u'My Evidence')
+    self.assertEqual(rawdisk_new.mount_path, u'/mnt/foo')
 
   def testEvidenceSerializationBadType(self):
     """Test that evidence_decode throws error on non-dict type."""

--- a/tests/evidence.py
+++ b/tests/evidence.py
@@ -17,6 +17,7 @@ import json
 import unittest
 
 from turbinia import evidence
+from turbinia import TurbiniaException
 
 
 class TestTurbiniaEvidence(unittest.TestCase):
@@ -33,3 +34,12 @@ class TestTurbiniaEvidence(unittest.TestCase):
     self.assertTrue(isinstance(e_new, evidence.RawDisk))
     self.assertEqual(e_new.name, u'My Evidence')
     self.assertEqual(e_new.mount_path, u'/mnt/foo')
+
+  def testEvidenceSerializationBadType(self):
+    """Test that evidence_decode throws error on non-dict type."""
+    self.assertRaises(TurbiniaException, evidence.evidence_decode, [1, 2])
+
+  def testEvidenceSerializationNoTypeAttribute(self):
+    """Test that evidence_decode throws error on dict with no type attribute."""
+    test = {1: 2, 3: 4}
+    self.assertRaises(TurbiniaException, evidence.evidence_decode, test)

--- a/tests/evidence.py
+++ b/tests/evidence.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Turbinia evidence."""
+
+import json
+import unittest
+
+from turbinia import evidence
+
+
+class TestTurbiniaEvidence(unittest.TestCase):
+  """Test evidence module."""
+
+  def testEvidenceSerialization(self):
+    """Test that evidence serializes/unserializes."""
+    e = evidence.RawDisk(
+        name=u'My Evidence', local_path=u'/tmp/foo', mount_path=u'/mnt/foo')
+    e_json = e.to_json()
+    self.assertTrue(isinstance(e_json, str))
+
+    e_new = evidence.evidence_decode(json.loads(e_json))
+    self.assertTrue(isinstance(e_new, evidence.RawDisk))
+    self.assertEqual(e_new.name, u'My Evidence')
+    self.assertEqual(e_new.mount_path, u'/mnt/foo')

--- a/tests/pubsub.py
+++ b/tests/pubsub.py
@@ -52,7 +52,7 @@ class MockPubSubResults(list):
 
 
 class TestTurbiniaRequest(unittest.TestCase):
-  """Test pubsub module."""
+  """Test TurbiniaRequest class."""
 
   def testTurbiniaRequestSerialization(self):
     """Test that TurbiniaRequests serializes/unserializes."""

--- a/tests/pubsub.py
+++ b/tests/pubsub.py
@@ -1,0 +1,129 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for Turbinia pubsub module."""
+
+import unittest
+
+import mock
+
+from turbinia import evidence
+from turbinia import pubsub
+from turbinia import TurbiniaException
+
+
+def getTurbiniaRequest():
+  """Get a Turbinia Request object with valid evidence attached.
+
+  Returns:
+    TurbiniaRequest object.
+  """
+  tr = pubsub.TurbiniaRequest(request_id=u'deadbeef', context={'kw': [1, 2]})
+  e = evidence.RawDisk(
+      name=u'My Evidence', local_path=u'/tmp/foo', mount_path=u'/mnt/foo')
+  tr.evidence.append(e)
+  return tr
+
+
+class MockPubSubMessage(object):
+  """This is a mock of a PubSub message."""
+
+  def __init__(self, data='fake data', message_id='12345'):
+    self.data = data if data else ''
+    self.message_id = message_id
+
+
+class MockPubSubResults(list):
+  """Mock of a PubSub Results list that can contain MockPubSubMessages."""
+
+  def __init__(self, ack_id='54321', message='fake message'):
+    super(MockPubSubResults, self).__init__()
+    self.append((ack_id, message))
+
+
+class TestTurbiniaRequest(unittest.TestCase):
+  """Test pubsub module."""
+
+  def testTurbiniaRequestSerialization(self):
+    """Test that TurbiniaRequests serializes/unserializes."""
+    tr = getTurbiniaRequest()
+    tr_json = tr.to_json()
+    self.assertTrue(isinstance(tr_json, str))
+
+    # Create a new Turbinia Request object to load our results into
+    tr_new = pubsub.TurbiniaRequest()
+    tr_new.from_json(tr_json)
+
+    self.assertTrue(isinstance(tr_new, pubsub.TurbiniaRequest))
+    self.assertTrue(tr_new.context['kw'][1], 2)
+    self.assertTrue(tr_new.request_id, u'deadbeef')
+    self.assertTrue(isinstance(tr_new.evidence[0], evidence.RawDisk))
+    self.assertEqual(tr_new.evidence[0].name, u'My Evidence')
+
+  def testTurbiniaRequestSerializationBadData(self):
+    """Tests that TurbiniaRequest will raise error on non-json data."""
+    tr_new = pubsub.TurbiniaRequest()
+    self.assertRaises(TurbiniaException, tr_new.from_json, 'non-json-data')
+
+  def testTurbiniaRequestSerializationBadJSON(self):
+    """Tests that TurbiniaRequest will raise error on wrong JSON object."""
+    e = evidence.RawDisk(name=u'My Evidence', local_path=u'/tmp/foo')
+    e_json = e.to_json()
+    self.assertTrue(isinstance(e_json, str))
+
+    tr_new = pubsub.TurbiniaRequest()
+    # Try to load serialization RawDisk() into a TurbiniaRequest, which should
+    # error because this is not the correct type.
+    self.assertRaises(TurbiniaException, tr_new.from_json, e_json)
+
+
+class TestTurbiniaPubSub(unittest.TestCase):
+  """Test turbinia.pubsub module."""
+
+  def setUp(self):
+    tr = getTurbiniaRequest()
+    self.pubsub = pubsub.TurbiniaPubSub(u'fake_topic')
+    results = MockPubSubResults(
+        ack_id=u'1234', message=MockPubSubMessage(tr.to_json(), u'msg id'))
+    self.pubsub.subscription = mock.MagicMock()
+    self.pubsub.subscription.pull.return_value = results
+
+  def testCheckMessages(self):
+    """Test check_messages to make sure it returns the expected results."""
+    results = self.pubsub.check_messages()
+    self.assertTrue(len(results) == 1)
+    tr_new = results[0]
+
+    # Make sure that the TurbiniaRequest object is as expected
+    self.assertTrue(isinstance(tr_new, pubsub.TurbiniaRequest))
+    self.assertTrue(tr_new.context['kw'][1], 2)
+    self.assertTrue(tr_new.request_id, u'deadbeef')
+    self.assertTrue(isinstance(tr_new.evidence[0], evidence.RawDisk))
+    self.assertEqual(tr_new.evidence[0].name, u'My Evidence')
+
+    # Make sure that the test message was acknowledged
+    self.pubsub.subscription.acknowledge.assert_called_with([u'1234'])
+
+  def testBadCheckMessages(self):
+    """Test check_messages returns empty list for an invalid message."""
+    results = MockPubSubResults(
+        ack_id=u'2345', message=MockPubSubMessage(u'non-json-data', u'msg id2'))
+    self.pubsub.subscription.pull.return_value = results
+
+    self.assertListEqual(self.pubsub.check_messages(), [])
+
+  def testSendMessage(self):
+    """Test sending a message."""
+    self.pubsub.topic = mock.MagicMock()
+    self.pubsub.send_message(u'test message text')
+    self.pubsub.topic.publish.assert_called_with(u'test message text')

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -75,7 +75,7 @@ class Evidence(object):
       description=None,
       source=None,
       local_path=None,
-      tags=None
+      tags=None,
       request_id=None):
     """Initialization for Evidence."""
     self.description = description

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -23,7 +23,8 @@ def evidence_decode(evidence_dict):
   """Decode JSON into appropriate Evidence object.
 
   Args:
-    evidence_str: Serialized evidence (i.e. a __dict__ post JSON decoding).
+    evidence_dict: JSON serializeable evidence object (i.e. a dict post JSON
+                   decoding).
 
   Returns:
     An instantiated Evidence object (or a sub-class of it).

--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -11,154 +11,168 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Google PubSub Client."""
+"""Google PubSub Listener for requests to Turbinia to process evidence."""
 
-import base64
-import httplib2
+import copy
 import json
 import logging
+import uuid
 
-# Google API
-from googleapiclient import discovery
-from googleapiclient import errors as google_errors
-from googleapiclient import http as storage_http
-from oauth2client import client as oauth2client
+from google.cloud import pubsub
 
 # Turbinia
 from turbinia import config
+from turbinia import evidence
+from turbinia import TurbiniaException
 
 log = logging.getLogger('turbinia')
 
-# PubSub Message types
-[
-    # Messages sent to server
-    ARTIFACTNEW,
-    WORKERUPDATE,
-    TASKUPDATE,
-    # Messages sent to workers
-    TASKSTART,
-    TASKSTOP,] = xrange(5)
 
+class TurbiniaRequest(object):
+  """An object to request evidence to be processed.
 
-class GoogleCloudClient(object):
+  Attributes:
+    request_id: A client specified ID for this request.
+    recipe: Recipe to use when processing this request.
+    context: A Dict of context data to be passed around with this request.
+    evidence: A list of Evidence objects.
+  """
 
-  def __init__(self, service):
-    self.service = service
-    self.client = None
+  def __init__(self, request_id=None, recipe=None, context=None,
+               evidence_=None):
+    """Initialization for TurbiniaRequest."""
+    self.request_id = request_id if request_id else uuid.uuid4().hex
+    self.recipe = recipe
+    self.context = context if context else {}
+    self.evidence = evidence_ if evidence_ else []
+    self.type = self.__class__.__name__
 
-  def _client_setup(self):
-    """Creates an API client for talking to Google Cloud.
+  def to_json(self):
+    """Convert object to JSON.
 
     Returns:
-        A client object for interacting with the cloud service.
+      A JSON serialized object.
     """
-    log.info(u'Creating API client for service: {0:s}'.format(self.service))
-    credentials = oauth2client.GoogleCredentials.get_application_default()
-    http = httplib2.Http()
-    credentials.authorize(http)
-    self.client = discovery.build(self.service, 'v1', http=http)
-    return self.client
+    serializable = copy.deepcopy(self.__dict__)
+    serializable['evidence'] = [x.serialize() for x in serializable['evidence']]
 
+    try:
+      serialized = json.dumps(serializable)
+    except TypeError as e:
+      msg = ('JSON serialization of TurbiniaRequest object {0:s} failed: '
+             '{1:s}'.format(self.type, str(e)))
+      raise TurbiniaException(msg)
 
-class PubSubMessage(dict):
+    return serialized
 
-  def __init__(self, message_type):
-    self['message_type'] = message_type
-    super(PubSubMessage, self).__init__()
-
-
-class PubSubClient(GoogleCloudClient):
-
-  def __init__(self, topic):
-    self.topic = topic
-    super(PubSubClient, self).__init__(u'pubsub')
-    config.LoadConfig()
-    self.subscription = u'projects/{0:s}/subscriptions/{1:s}'.format(
-        config.PROJECT, self.topic)
-
-  def _setup(self):
-    self._client_setup()
-
-  def _validate_message(self, message):
-    """Validates pubsub messages to ensure required fields are available.
+  def from_json(self, json_str):
+    """Loads JSON serialized data into self.
 
     Args:
-      message: dict of pubsub message
+      json_str (str): Json serialized TurbiniaRequest object.
+
+    Raises:
+      TurbiniaException: If json can not be loaded, or deserialized object is
+          not of the correct type.
+    """
+    try:
+      obj = json.loads(json_str)
+    except ValueError as e:
+      raise TurbiniaException(
+          u'Can not load json from string {0:s}'.format(str(e)))
+
+    if obj.get('type', None) != self.type:
+      raise TurbiniaException(
+          u'Deserialized object does not have type of {0:s}'.format(self.type))
+
+    obj['evidence'] = [evidence.evidence_decode(e) for e in obj['evidence']]
+    # pylint: disable=attribute-defined-outside-init
+    self.__dict__ = obj
+
+
+class TurbiniaPubSub(object):
+  """PubSub client object for Google Cloud.
+
+  Attributes:
+    topic: The pubsub topic object
+    topic_name: The pubsub topic name
+    subscription: The pubsub subscription object
+  """
+
+  def __init__(self, topic_name):
+    """Initialization for PubSubClient."""
+    self.topic_name = topic_name
+    self.topic = None
+    self.subscription = None
+
+  def setup(self):
+    """Set up the client."""
+    config.LoadConfig()
+    client = pubsub.Client(project=config.PROJECT)
+    self.topic = client.topic(self.topic_name)
+    log.debug('Connecting to PubSub Subscription on {0:s}'.format(self.topic))
+    self.subscription = self.topic.subscription(self.topic_name)
+
+  def _validate_message(self, message):
+    """Validates pubsub messages and returns them as a new TurbiniaRequest obj.
+
+    Args:
+      message: PubSub message string
 
     Returns:
-      Bool indicating whether message is properly validated
+      A TurbiniaRequest object or None if there are decoding failures.
     """
-    required_fields = {
-        ARTIFACTNEW: [u'artifact'],
-        TASKUPDATE: [u'task_id', u'job_id', u'status'],
-        WORKERUPDATE: [u'worker_id', u'status'],
-        TASKSTART: [u'task_id', u'job_id'],
-        TASKSTOP: [u'task_id', u'job_id'],}
+    request = TurbiniaRequest()
+    try:
+      request.from_json(message)
+    except TurbiniaException as e:
+      log.error(u'Error decoding pubsub message: {0:s}'.format(str(e)))
+      return None
 
-    # TODO(aarontp): Enforce these
-    optional_fields = {
-        ARTIFACTNEW: [],
-        TASKUPDATE: [u'update_text', u'result'],
-        WORKERUPDATE: [u'update_text', u'result'],
-        TASKSTART: [],
-        TASKSTOP: [],}
+    return request
 
-    if not message.has_key(u'message_type'):
-      log.error(u'Message has no message_type: {0:s}'.format(str(message)))
-      return False
-
-    for field in required_fields.get(message[u'message_type'], []):
-      if not message.has_key(field):
-        log.error(
-            u'Message type {0:s} must have field {1:s}: {2:s}'.format(
-                message.get(u'message_type'), field, str(message)))
-        return False
-
-    return True
-
-  def check_message(self):
+  def check_messages(self):
     """Checks for a pubsub message.
 
     Returns:
-      Data dict if message is received, else None
+      A list of any TurbiniaRequest objects received, else an empty list
     """
-    data = None
-    body = {
-        u'returnImmediately': False,
-        u'maxMessages': 1,}
+    results = self.subscription.pull(return_immediately=True)
+    logging.info(u'Recieved {0:d} pubsub messages'.format(len(results)))
 
-    resp = self.client.projects().subscriptions().pull(
-        subscription=self.subscription, body=body).execute()
-    received_messages = resp.get(u'receivedMessages')
-    if received_messages is not None:
-      ack_ids = []
-      received_message = received_messages[0]
-      pubsub_message = received_message.get(u'message')
-      if pubsub_message:
-        log.info(u'PubSub message received')
-        # Process messages
-        data = base64.b64decode(str(pubsub_message.get(u'data')))
-        try:
-          data = json.loads(data)
-          log.info(u'Message body: {0:s}'.format(data))
-        except (ValueError, KeyError) as e:
-          log.error(u'Error processing message: {0:s}'.format(e))
+    ack_ids = []
+    requests = []
+    for ack_id, message in results:
+      data = message.data
+      log.info(u'Processing PubSub Message {0:s}'.format(message.message_id))
+      log.debug(u'PubSub Message body: {0:s}'.format(data))
 
-        # Get the message's ack ID
-        ack_ids.append(received_message.get(u'ackId'))
+      request = self._validate_message(data)
+      if request:
+        requests.append(request)
+        ack_ids.append(ack_id)
+      else:
+        log.error(u'Error processing PubSub message: {0:s}'.format(data))
 
-        # Create a POST body for the acknowledge request
-        ack_body = {u'ackIds': ack_ids}
+    if results:
+      self.subscription.acknowledge(ack_ids)
 
-        # Acknowledge the message.
-        self.client.projects().subscriptions().acknowledge(
-            subscription=self.subscription, body=ack_body).execute()
+    return requests
 
-    if not self._validate_message(data):
-      log.error('Error processing invalid message: {0:s}'.format(data))
-
-    return data
-
-  # TODO(aarontp): fill in
   def send_message(self, message):
-    pass
+    """Send a pubsub message.
+
+    message: The message to send.
+    """
+    data = message.encode('utf-8')
+    msg_id = self.topic.publish(data)
+    logging.info(u'Published message {0:s} to topic {1:s}'.format(
+        msg_id, self.topic_name))
+
+  def send_request(self, request):
+    """Sends a TurbiniaRequest message.
+
+    Args:
+      request: A TurbiniaRequest object.
+    """
+    self.send_message(request.to_json())

--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -38,8 +38,8 @@ class TurbiniaRequest(object):
     evidence: A list of Evidence objects.
   """
 
-  def __init__(self, request_id=None, recipe=None, context=None,
-               evidence_=None):
+  def __init__(
+      self, request_id=None, recipe=None, context=None, evidence_=None):
     """Initialization for TurbiniaRequest."""
     self.request_id = request_id if request_id else uuid.uuid4().hex
     self.recipe = recipe
@@ -59,8 +59,9 @@ class TurbiniaRequest(object):
     try:
       serialized = json.dumps(serializable)
     except TypeError as e:
-      msg = ('JSON serialization of TurbiniaRequest object {0:s} failed: '
-             '{1:s}'.format(self.type, str(e)))
+      msg = (
+          'JSON serialization of TurbiniaRequest object {0:s} failed: '
+          '{1:s}'.format(self.type, str(e)))
       raise TurbiniaException(msg)
 
     return serialized
@@ -166,8 +167,9 @@ class TurbiniaPubSub(object):
     """
     data = message.encode('utf-8')
     msg_id = self.topic.publish(data)
-    logging.info(u'Published message {0:s} to topic {1:s}'.format(
-        msg_id, self.topic_name))
+    logging.info(
+        u'Published message {0:s} to topic {1:s}'.format(
+            msg_id, self.topic_name))
 
   def send_request(self, request):
     """Sends a TurbiniaRequest message.

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -127,7 +127,7 @@ class BaseTaskManager(object):
     for job in self.jobs:
       if [True for t in job.evidence_input if isinstance(evidence_, t)]:
         log.info(
-            u'Using {0:s} job to process {1:s}'.format(
+            u'Adding {0:s} job to process {1:s}'.format(
                 job.name, evidence_.name))
         job_count += 1
         for task in job.create_tasks([evidence_]):
@@ -285,8 +285,9 @@ class PSQTaskManager(BaseTaskManager):
       for evidence_ in request.evidence:
         if not evidence_.request_id:
           evidence_.request_id = request.request_id
-        log.info(u'Received evidence [{0:s}] from PubSub message.'.format(
-            str(evidence_)))
+        log.info(
+            u'Received evidence [{0:s}] from PubSub message.'.format(
+                str(evidence_)))
         evidence_list.append(evidence_)
     return evidence_list
 

--- a/turbiniactl
+++ b/turbiniactl
@@ -49,8 +49,6 @@ if __name__ == '__main__':
       '-d', '--debug', action='store_true', help='debug', default=True)
   parser.add_argument('-o', '--output_dir', help='Directory path for output')
   parser.add_argument('-L', '--log_file', help='Log file')
-  parser.add_argument('-S', '--server', action='store_true',
-                      help='Run Turbinia Server indefinitely')
   parser.add_argument(
       '-S',
       '--server',
@@ -146,19 +144,18 @@ if __name__ == '__main__':
       worker = psq.Worker(queue=task_manager_.psq)
     else:
       worker = psq.MultiprocessWorker(queue=task_manager_.psq)
-    # Log here instead of print to stay consistent with all the rest of the PSQ
-    # output which is logged.
     log.info(
         u'Starting PSQ listener on queue {0:s}'.format(task_manager_.psq.name))
     worker.listen()
   elif args.command == 'server':
-    print 'Running Turbinia Server.'
+    log.info(u'Running Turbinia Server.')
     task_manager_.run()
   elif args.command == 'listjobs':
-    print 'Available Jobs:'
-    print '\n'.join(['\t{0:s}'.format(job.name) for job in task_manager_.jobs])
+    log.info(u'Available Jobs:')
+    log.info(
+        '\n'.join(['\t{0:s}'.format(job.name) for job in task_manager_.jobs]))
   else:
-    print 'Command {0:s} not implemented.'.format(args.command)
+    log.warning(u'Command {0:s} not implemented.'.format(args.command))
 
   # If we have evidence to process and we also want to run as a server, then
   # we'll just process the evidence directly rather than send it through the
@@ -170,8 +167,9 @@ if __name__ == '__main__':
   elif evidence_:
     request = TurbiniaRequest()
     request.evidence.append(evidence_)
-    print u'Creating PubSub request with evidence {0:s}'.format(evidence_.name)
+    log.info(
+        u'Creating PubSub request with evidence {0:s}'.format(evidence_.name))
     task_manager_.server_pubsub.send_request(request)
 
-  print 'Done.'
+  log.info(u'Done.')
   sys.exit(0)

--- a/turbiniactl
+++ b/turbiniactl
@@ -32,6 +32,7 @@ from turbinia.config import logger
 from turbinia import evidence
 from turbinia import task_manager
 from turbinia import VERSION
+from turbinia.pubsub import TurbiniaRequest
 
 log = logging.getLogger('turbinia')
 logger.setup()
@@ -48,6 +49,8 @@ if __name__ == '__main__':
       '-d', '--debug', action='store_true', help='debug', default=True)
   parser.add_argument('-o', '--output_dir', help='Directory path for output')
   parser.add_argument('-L', '--log_file', help='Log file')
+  parser.add_argument('-S', '--server', action='store_true',
+                      help='Run Turbinia Server indefinitely')
   parser.add_argument(
       '-S',
       '--server',
@@ -104,6 +107,9 @@ if __name__ == '__main__':
       help='Run PSQ Worker in a single thread',
       required=False)
 
+  # Server
+  parser_server = subparsers.add_parser('server', help='Run Turbinia Server')
+
   args = parser.parse_args()
   if args.verbose:
     log.setLevel(logging.INFO)
@@ -145,13 +151,27 @@ if __name__ == '__main__':
     log.info(
         u'Starting PSQ listener on queue {0:s}'.format(task_manager_.psq.name))
     worker.listen()
+  elif args.command == 'server':
+    print 'Running Turbinia Server.'
+    task_manager_.run()
   elif args.command == 'listjobs':
     print 'Available Jobs:'
     print '\n'.join(['\t{0:s}'.format(job.name) for job in task_manager_.jobs])
   else:
     print 'Command {0:s} not implemented.'.format(args.command)
 
-if evidence_:
-  config.SINGLE_RUN = True if not args.server else False
-  task_manager_.add_evidence(evidence_)
-  task_manager_.run()
+  # If we have evidence to process and we also want to run as a server, then
+  # we'll just process the evidence directly rather than send it through the
+  # PubSub frontend interface.  If we're not running as a server then we will
+  # create a new TurbiniaRequest and send it over PubSub.
+  if evidence_ and args.server:
+    task_manager_.add_evidence(evidence_)
+    task_manager_.run()
+  elif evidence_:
+    request = TurbiniaRequest()
+    request.evidence.append(evidence_)
+    print u'Creating PubSub request with evidence {0:s}'.format(evidence_.name)
+    task_manager_.server_pubsub.send_request(request)
+
+  print 'Done.'
+  sys.exit(0)


### PR DESCRIPTION
This adds a listener to the Turbinia server that will listen for incoming requests to process evidence.  It also changes turbiniactl to send evidence over pubsub when it is not operating as a server.