### PR TITLE
Add pre/post-process hooks for evidence

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -73,6 +73,24 @@ class Evidence(object):
 
     return serialized
 
+  def preprocess(self):
+    """Preprocess this evidence prior to task running.
+
+    This gets run in the context of the local task execution on the worker
+    nodes prior to the task itself running.  This can be used to prepare the
+    evidence to be processed (e.g. attach a cloud disk, mount a local disk etc).
+    """
+    pass
+
+  def postprocess(self):
+    """Postprocess this evidence after the task runs.
+
+    This gets run in the context of the local task execution on the worker
+    nodes after the task itself runs.  This can be used to clean-up after the
+    evidence is processed (e.g. detach a cloud disk, etc,).
+    """
+    pass
+
 
 class Directory(Evidence):
   """Filesystem directory evidence."""

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -86,7 +86,7 @@ class Evidence(object):
     """Postprocess this evidence after the task runs.
 
     This gets run in the context of the local task execution on the worker
-    nodes after the task itself runs.  This can be used to clean-up after the
+    nodes after the task has finished.  This can be used to clean-up after the
     evidence is processed (e.g. detach a cloud disk, etc,).
     """
     pass

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -79,6 +79,7 @@ class TurbiniaTaskResult(object):
       with open(logfile, 'w') as f:
         f.write('\n'.join(self._log))
         f.write('\n')
+    self.input_evidence.postprocess()
     self.status = status
 
   def log(self, log_msg):
@@ -155,6 +156,7 @@ class TurbiniaTask(object):
       raise TurbiniaException(
           'Evidence local path {0:s} does not exist'.format(
               evidence.local_path))
+    evidence.preprocess()
     return self.result
 
   def create_output_dir(self):


### PR DESCRIPTION
What do you think about this as a base implementation for {pre,post}-processing could work?  I realized that almost all of the cases for preprocessing are related to specific evidence types, and we can use the normal inheritance mechanisms here to make things work.  For example, the GoogleCloudDisk.preprocess() can do the attaching, and then it can call its parent's (RawDisk's) preprocess() to do the actual local mounting of the disk (if we wanted to actually mount it) too.

If we have a non-evidence specific type of pre/post processing that we want to do, I think we can implement that as decorators for the TurbiniaTask.run() methods, but I wasn't sure if we had a good use-case for that, so I didn't want to add it until we needed it.