### PR TITLE
Process GCP persistent disks with embedded raw image

### DIFF
--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -35,6 +35,7 @@ CONFIGVARS = [
     'OUTPUT_DIR',
     'SLEEP_TIME',
     'SINGLE_RUN',
+    'MOUNT_DIR_PREFIX',
     # GCE CONFIG
     'PROJECT',
     'ZONE',

--- a/turbinia/config/turbinia_config.py
+++ b/turbinia/config/turbinia_config.py
@@ -24,6 +24,9 @@ OUTPUT_DIR = None
 SLEEP_TIME = 10
 # Whether to run as a single run, or to keep server running indefinitely
 SINGLE_RUN = False
+# Local directory in the worker to put other mount directories for locally
+# mounting images/disks
+MOUNT_DIR_PREFIX = u'/mnt/turbinia-mounts'
 
 # GCE configuration
 PROJECT = None

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -14,10 +14,12 @@
 """Turbinia Evidence objects."""
 
 import json
+import os
 import sys
 
 from turbinia import TurbiniaException
 from turbinia.processors import google_cloud
+from turbinia.processors import mount_local
 
 
 def evidence_decode(evidence_dict):
@@ -232,10 +234,12 @@ class GoogleCloudDiskRawEmbedded(GoogleCloudDisk):
 
   def preprocess(self):
     google_cloud.PreprocessAttachDisk(self)
-    self.local_path = self.embedded_path
+    mount_local.PreprocessMountDisk(self)
+    self.local_path = os.path.join(self.mount_path, self.embedded_path)
 
   def postprocess(self):
     google_cloud.PostprocessDetachDisk(self)
+    mount_local.PreprocessUnmountDisk(self)
 
 
 class PlasoFile(Evidence):

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -213,6 +213,31 @@ class GoogleCloudDisk(RawDisk):
     google_cloud.PostprocessDetachDisk(self)
 
 
+class GoogleCloudDiskRawEmbedded(GoogleCloudDisk):
+  """Evidence object for raw disks embedded in Persistent Disks.
+
+  This is for a raw image file that is located in the filesystem of a mounted
+  GCP Persistent Disk.  This can be useful if you want to process a raw disk
+  image originating from outside cloud, and it is much more performant and
+  reliable option than reading it directly from GCS FUSE.
+
+  Attributes:
+    embedded_path: The path of the raw disk image inside the Persistent Disk
+  """
+
+  def __init__(self, embedded_path=None, *args, **kwargs):
+    """Initialization for Google Cloud Disk."""
+    self.embedded_path = embedded_path
+    super(GoogleCloudDiskRawEmbedded, self).__init__(*args, **kwargs)
+
+  def preprocess(self):
+    google_cloud.PreprocessAttachDisk(self)
+    self.local_path = self.embedded_path
+
+  def postprocess(self):
+    google_cloud.PostprocessDetachDisk(self)
+
+
 class PlasoFile(Evidence):
   """Plaso output file evidence.
 

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -27,7 +27,7 @@ def PreprocessMountDisk(evidence):
   """Locally mounts disk in an instance.
 
   Args:
-    evidence: A turbinia.evidence.RawDisk or subclass object.
+    evidence: A turbinia.evidence.RawDisk object or a subclass of it.
   """
   config.LoadConfig()
   mount_prefix = config.MOUNT_DIR_PREFIX

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -1,0 +1,80 @@
+# Copyright 2017 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Evidence processor to mount local images or disks."""
+
+import logging
+import os
+import subprocess
+import tempfile
+
+from turbinia import config
+from turbinia import TurbiniaException
+
+log = logging.getLogger('turbinia')
+
+def PreprocessMountDisk(evidence):
+  """Locally mounts disk in an instance.
+
+  Args:
+    evidence: A turbinia.evidence.RawDisk or subclass object.
+  """
+  config.LoadConfig()
+  mount_prefix = config.MOUNT_DIR_PREFIX
+
+  if os.path.exists(mount_prefix) and not os.isdir(mount_prefix):
+    raise TurbiniaException(
+        'Mount dir {0:s} exists, but is not a directory'.format(mount_prefix))
+  if not os.path.exists(mount_prefix):
+    log.info('Creating local mount parent directory {0:s}'.format(mount_prefix))
+    try:
+      os.makedirs(mount_prefix)
+    except OSError as e:
+      raise TurbiniaException(
+          'Could not create mount directory {0:s}: {1!s}'.format(
+              mount_prefix, e))
+
+  evidence.mount_path = tempfile.mkdtemp(prefix='turbinia', dir=mount_prefix)
+  # TODO(aarontp): Remove hard-coded sudo in commands:
+  # https://github.com/google/turbinia/issues/73
+  mount_cmd = ['sudo', 'mount', evidence.local_path, evidence.mount_path]
+  log.info('Running: {0:s}'.format(' '.join(mount_cmd)))
+  try:
+    subprocess.check_call(mount_cmd)
+  except subprocess.CalledProcessError as e:
+    raise TurbiniaException('Could not mount directory {1!s}'.format(e))
+
+def PostprocessUnmountDisk(evidence):
+  """Locally unmounts disk in an instance.
+
+  Args:
+    evidence: A turbinia.evidence.RawDisk or subclass object.
+  """
+  # TODO(aarontp): Remove hard-coded sudo in commands:
+  # https://github.com/google/turbinia/issues/73
+  umount_cmd = ['sudo', 'umount', evidence.mount_path]
+  log.info('Running: {0:s}'.format(' '.join(umount_cmd)))
+  try:
+    subprocess.check_call(umount_cmd)
+  except subprocess.CalledProcessError as e:
+    raise TurbiniaException('Could not unmount directory {1!s}'.format(e))
+
+  log.info('Removing mount path {0:s}'.format(evidence.mount_path))
+  try:
+    os.rmdir(evidence.mount_path)
+  except OSError as e:
+    raise TurbiniaException(
+        'Could not remove mount path directory {0:s}: {1!s}'.format(
+            evidence.mount_path, e))
+
+  evidence.mount_path = None

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -32,7 +32,7 @@ def PreprocessMountDisk(evidence):
   config.LoadConfig()
   mount_prefix = config.MOUNT_DIR_PREFIX
 
-  if os.path.exists(mount_prefix) and not os.isdir(mount_prefix):
+  if os.path.exists(mount_prefix) and not os.path.isdir(mount_prefix):
     raise TurbiniaException(
         'Mount dir {0:s} exists, but is not a directory'.format(mount_prefix))
   if not os.path.exists(mount_prefix):
@@ -52,7 +52,7 @@ def PreprocessMountDisk(evidence):
   try:
     subprocess.check_call(mount_cmd)
   except subprocess.CalledProcessError as e:
-    raise TurbiniaException('Could not mount directory {1!s}'.format(e))
+    raise TurbiniaException('Could not mount directory {0!s}'.format(e))
 
 def PostprocessUnmountDisk(evidence):
   """Locally unmounts disk in an instance.
@@ -67,7 +67,7 @@ def PostprocessUnmountDisk(evidence):
   try:
     subprocess.check_call(umount_cmd)
   except subprocess.CalledProcessError as e:
-    raise TurbiniaException('Could not unmount directory {1!s}'.format(e))
+    raise TurbiniaException('Could not unmount directory {0!s}'.format(e))
 
   log.info('Removing mount path {0:s}'.format(evidence.mount_path))
   try:

--- a/turbiniactl
+++ b/turbiniactl
@@ -108,6 +108,31 @@ if __name__ == '__main__':
   parser_googleclouddisk.add_argument(
       '-n', '--name', help='Descriptive name of the evidence', required=False)
 
+  # Google Cloud Persistent Disk Embedded Raw Image
+  parser_googleclouddiskembedded = subparsers.add_parser(
+      'googleclouddiskembedded',
+      help='Process Google Cloud Persistent Disk with an embedded raw disk '
+           'image as Evidence')
+  parser_googleclouddiskembedded.add_argument(
+      '-e', '--embedded_path',
+      help='Path within the Persistent Disk that points to the raw image file',
+      required=True)
+  parser_googleclouddiskembedded.add_argument(
+      '-d', '--disk_name', help='Google Cloud name for disk', required=True)
+  parser_googleclouddiskembedded.add_argument(
+      '-p', '--project', help='Project that the disk is associated with',
+      required=True)
+  parser_googleclouddiskembedded.add_argument(
+      '-z', '--zone', help='Geographic zone the disk exists in',
+      required=True)
+  parser_googleclouddiskembedded.add_argument(
+      '-s',
+      '--source',
+      help='Description of the source of the evidence',
+      required=False)
+  parser_googleclouddiskembedded.add_argument(
+      '-n', '--name', help='Descriptive name of the evidence', required=False)
+
   # Directory
   parser_directory = subparsers.add_parser(
       'directory', help='Process a directory as Evidence')

--- a/turbiniactl
+++ b/turbiniactl
@@ -197,6 +197,12 @@ if __name__ == '__main__':
     evidence_ = evidence.GoogleCloudDisk(
         name=args.name, disk_name=args.disk_name, project=args.project,
         zone=args.zone, source=args.source)
+  elif args.command == 'googleclouddiskembedded':
+    args.name = args.name if args.name else args.disk_name
+    evidence_ = evidence.GoogleCloudDiskRawEmbedded(
+        name=args.name, disk_name=args.disk_name,
+        embedded_path=args.embedded_path, project=args.project, zone=args.zone,
+        source=args.source)
   elif args.command == 'psqworker':
     # Set up root logger level which is normally set by the psqworker command
     # which we are bypassing.

--- a/turbiniactl
+++ b/turbiniactl
@@ -88,7 +88,7 @@ if __name__ == '__main__':
   parser_rawdisk.add_argument(
       '-n', '--name', help='Descriptive name of the evidence', required=False)
 
-  # Google Cloud Disk
+  # Parser options for Google Cloud Disk Evidence type
   parser_googleclouddisk = subparsers.add_parser(
       'googleclouddisk',
       help='Process Google Cloud Persistent Disk as Evidence')
@@ -108,7 +108,7 @@ if __name__ == '__main__':
   parser_googleclouddisk.add_argument(
       '-n', '--name', help='Descriptive name of the evidence', required=False)
 
-  # Google Cloud Persistent Disk Embedded Raw Image
+  # Parser options for Google Cloud Persistent Disk Embedded Raw Image
   parser_googleclouddiskembedded = subparsers.add_parser(
       'googleclouddiskembedded',
       help='Process Google Cloud Persistent Disk with an embedded raw disk '
@@ -133,7 +133,7 @@ if __name__ == '__main__':
   parser_googleclouddiskembedded.add_argument(
       '-n', '--name', help='Descriptive name of the evidence', required=False)
 
-  # Directory
+  # Parser options for Directory evidence type
   parser_directory = subparsers.add_parser(
       'directory', help='Process a directory as Evidence')
   parser_directory.add_argument(


### PR DESCRIPTION
Note:  Also needed to fully support this type of evidence format is a task to do the conversion from raw image files in GCS to GCP PD with embedded raw images (Issue #63 ).