### PR TITLE
Add results and exception handler decorator for workers

### DIFF
--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -56,22 +56,8 @@ def task_runner(obj, *args, **kwargs):
 
   Returns:
     Output from TurbiniaTask (should be TurbiniaTaskResult).
-
-  Raises:
-    Re-raises exceptions that are thrown from the task.
   """
-  # TODO(aarontp): Add proper error checks/handling
-  res = None
-  try:
-    res = obj.run(*args, **kwargs)
-  except Exception as e:
-    # TODO(aarontp): Create synthetic TurbiniaTaskResult upon failure to
-    # propogate errors to the Task Manager
-    logging.warning(
-        u'Exception thrown from Task: {0:s}'.format(traceback.format_exc()))
-    raise e
-
-  return res
+  return obj.run_wrapper(*args, **kwargs)
 
 
 class BaseTaskManager(object):

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -233,8 +233,8 @@ class PSQTaskManager(BaseTaskManager):
       task_result: The TurbiniaTaskResult object
     """
     if not task_result.successful:
-      log.error(u'Task {0:s} from {1:s} was not successful'.format(
-          task_result.task_name, task_result.worker_name))
+      log.error(u'Task {0:s} from {1:s} failed: [{2:s}]'.format(
+          task_result.task_name, task_result.worker_name, task_result.status))
     else:
       log.info(
           u'Task {0:s} from {1:s} executed with status [{2:s}]'.format(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -22,11 +22,41 @@ import logging
 import os
 import platform
 import time
+import traceback
 import uuid
 
 from turbinia import config
 from turbinia import output_writers
 from turbinia import TurbiniaException
+
+
+# pylint: disable=unused-argument
+def results_handler(func, *args, **kwargs):
+  """Decorator to manage TurbiniaTaskResults and exception handling.
+
+  All TurbiniaTask.run() methods need to use this decorator in order to handle
+  the management of TurbiniaTaskResults and the exception handling and logging.
+  Otherwise details from exceptions in the worker cannot be propogated back to
+  the Turbinia TaskManager.
+  """
+  def decorator(self, evidence, *args, **kwargs):
+    """Function wrapper returned by decorator."""
+    if not isinstance(self, TurbiniaTask):
+      raise TurbiniaException(
+          'results_handler decorator can only be set on TurbiniaTask methods')
+
+    result = self.setup(evidence)
+    try:
+      result = func(self, evidence=evidence, result=result, *args, **kwargs)
+    # pylint: disable=broad-except
+    except Exception as e:
+      msg = 'Task failed with exeption: [{0!s}]'.format(e)
+      result.close(success=False, status=msg)
+      result.set_error(e.message, traceback.format_exc())
+
+    return result
+
+  return decorator
 
 
 class TurbiniaTaskResult(object):
@@ -160,7 +190,7 @@ class TurbiniaTaskResult(object):
       if writer.name != 'LocalOutputWriter':
         writer.write(file_)
 
-  def set_error(self, error, traceback):
+  def set_error(self, error, traceback_):
     """Add error and traceback.
 
     Args:
@@ -168,7 +198,7 @@ class TurbiniaTaskResult(object):
         traceback: Traceback of the error.
     """
     self.error['error'] = error
-    self.error['traceback'] = traceback
+    self.error['traceback'] = traceback_
 
 
 class TurbiniaTask(object):
@@ -221,11 +251,14 @@ class TurbiniaTask(object):
     return self.result
 
 
-  def run(self, evidence):
+  def run(self, evidence, result):
     """Entry point to execute the task.
+
+    This method needs to be wrapped in the @results_handler decorator.
 
     Args:
       evidence: Evidence object.
+      result: A TurbiniaTaskResult object to place task results into.
 
     Returns:
         TurbiniaTaskResult object.

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -50,7 +50,7 @@ def results_handler(func, *args, **kwargs):
       result = func(self, evidence=evidence, result=result, *args, **kwargs)
     # pylint: disable=broad-except
     except Exception as e:
-      msg = 'Task failed with exeption: [{0!s}]'.format(e)
+      msg = 'Task failed with exception: [{0!s}]'.format(e)
       result.close(success=False, status=msg)
       result.set_error(e.message, traceback.format_exc())
 

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -17,22 +17,24 @@ import os
 import subprocess
 
 from turbinia.workers import TurbiniaTask
+from turbinia.workers import results_handler
 from turbinia.evidence import PlasoFile
 
 
 class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 
-  def run(self, evidence):
+  @results_handler
+  def run(self, evidence, result):
     """Task that process data with Plaso.
 
     Args:
         evidence: Path to data to process.
+        result: A TurbiniaTaskResult object to place task results into.
 
     Returns:
         TurbiniaTaskResult object.
     """
-    result = self.setup(evidence)
     plaso_result = PlasoFile()
 
     plaso_file = os.path.join(self.output_dir, u'{0:s}.plaso'.format(self.id))

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -17,14 +17,12 @@ import os
 import subprocess
 
 from turbinia.workers import TurbiniaTask
-from turbinia.workers import results_handler
 from turbinia.evidence import PlasoFile
 
 
 class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 
-  @results_handler
   def run(self, evidence, result):
     """Task that process data with Plaso.
 


### PR DESCRIPTION
This will catch exceptions and set the TurbiniaResult appropriately.  It also moves the TurbiniaResult setup out of the run function and into the decorator.  In the future we can potentially move other results handling into the decorator as well.  Fixes #70.