### PR TITLE
 Plumb the request_id into tasks/datastore

### DIFF
--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -49,6 +49,9 @@ class BaseStateManager(object):
   def get_task_dict(self, task):
     """Creates a dict of the fields we want to persist into storage.
 
+    This combines attributes from both the Task and the TaskResult into one flat
+    object representing the overall state.
+
     Args:
       task: A TurbiniaTask object.
 

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -156,6 +156,7 @@ class BaseTaskManager(object):
       task: An instantiated Turbinia Task
       evidence_: An Evidence object to be processed.
     """
+    task.request_id = evidence_.request_id
     self.tasks.append(task)
     self.state_manager.write_new_task(task)
     self.enqueue_task(task, evidence_)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -186,6 +186,7 @@ class TurbiniaTask(object):
       name: Name of task
       output_dir: The directory output will go into (including per-task folder).
       result: A TurbiniaTaskResult object.
+      request_id: The id of the initial request to process this evidence.
       state_key: A key used to manage task state
       stub: The task manager implementation specific task stub that exists
             server side to keep a reference to the remote task objects.  For PSQ
@@ -194,9 +195,9 @@ class TurbiniaTask(object):
   """
 
   # The list of attributes that we will persist into storage
-  STORED_ATTRIBUTES = ['id', 'last_update', 'name']
+  STORED_ATTRIBUTES = ['id', 'last_update', 'name', 'request_id']
 
-  def __init__(self, name=None, base_output_dir=None):
+  def __init__(self, name=None, base_output_dir=None, request_id=None):
     """Initialization for TurbiniaTask."""
     self.base_output_dir = base_output_dir
     self.id = uuid.uuid4().hex
@@ -204,6 +205,7 @@ class TurbiniaTask(object):
     self.name = name if name else self.__class__.__name__
     self.output_dir = None
     self.result = None
+    self.request_id = request_id
     self.state_key = None
     self.stub = None
 

--- a/turbiniactl
+++ b/turbiniactl
@@ -42,7 +42,7 @@ log = logging.getLogger('turbinia')
 logger.setup()
 
 
-def PrintTaskStatus(project, region, days=1):
+def PrintTaskStatus(project, region, days=1, all_fields=False):
   """Prints the recent history for Turbinia Tasks.
 
   Args:
@@ -70,7 +70,7 @@ def PrintTaskStatus(project, region, days=1):
   task_results = results[0]
   num_results = len(task_results)
   if not num_results:
-    print 'No Tasks found.'
+    print '\nNo Tasks found.'
     return
 
   print '\nRetrieved {0:d} Task results:'.format(num_results)
@@ -80,8 +80,14 @@ def PrintTaskStatus(project, region, days=1):
     else:
       success = 'Running'
     status = task.get('status', 'Task in Progress')
-    print '{0:s} {1:s} {2:s} {3:s}: {4:s} '.format(
-        task['last_update'], task['id'], task['name'], success, status)
+    if all_fields:
+      print '{0:s} request: {1:s} task: {2:s} {3:s} {4:s}: {5:s}'.format(
+          task['last_update'], task['request_id'], task['id'], task['name'],
+          success, status)
+    else:
+      print '{0:s} {1:s} {2:s}: {3:s}'.format(
+          task['last_update'], task['name'], success, status)
+
 
 
 if __name__ == '__main__':
@@ -211,6 +217,12 @@ if __name__ == '__main__':
       'status',
       help='Get Turbinia Task status')
   parser_status.add_argument(
+      '-a',
+      '--all_fields',
+      action='store_true',
+      help='Show all task status fields in output',
+      required=False)
+  parser_status.add_argument(
       '-d',
       '--days_history',
       default=1,
@@ -299,7 +311,8 @@ if __name__ == '__main__':
     # should figure out a better way to do this in case it changes.
     region = config.ZONE[:-2]
     PrintTaskStatus(
-        project=config.PROJECT, region=region, days=args.days_history)
+        project=config.PROJECT, region=region, days=args.days_history,
+        all_fields=args.all_fields)
   elif args.command == 'listjobs':
     log.info(u'Available Jobs:')
     log.info(
@@ -321,7 +334,8 @@ if __name__ == '__main__':
       print request.to_json().encode('utf-8')
     else:
       log.info(
-          u'Creating PubSub request with evidence {0:s}'.format(evidence_.name))
+          u'Creating PubSub request {0:s} with evidence {1:s}'.format(
+              request.request_id, evidence_.name))
       task_manager_.server_pubsub.send_request(request)
 
   log.info(u'Done.')

--- a/turbiniactl
+++ b/turbiniactl
@@ -75,10 +75,13 @@ def PrintTaskStatus(project, region, days=1):
 
   print '\nRetrieved {0:d} Task results:'.format(num_results)
   for task in task_results:
-    success = 'Successful' if task['successful'] else 'Failed'
+    if task.has_key('successful'):
+      success = 'Successful' if task['successful'] else 'Failed'
+    else:
+      success = 'Running'
+    status = task.get('status', 'Task in Progress')
     print '{0:s} {1:s} {2:s} {3:s}: {4:s} '.format(
-        task['last_update'], task['id'], task['name'], success,
-        task['status'])
+        task['last_update'], task['id'], task['name'], success, status)
 
 
 if __name__ == '__main__':

--- a/turbiniactl
+++ b/turbiniactl
@@ -16,6 +16,8 @@
 """Command line interface for Turbinia."""
 # pylint: disable=bad-indentation
 
+from __future__ import unicode_literals
+
 import argparse
 from datetime import datetime
 from datetime import timedelta
@@ -300,10 +302,10 @@ if __name__ == '__main__':
     else:
       worker = psq.MultiprocessWorker(queue=task_manager_.psq)
     log.info(
-        u'Starting PSQ listener on queue {0:s}'.format(task_manager_.psq.name))
+        'Starting PSQ listener on queue {0:s}'.format(task_manager_.psq.name))
     worker.listen()
   elif args.command == 'server':
-    log.info(u'Running Turbinia Server.')
+    log.info('Running Turbinia Server.')
     task_manager_.run()
   elif args.command == 'status':
     # TODO(aarontp): This seems to be a valid assumption right now, but we
@@ -313,11 +315,11 @@ if __name__ == '__main__':
         project=config.PROJECT, region=region, days=args.days_history,
         all_fields=args.all_fields)
   elif args.command == 'listjobs':
-    log.info(u'Available Jobs:')
+    log.info('Available Jobs:')
     log.info(
         '\n'.join(['\t{0:s}'.format(job.name) for job in task_manager_.jobs]))
   else:
-    log.warning(u'Command {0:s} not implemented.'.format(args.command))
+    log.warning('Command {0:s} not implemented.'.format(args.command))
 
   # If we have evidence to process and we also want to run as a server, then
   # we'll just process the evidence directly rather than send it through the
@@ -333,9 +335,9 @@ if __name__ == '__main__':
       print request.to_json().encode('utf-8')
     else:
       log.info(
-          u'Creating PubSub request {0:s} with evidence {1:s}'.format(
+          'Creating PubSub request {0:s} with evidence {1:s}'.format(
               request.request_id, evidence_.name))
       task_manager_.server_pubsub.send_request(request)
 
-  log.info(u'Done.')
+  log.info('Done.')
   sys.exit(0)


### PR DESCRIPTION
- Also add --all_fields for more verbose turbiniactl status output
- Also small comment in state_manager