### PR TITLE
Make sure new evidence objects have their ancestor's request_id

### DIFF
--- a/turbiniactl
+++ b/turbiniactl
@@ -308,6 +308,12 @@ if __name__ == '__main__':
       'status',
       help='Get Turbinia Task status')
   parser_status.add_argument(
+      '-a',
+      '--all_fields',
+      action='store_true',
+      help='Show all task status fields in output',
+      required=False)
+  parser_status.add_argument(
       '-d',
       '--days_history',
       default=1,

--- a/turbiniactl
+++ b/turbiniactl
@@ -308,12 +308,6 @@ if __name__ == '__main__':
       'status',
       help='Get Turbinia Task status')
   parser_status.add_argument(
-      '-a',
-      '--all_fields',
-      action='store_true',
-      help='Show all task status fields in output',
-      required=False)
-  parser_status.add_argument(
       '-d',
       '--days_history',
       default=1,


### PR DESCRIPTION
This means copying the request_id into the TurbiniaTaskResult and then copying it when the result closes.  Also updated some comments.