### PR TITLE
Pin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-plaso>=1.5.1
+plaso>=20171118
 psq>=0.5.0
 google-api-python-client>=1.6.2
+google-cloud-pubsub==0.26.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ sudo python setup.py install
 
 from setuptools import find_packages
 from setuptools import setup
+from pip.req import parse_requirements
+from pip.download import PipSession
 
 setup(
     name='Turbinia',
@@ -31,4 +33,6 @@ setup(
     include_package_data=True,
     zip_safe=False,
     scripts=['turbiniactl'],
-    install_requires=frozenset(['google-api-python-client', 'plaso', 'psq']))
+    install_requires=[str(req.req) for req in parse_requirements(
+        "requirements.txt", session=PipSession())
+    ])

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,5 @@ setup(
     zip_safe=False,
     scripts=['turbiniactl'],
     install_requires=[str(req.req) for req in parse_requirements(
-        "requirements.txt", session=PipSession())
+        'requirements.txt', session=PipSession())
     ])


### PR DESCRIPTION
We need to pin google-cloud-pubsub to version 0.26.0 before we fix our call to pubsub client.
Also read from requirements.txt in setup.py so we can handle versions there.