### PR TITLE
Add urllib3 with 'secure' extras to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ psq>=0.5.0
 google-api-python-client>=1.6.2
 google-cloud-pubsub==0.26.0
 google-cloud-core==0.26.0
+urllib3[secure]


### PR DESCRIPTION
So, this gives the secure "extras" for urllib3, and this (besides making it more secure) squashes the SSL warnings.  I'm not positive that this is the idiomatic way to handle this kind of thing, so let me know what you think.