### PR TITLE
Move saving of new evidence into execution handler

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -113,9 +113,9 @@ class TurbiniaTaskResult(object):
         f.write('\n')
       self.save_local_file(logfile)
 
-    [self.save_local_file(e.local_path) for e in self.evidence if e.local_path]
-
     for evidence in self.evidence:
+      if evidence.local_path:
+        self.save_local_file(evidence.local_path)
       if not evidence.request_id:
         evidence.request_id = self.request_id
 
@@ -223,7 +223,8 @@ class TurbiniaTask(object):
     self.state_key = None
     self.stub = None
 
-  def execute(self, cmd, result, save_files=None, close=False):
+  def execute(self, cmd, result, save_files=None, new_evidence=None,
+              close=False):
     """Executes a given binary and saves output.
 
     Args:
@@ -231,12 +232,15 @@ class TurbiniaTask(object):
       result (TurbiniaTaskResult): The result object to put data into.
       save_files (list): A list of files to save (files referenced by Evidence
           objects are automatically saved, so no need to include them).
+      new_evidence (list): These are new evidence objects created by the task.
+          If the task is successful, they will be added to the result.
       close (bool): Whether to close out the result.
 
     Returns:
       Tuple of the return code, and the TurbiniaTaskResult object
     """
     save_files = save_files if save_files else []
+    new_evidence = new_evidence if new_evidence else []
     proc = subprocess.Popen(cmd)
     stdout, stderr = proc.communicate()
     result.error['stdout'] = stdout
@@ -252,6 +256,8 @@ class TurbiniaTask(object):
       for file_ in save_files:
         result.log('Output file at {0:s}'.format(file_))
         result.save_local_file(file_)
+      for evidence in new_evidence:
+        result.add_evidence(evidence)
 
       if close:
         result.close(success=True)

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -35,6 +35,7 @@ class PlasoTask(TurbiniaTask):
     plaso_evidence = PlasoFile()
 
     plaso_file = os.path.join(self.output_dir, u'{0:s}.plaso'.format(self.id))
+    plaso_evidence.local_path = plaso_file
     plaso_log = os.path.join(self.output_dir, u'{0:s}.log'.format(self.id))
 
     # TODO(aarontp): Move these flags into a recipe
@@ -46,9 +47,7 @@ class PlasoTask(TurbiniaTask):
 
     result.log(u'Running plaso as [{0:s}]'.format(' '.join(cmd)))
 
-    ret, result = self.execute(cmd, result, save_files=[plaso_log], close=True)
-    if not ret:
-      plaso_evidence.local_path = plaso_file
-      result.add_evidence(plaso_evidence)
+    self.execute(cmd, result, save_files=[plaso_log],
+                 new_evidence=[plaso_evidence], close=True)
 
     return result

--- a/turbinia/workers/psort.py
+++ b/turbinia/workers/psort.py
@@ -37,6 +37,7 @@ class PsortTask(TurbiniaTask):
     psort_evidence = PlasoCsvFile()
 
     psort_file = os.path.join(self.output_dir, '{0:s}.csv'.format(self.id))
+    psort_evidence.local_path = psort_file
     psort_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
 
     cmd = ['psort.py', '--status_view', 'none', '--logfile', psort_log]
@@ -44,9 +45,7 @@ class PsortTask(TurbiniaTask):
 
     result.log('Running psort as [{0:s}]'.format(' '.join(cmd)))
 
-    ret, result = self.execute(cmd, result, save_files=[psort_log], close=True)
-    if not ret:
-      psort_evidence.local_path = psort_file
-      result.add_evidence(psort_evidence)
+    self.execute(cmd, result, save_files=[psort_log],
+                 new_evidence=[psort_evidence], close=True)
 
     return result


### PR DESCRIPTION
This saves a few lines of boiler plate in the task code, and also fixes a bug where evidence wasn't being saved correctly after the refactor into the new execution method (because close was being called before the evidence was added).