### PR TITLE
Add Checks to avoid requests to incompatible instances

### DIFF
--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -36,6 +36,7 @@ CONFIGVARS = [
     'SLEEP_TIME',
     'SINGLE_RUN',
     'MOUNT_DIR_PREFIX',
+    'SHARED_FILESYSTEM',
     # GCE CONFIG
     'PROJECT',
     'ZONE',

--- a/turbinia/config/turbinia_config.py
+++ b/turbinia/config/turbinia_config.py
@@ -15,7 +15,7 @@
 
 # Turbinia Config
 
-# Valid values are 'PSQ' or 'Celery'
+# 'PSQ' is currently the only valid option
 TASK_MANAGER = u'PSQ'
 
 # File to log to
@@ -33,6 +33,12 @@ SINGLE_RUN = False
 # Local directory in the worker to put other mount directories for locally
 # mounting images/disks
 MOUNT_DIR_PREFIX = u'/mnt/turbinia-mounts'
+
+# This indicates whether the workers are running in an environment with a shared
+# filesystem.  This should be False for environments with workers running in
+# GCE, and True for environments that have workers on dedicated machines with
+# NFS or a SAN for Evidence objects.
+SHARED_FILESYSTEM = False
 
 # GCE configuration
 PROJECT = None

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -66,6 +66,11 @@ class Evidence(object):
   evidence.
 
   Attributes:
+    cloud_only: Set to True for evidence types that can only be processed in a
+        cloud environment, e.g. GoogleCloudDisk.
+    copyable: Whether this evidence can be copied.  This will be set to True for
+        object types that we want to copy to/from storage (e.g. PlasoFile, but
+        not RawDisk).
     name: Name of evidence.
     description: Description of evidence.
     source: String indicating where evidence came from (including tool version
@@ -84,6 +89,8 @@ class Evidence(object):
       tags=None,
       request_id=None):
     """Initialization for Evidence."""
+    self.copyable = False
+    self.cloud_only = False
     self.description = description
     self.source = source
     self.local_path = local_path
@@ -209,6 +216,7 @@ class GoogleCloudDisk(RawDisk):
     self.disk_name = disk_name
     self.type = type_
     super(GoogleCloudDisk, self).__init__(*args, **kwargs)
+    self.cloud_only = True
 
   def preprocess(self):
     google_cloud.PreprocessAttachDisk(self)
@@ -255,6 +263,7 @@ class PlasoFile(Evidence):
     """Initialization for Plaso File evidence."""
     self.plaso_version = plaso_version
     super(PlasoFile, self).__init__(*args, **kwargs)
+    self.copyable = True
 
 
 class PlasoCsvFile(PlasoFile):
@@ -273,3 +282,4 @@ class ReportText(Evidence):
   def __init__(self, text_data=None, *args, **kwargs):
     self.text_data = text_data
     super(ReportText, self).__init__(*args, **kwargs)
+    self.copyable = True

--- a/turbiniactl
+++ b/turbiniactl
@@ -193,6 +193,12 @@ if __name__ == '__main__':
       action='store_true',
       help='Show all task status fields in output',
       required=False)
+  parser.add_argument(
+      '-f',
+      '--force_evidence',
+      action='store_true',
+      help='Force evidence processing attempt on incompatible platform',
+      required=False)
   parser.add_argument('-o', '--output_dir', help='Directory path for output')
   parser.add_argument('-L', '--log_file', help='Log file')
   parser.add_argument(
@@ -417,7 +423,7 @@ if __name__ == '__main__':
     log.warning('Command {0:s} not implemented.'.format(args.command))
 
 
-  if evidence_:
+  if evidence_ and not args.force_evidence:
     if config.SHARED_FILESYSTEM and evidence_.cloud_only:
       log.error('The evidence type {0:s} is Cloud only, and this instance of '
                 'Turbinia is not a cloud instance.'.format(evidence_.type))

--- a/turbiniactl
+++ b/turbiniactl
@@ -416,6 +416,19 @@ if __name__ == '__main__':
   else:
     log.warning('Command {0:s} not implemented.'.format(args.command))
 
+
+  if evidence_:
+    if config.SHARED_FILESYSTEM and evidence_.cloud_only:
+      log.error('The evidence type {0:s} is Cloud only, and this instance of '
+                'Turbinia is not a cloud instance.'.format(evidence_.type))
+      sys.exit(1)
+    elif not config.SHARED_FILESYSTEM and not evidence_.cloud_only:
+      log.error('The evidence type {0:s} cannot run on Cloud instances of '
+                'Turbinia. Consider wrapping it in a '
+                'GoogleCloudDiskRawEmbedded or other Cloud compatible '
+                'object'.format(evidence_.type))
+      sys.exit(1)
+
   # If we have evidence to process and we also want to run as a server, then
   # we'll just process the evidence directly rather than send it through the
   # PubSub frontend interface.  If we're not running as a server then we will


### PR DESCRIPTION
Also adds 'copyable' attribute for evidence types that we can copy around (e.g. PlasoFile).