### PR TITLE
Fixes optional configuration variables

### DIFF
--- a/turbinia/config/turbinia_config.py
+++ b/turbinia/config/turbinia_config.py
@@ -59,3 +59,10 @@ GCS_OUTPUT_PATH = False
 
 # Which state manager to use
 STATE_MANAGER = u'Datastore'
+
+#Optional 
+REDIS_HOST = u'NA'
+REDIS_PORT = u'NA'
+TIMESKETCH_HOST = u'NA'
+TIMESKETCH_USER = u'NA'
+TIMESKETCH_PASSWORD = u'NA'


### PR DESCRIPTION
Responding to Issue #101, "Clean up config."  

-Adds and sets previously unincluded optional configuration variables to a null string. 

-Not sure about removal of INSTANCE, DEVICE_NAME, SCRATCH_PATH.