### PR TITLE
Save local evidence output path too

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -108,6 +108,7 @@ class TurbiniaTaskResult(object):
 
     for evidence in self.evidence:
       if evidence.local_path:
+        self.saved_paths.append(evidence.local_path)
         self.save_local_file(evidence.local_path)
       if not evidence.request_id:
         evidence.request_id = self.request_id


### PR DESCRIPTION
We also want to save the local path for later retrieval through `turbiniactl status` in the cases where we're running with a shared FS.

Ignore the config change, I'll rebase it before submission (just wanted to get this in first).