### PR TITLE
Added future's unicode_literals to make strings as unicorn by default.

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/python
 #
 # Copyright 2017 Google Inc.

--- a/tests/config/config.py
+++ b/tests/config/config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/evidence.py
+++ b/tests/evidence.py
@@ -29,14 +29,14 @@ class TestTurbiniaEvidence(unittest.TestCase):
   def testEvidenceSerialization(self):
     """Test that evidence serializes/unserializes."""
     rawdisk = evidence.RawDisk(
-        name='gMy Evidence', local_path='/tmp/foo', mount_path='/mnt/foo')
+        name='My Evidence', local_path='/tmp/foo', mount_path='/mnt/foo')
     rawdisk_json = rawdisk.to_json()
     self.assertTrue(isinstance(rawdisk_json, str))
 
     rawdisk_new = evidence.evidence_decode(json.loads(rawdisk_json))
     self.assertTrue(isinstance(rawdisk_new, evidence.RawDisk))
-    self.assertEqual(rawdisk_new.name, 'gMy Evidence')
-    self.assertEqual(rawdisk_new.mount_path, 'g/mnt/foo')
+    self.assertEqual(rawdisk_new.name, 'My Evidence')
+    self.assertEqual(rawdisk_new.mount_path, '/mnt/foo')
 
   def testEvidenceSerializationBadType(self):
     """Test that evidence_decode throws error on non-dict type."""

--- a/tests/evidence.py
+++ b/tests/evidence.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,8 @@
 # limitations under the License.
 """Tests for Turbinia evidence."""
 
+from __future__ import unicode_literals
+
 import json
 import unittest
 
@@ -26,14 +29,14 @@ class TestTurbiniaEvidence(unittest.TestCase):
   def testEvidenceSerialization(self):
     """Test that evidence serializes/unserializes."""
     rawdisk = evidence.RawDisk(
-        name=u'My Evidence', local_path=u'/tmp/foo', mount_path=u'/mnt/foo')
+        name='gMy Evidence', local_path='/tmp/foo', mount_path='/mnt/foo')
     rawdisk_json = rawdisk.to_json()
     self.assertTrue(isinstance(rawdisk_json, str))
 
     rawdisk_new = evidence.evidence_decode(json.loads(rawdisk_json))
     self.assertTrue(isinstance(rawdisk_new, evidence.RawDisk))
-    self.assertEqual(rawdisk_new.name, u'My Evidence')
-    self.assertEqual(rawdisk_new.mount_path, u'/mnt/foo')
+    self.assertEqual(rawdisk_new.name, 'gMy Evidence')
+    self.assertEqual(rawdisk_new.mount_path, 'g/mnt/foo')
 
   def testEvidenceSerializationBadType(self):
     """Test that evidence_decode throws error on non-dict type."""

--- a/tests/output_manager.py
+++ b/tests/output_manager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests/pubsub.py
+++ b/tests/pubsub.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tests for Turbinia pubsub module."""
+
+from __future__ import unicode_literals
 
 import unittest
 
@@ -29,9 +32,9 @@ def getTurbiniaRequest():
     TurbiniaRequest object.
   """
   request = pubsub.TurbiniaRequest(
-      request_id=u'deadbeef', context={'kw': [1, 2]})
+      request_id='deadbeef', context={'kw': [1, 2]})
   rawdisk = evidence.RawDisk(
-      name=u'My Evidence', local_path=u'/tmp/foo', mount_path=u'/mnt/foo')
+      name='My Evidence', local_path='/tmp/foo', mount_path='/mnt/foo')
   request.evidence.append(rawdisk)
   return request
 
@@ -67,9 +70,9 @@ class TestTurbiniaRequest(unittest.TestCase):
 
     self.assertTrue(isinstance(request_new, pubsub.TurbiniaRequest))
     self.assertTrue(request_new.context['kw'][1], 2)
-    self.assertTrue(request_new.request_id, u'deadbeef')
+    self.assertTrue(request_new.request_id, 'deadbeef')
     self.assertTrue(isinstance(request_new.evidence[0], evidence.RawDisk))
-    self.assertEqual(request_new.evidence[0].name, u'My Evidence')
+    self.assertEqual(request_new.evidence[0].name, 'My Evidence')
 
   def testTurbiniaRequestSerializationBadData(self):
     """Tests that TurbiniaRequest will raise error on non-json data."""
@@ -78,7 +81,7 @@ class TestTurbiniaRequest(unittest.TestCase):
 
   def testTurbiniaRequestSerializationBadJSON(self):
     """Tests that TurbiniaRequest will raise error on wrong JSON object."""
-    rawdisk = evidence.RawDisk(name=u'My Evidence', local_path=u'/tmp/foo')
+    rawdisk = evidence.RawDisk(name='My Evidence', local_path='/tmp/foo')
     rawdisk_json = rawdisk.to_json()
     self.assertTrue(isinstance(rawdisk_json, str))
 
@@ -93,9 +96,9 @@ class TestTurbiniaPubSub(unittest.TestCase):
 
   def setUp(self):
     request = getTurbiniaRequest()
-    self.pubsub = pubsub.TurbiniaPubSub(u'fake_topic')
+    self.pubsub = pubsub.TurbiniaPubSub('fake_topic')
     results = MockPubSubResults(
-        ack_id=u'1234', message=MockPubSubMessage(request.to_json(), u'msg id'))
+        ack_id='1234', message=MockPubSubMessage(request.to_json(), 'msg id'))
     self.pubsub.subscription = mock.MagicMock()
     self.pubsub.subscription.pull.return_value = results
 
@@ -108,17 +111,17 @@ class TestTurbiniaPubSub(unittest.TestCase):
     # Make sure that the TurbiniaRequest object is as expected
     self.assertTrue(isinstance(request_new, pubsub.TurbiniaRequest))
     self.assertTrue(request_new.context['kw'][1], 2)
-    self.assertTrue(request_new.request_id, u'deadbeef')
+    self.assertTrue(request_new.request_id, 'deadbeef')
     self.assertTrue(isinstance(request_new.evidence[0], evidence.RawDisk))
-    self.assertEqual(request_new.evidence[0].name, u'My Evidence')
+    self.assertEqual(request_new.evidence[0].name, 'My Evidence')
 
     # Make sure that the test message was acknowledged
-    self.pubsub.subscription.acknowledge.assert_called_with([u'1234'])
+    self.pubsub.subscription.acknowledge.assert_called_with(['1234'])
 
   def testBadCheckMessages(self):
     """Test check_messages returns empty list for an invalid message."""
     results = MockPubSubResults(
-        ack_id=u'2345', message=MockPubSubMessage(u'non-json-data', u'msg id2'))
+        ack_id='2345', message=MockPubSubMessage('non-json-data', 'msg id2'))
     self.pubsub.subscription.pull.return_value = results
 
     self.assertListEqual(self.pubsub.check_messages(), [])
@@ -126,5 +129,5 @@ class TestTurbiniaPubSub(unittest.TestCase):
   def testSendMessage(self):
     """Test sending a message."""
     self.pubsub.topic = mock.MagicMock()
-    self.pubsub.send_message(u'test message text')
-    self.pubsub.topic.publish.assert_called_with(u'test message text')
+    self.pubsub.send_message('test message text')
+    self.pubsub.topic.publish.assert_called_with('test message text')

--- a/tools/gcf_init/deploy_gcf.py
+++ b/tools/gcf_init/deploy_gcf.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/env python
 
 import subprocess

--- a/turbinia/__init__.py
+++ b/turbinia/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Basic Turbinia config."""
+
+from __future__ import unicode_literal
 
 import imp
 import itertools
@@ -84,7 +87,7 @@ def LoadConfig():
       break
 
   if config_file is None:
-    raise TurbiniaConfigException(u'No config files found')
+    raise TurbiniaConfigException('No config files found')
 
   log.info('Loading config from {0:s}'.format(config_file))
   _config = imp.load_source('config', config_file)
@@ -100,10 +103,10 @@ def ValidateAndSetConfig(_config):
   for var in CONFIGVARS:
     if not hasattr(_config, var):
       raise TurbiniaConfigException(
-          u'No config attribute {0:s}:{1:s}'.format(_config.configSource, var))
+          'No config attribute {0:s}:{1:s}'.format(_config.configSource, var))
     if getattr(_config, var) is None:
       raise TurbiniaConfigException(
-          u'Config attribute {0:s}:{1:s} is not set'.format(
+          'Config attribute {0:s}:{1:s} is not set'.format(
               _config.configSource, var))
 
     # Set the attribute in the current module

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +14,7 @@
 # limitations under the License.
 """Sets up logging."""
 
+from __future__ import unicode_literals
 import logging
 
 from turbinia import config
@@ -49,14 +51,14 @@ def setup():
         need_stream_handler = False
 
   file_handler = logging.FileHandler(config.LOG_FILE)
-  formatter = logging.Formatter(u'%(asctime)s:%(levelname)s:%(message)s')
+  formatter = logging.Formatter('g%(asctime)s:%(levelname)s:%(message)s')
   file_handler.setFormatter(formatter)
   file_handler.setLevel(logging.DEBUG)
   if need_file_handler:
     logger.addHandler(file_handler)
 
   console_handler = logging.StreamHandler()
-  formatter = logging.Formatter(u'[%(levelname)s] %(message)s')
+  formatter = logging.Formatter('g[%(levelname)s] %(message)s')
   console_handler.setFormatter(formatter)
   if need_stream_handler:
     logger.addHandler(console_handler)

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -51,14 +51,14 @@ def setup():
         need_stream_handler = False
 
   file_handler = logging.FileHandler(config.LOG_FILE)
-  formatter = logging.Formatter('g%(asctime)s:%(levelname)s:%(message)s')
+  formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
   file_handler.setFormatter(formatter)
   file_handler.setLevel(logging.DEBUG)
   if need_file_handler:
     logger.addHandler(file_handler)
 
   console_handler = logging.StreamHandler()
-  formatter = logging.Formatter('g[%(levelname)s] %(message)s')
+  formatter = logging.Formatter('[%(levelname)s] %(message)s')
   console_handler.setFormatter(formatter)
   if need_stream_handler:
     logger.addHandler(console_handler)

--- a/turbinia/config/turbinia_config.py
+++ b/turbinia/config/turbinia_config.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,12 +12,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import unicode_literals
+
+
 """Dummy Turbinia config file."""
 
 # Turbinia Config
 
 # 'PSQ' is currently the only valid option
-TASK_MANAGER = u'PSQ'
+TASK_MANAGER = 'PSQ'
 
 # File to log to
 LOG_FILE = None
@@ -32,7 +37,7 @@ SINGLE_RUN = False
 
 # Local directory in the worker to put other mount directories for locally
 # mounting images/disks
-MOUNT_DIR_PREFIX = u'/mnt/turbinia-mounts'
+MOUNT_DIR_PREFIX = '/mnt/turbinia-mounts'
 
 # This indicates whether the workers are running in an environment with a shared
 # filesystem.  This should be False for environments with workers running in
@@ -47,7 +52,7 @@ INSTANCE = None
 DEVICE_NAME = None
 SCRATCH_PATH = None
 BUCKET_NAME = None
-PSQ_TOPIC = u'turbinia-psq'
+PSQ_TOPIC = 'turbinia-psq'
 
 # Topic Turbinia will listen on for new Artifact events.  This is also used as
 # the Turbinia instance/namespace as it is a unique string per Turbinia
@@ -58,4 +63,4 @@ PUBSUB_TOPIC = None
 GCS_OUTPUT_PATH = False
 
 # Which state manager to use
-STATE_MANAGER = u'Datastore'
+STATE_MANAGER = 'Datastore'

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/jobs/__init__.py
+++ b/turbinia/jobs/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/python
 #
 # Copyright 2015 Google Inc.

--- a/turbinia/jobs/be.py
+++ b/turbinia/jobs/be.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/jobs/plaso.py
+++ b/turbinia/jobs/plaso.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/jobs/psort.py
+++ b/turbinia/jobs/psort.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/jobs/worker_stat.py
+++ b/turbinia/jobs/worker_stat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/lib/google_cloud.py
+++ b/turbinia/lib/google_cloud.py
@@ -98,7 +98,7 @@ class GoogleCloudProject(object):
       if 'error' in result:
         raise TurbiniaException(result['error'])
 
-      if not block or result['status'] == u'DONE':
+      if not block or result['status'] == 'DONE':
         return result
       time.sleep(1)  # Seconds between requests
 

--- a/turbinia/lib/google_cloud.py
+++ b/turbinia/lib/google_cloud.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Google Cloud resources library."""
+
+from __future__ import unicode_literals
 
 import json
 import logging
@@ -87,15 +90,15 @@ class GoogleCloudProject(object):
       if zone:
         result = service.zoneOperations().get(
             project=self.project_id, zone=zone,
-            operation=operation[u'name']).execute()
+            operation=operation['gname']).execute()
       else:
         result = service.globalOperations().get(
-            project=self.project_id, operation=operation[u'name']).execute()
+            project=self.project_id, operation=operation['gname']).execute()
 
-      if u'error' in result:
-        raise TurbiniaException(result[u'error'])
+      if 'gerror' in result:
+        raise TurbiniaException(result['gerror'])
 
-      if not block or result[u'status'] == u'DONE':
+      if not block or result['gstatus'] == u'DONE':
         return result
       time.sleep(1)  # Seconds between requests
 
@@ -105,7 +108,7 @@ class GoogleCloudProject(object):
     Returns:
       A Google Compute Engine service object.
     """
-    return self._CreateService(u'compute', self.COMPUTE_ENGINE_API_VERSION)
+    return self._CreateService('gcompute', self.COMPUTE_ENGINE_API_VERSION)
 
   def GceOperation(self, operation, zone=None, block=False):
     """Convinient method for GCE operation.
@@ -130,11 +133,11 @@ class GoogleCloudProject(object):
         project=self.project_id).execute()
     result = self.GceOperation(operation, zone=self.default_zone)
     instances = dict()
-    for zone in result[u'items']:
+    for zone in result['gitems']:
       try:
-        for instance in result[u'items'][zone][u'instances']:
-          zone = instance[u'zone'].split('/')[-1:][0]
-          instances[instance[u'name']] = dict(zone=zone)
+        for instance in result['gitems'][zone][u'instances']:
+          zone = instance['gzone'].split('/')[-1:][0]
+          instances[instance['gname']] = dict(zone=zone)
       except KeyError:
         pass
     return instances
@@ -156,10 +159,10 @@ class GoogleCloudProject(object):
     try:
       instance = instances[instance_name]
       if not zone:
-        zone = instance[u'zone']
+        zone = instance['gzone']
       return GoogleComputeInstance(project=self, zone=zone, name=instance_name)
     except KeyError:
-      raise TurbiniaException(u'Unknown instance')
+      raise TurbiniaException('gUnknown instance')
 
 
 class GoogleCloudFunction(GoogleCloudProject):
@@ -187,7 +190,7 @@ class GoogleCloudFunction(GoogleCloudProject):
     Returns:
       A Google Cloud Function service object.
     """
-    return self._CreateService(u'cloudfunctions',
+    return self._CreateService('gcloudfunctions',
                                self.CLOUD_FUNCTIONS_API_VERSION)
 
   def ExecuteFunction(self, function_name, args):
@@ -273,7 +276,7 @@ class GoogleComputeBaseResource(object):
     Returns:
       The full API URL to the resource.
     """
-    return self.GetValue(u'selfLink')
+    return self.GetValue('gselfLink')
 
 
 class GoogleComputeInstance(GoogleComputeBaseResource):
@@ -318,11 +321,11 @@ class GoogleComputeInstance(GoogleComputeBaseResource):
       disk: Disk to attach (instance of GoogleComputeDisk).
       read_write: Boolean saying if the disk should be attached in RW mode.
     """
-    mode = u'READ_ONLY'  # Default mode
+    mode = 'gREAD_ONLY'  # Default mode
     if read_write:
-      mode = u'READ_WRITE'
+      mode = 'gREAD_WRITE'
 
-    log.info(u'Attaching {0:s} to VM {1:s} in {2:s} mode'.format(
+    log.info('gAttaching {0:s} to VM {1:s} in {2:s} mode'.format(
         disk.name, self.name, mode))
 
     operation_config = {
@@ -345,7 +348,7 @@ class GoogleComputeInstance(GoogleComputeBaseResource):
     Args:
       disk: Disk to detach (instance of GoogleComputeDisk).
     """
-    log.info(u'Detaching {0:s} from VM {1:s}'.format(disk.name, self.name))
+    log.info('gDetaching {0:s} from VM {1:s}'.format(disk.name, self.name))
 
     operation = self.project.GceApi().instances().detachDisk(
         instance=self.name,

--- a/turbinia/lib/google_cloud.py
+++ b/turbinia/lib/google_cloud.py
@@ -90,15 +90,15 @@ class GoogleCloudProject(object):
       if zone:
         result = service.zoneOperations().get(
             project=self.project_id, zone=zone,
-            operation=operation['gname']).execute()
+            operation=operation['name']).execute()
       else:
         result = service.globalOperations().get(
-            project=self.project_id, operation=operation['gname']).execute()
+            project=self.project_id, operation=operation['name']).execute()
 
-      if 'gerror' in result:
-        raise TurbiniaException(result['gerror'])
+      if 'error' in result:
+        raise TurbiniaException(result['error'])
 
-      if not block or result['gstatus'] == u'DONE':
+      if not block or result['status'] == u'DONE':
         return result
       time.sleep(1)  # Seconds between requests
 
@@ -108,7 +108,7 @@ class GoogleCloudProject(object):
     Returns:
       A Google Compute Engine service object.
     """
-    return self._CreateService('gcompute', self.COMPUTE_ENGINE_API_VERSION)
+    return self._CreateService('compute', self.COMPUTE_ENGINE_API_VERSION)
 
   def GceOperation(self, operation, zone=None, block=False):
     """Convinient method for GCE operation.
@@ -133,11 +133,11 @@ class GoogleCloudProject(object):
         project=self.project_id).execute()
     result = self.GceOperation(operation, zone=self.default_zone)
     instances = dict()
-    for zone in result['gitems']:
+    for zone in result['items']:
       try:
-        for instance in result['gitems'][zone][u'instances']:
-          zone = instance['gzone'].split('/')[-1:][0]
-          instances[instance['gname']] = dict(zone=zone)
+        for instance in result['items'][zone]['instances']:
+          zone = instance['zone'].split('/')[-1:][0]
+          instances[instance['name']] = dict(zone=zone)
       except KeyError:
         pass
     return instances
@@ -159,10 +159,10 @@ class GoogleCloudProject(object):
     try:
       instance = instances[instance_name]
       if not zone:
-        zone = instance['gzone']
+        zone = instance['zone']
       return GoogleComputeInstance(project=self, zone=zone, name=instance_name)
     except KeyError:
-      raise TurbiniaException('gUnknown instance')
+      raise TurbiniaException('Unknown instance')
 
 
 class GoogleCloudFunction(GoogleCloudProject):
@@ -190,7 +190,7 @@ class GoogleCloudFunction(GoogleCloudProject):
     Returns:
       A Google Cloud Function service object.
     """
-    return self._CreateService('gcloudfunctions',
+    return self._CreateService('cloudfunctions',
                                self.CLOUD_FUNCTIONS_API_VERSION)
 
   def ExecuteFunction(self, function_name, args):
@@ -276,7 +276,7 @@ class GoogleComputeBaseResource(object):
     Returns:
       The full API URL to the resource.
     """
-    return self.GetValue('gselfLink')
+    return self.GetValue('selfLink')
 
 
 class GoogleComputeInstance(GoogleComputeBaseResource):
@@ -321,11 +321,11 @@ class GoogleComputeInstance(GoogleComputeBaseResource):
       disk: Disk to attach (instance of GoogleComputeDisk).
       read_write: Boolean saying if the disk should be attached in RW mode.
     """
-    mode = 'gREAD_ONLY'  # Default mode
+    mode = 'READ_ONLY'  # Default mode
     if read_write:
-      mode = 'gREAD_WRITE'
+      mode = 'READ_WRITE'
 
-    log.info('gAttaching {0:s} to VM {1:s} in {2:s} mode'.format(
+    log.info('Attaching {0:s} to VM {1:s} in {2:s} mode'.format(
         disk.name, self.name, mode))
 
     operation_config = {
@@ -348,7 +348,7 @@ class GoogleComputeInstance(GoogleComputeBaseResource):
     Args:
       disk: Disk to detach (instance of GoogleComputeDisk).
     """
-    log.info('gDetaching {0:s} from VM {1:s}'.format(disk.name, self.name))
+    log.info('Detaching {0:s} from VM {1:s}'.format(disk.name, self.name))
 
     operation = self.project.GceApi().instances().detachDisk(
         instance=self.name,

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/processors/google_cloud.py
+++ b/turbinia/processors/google_cloud.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Evidence processor for Google Cloud resources."""
+
+from __future__ import unicode_literals
 
 import logging
 import os
@@ -71,9 +74,9 @@ def PreprocessAttachDisk(evidence):
   Args:
     evidence: A turbinia.evidence.GoogleCloudProject object.
   """
-  path = u'/dev/disk/by-id/google-{0:s}'.format(evidence.disk_name)
+  path = '/dev/disk/by-id/google-{0:s}'.format(evidence.disk_name)
   if IsBlockDevice(path):
-    log.info(u'Disk {0:s} already attached!'.format(evidence.disk_name))
+    log.info('Disk {0:s} already attached!'.format(evidence.disk_name))
     evidence.local_path = path
     return
 
@@ -83,18 +86,18 @@ def PreprocessAttachDisk(evidence):
                                default_zone=config.ZONE)
   instance = project.GetInstance(instance_name, zone=config.ZONE)
   disk = instance.GetDisk(evidence.disk_name)
-  log.info(u'Attaching disk {0:s} to instance {1:s}'.format(
+  log.info('Attaching disk {0:s} to instance {1:s}'.format(
       evidence.disk_name, instance_name))
   instance.AttachDisk(disk)
 
   # Make sure we have a proper block device
   for _ in xrange(RETRY_MAX):
     if IsBlockDevice(path):
-      log.info(u'Block device {0:s} successfully attached'.format(path))
+      log.info('Block device {0:s} successfully attached'.format(path))
       break
     if os.path.exists(path):
       log.info(
-          u'Block device {0:s} mode is {1}'.format(path, os.stat(path).st_mode))
+          'Block device {0:s} mode is {1}'.format(path, os.stat(path).st_mode))
     time.sleep(1)
 
   evidence.local_path = path
@@ -109,10 +112,10 @@ def PostprocessDetachDisk(evidence):
   if evidence.local_path:
     path = evidence.local_path
   else:
-    path = u'/dev/disk/by-id/google-{0:s}'.format(evidence.disk_name)
+    path = '/dev/disk/by-id/google-{0:s}'.format(evidence.disk_name)
 
   if not IsBlockDevice(path):
-    log.info(u'Disk {0:s} already detached!'.format(evidence.disk_name))
+    log.info('Disk {0:s} already detached!'.format(evidence.disk_name))
     return
 
   config.LoadConfig()
@@ -121,14 +124,14 @@ def PostprocessDetachDisk(evidence):
                                default_zone=config.ZONE)
   instance = project.GetInstance(instance_name, zone=config.ZONE)
   disk = instance.GetDisk(evidence.disk_name)
-  log.info(u'Detaching disk {0:s} from instance {1:s}'.format(
+  log.info('Detaching disk {0:s} from instance {1:s}'.format(
       evidence.disk_name, instance_name))
   instance.DetachDisk(disk)
 
   # Make sure device is Detached
   for _ in xrange(RETRY_MAX):
     if not os.path.exists(path):
-      log.info(u'Block device {0:s} is no longer attached'.format(path))
+      log.info('Block device {0:s} is no longer attached'.format(path))
       evidence.local_path = None
       break
     time.sleep(5)

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2016 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -101,12 +102,12 @@ class TurbiniaTaskResult(object):
     self.successful = success
     self.run_time = datetime.now() - self.start_time
     if not status:
-      status = u'Completed successfully in {0:s} on {1:s}'.format(
+      status = 'Completed successfully in {0:s} on {1:s}'.format(
           str(self.run_time), self.worker_name)
     self.log(status)
 
     # Write result log info to file
-    logfile = os.path.join(self.output_dir, u'worker-log.txt')
+    logfile = os.path.join(self.output_dir, 'worker-log.txt')
     if self.output_dir and os.path.exists(self.output_dir):
       with open(logfile, 'w') as f:
         f.write('\n'.join(self._log))
@@ -248,7 +249,7 @@ class TurbiniaTask(object):
     ret = proc.returncode
 
     if ret:
-      msg = u'Execution failed with status {0:d}'.format(ret)
+      msg = 'Execution failed with status {0:d}'.format(ret)
       result.log(msg)
       if close:
         result.close(success=False, status=msg)

--- a/turbinia/workers/be.py
+++ b/turbinia/workers/be.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Task for running Plaso."""
+
+from __future__ import unicode_literals
 
 import os
 
@@ -34,18 +37,18 @@ class PlasoTask(TurbiniaTask):
     """
     plaso_evidence = PlasoFile()
 
-    plaso_file = os.path.join(self.output_dir, u'{0:s}.plaso'.format(self.id))
+    plaso_file = os.path.join(self.output_dir, '{0:s}.plaso'.format(self.id))
     plaso_evidence.local_path = plaso_file
-    plaso_log = os.path.join(self.output_dir, u'{0:s}.log'.format(self.id))
+    plaso_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
 
     # TODO(aarontp): Move these flags into a recipe
     cmd = (
-        u'log2timeline.py --status_view none --hashers all '
-        u'--partition all --vss_stores all').split()
-    cmd.extend([u'--logfile', plaso_log])
+        'log2timeline.py --status_view none --hashers all '
+        '--partition all --vss_stores all').split()
+    cmd.extend(['--logfile', plaso_log])
     cmd.extend([plaso_file, evidence.local_path])
 
-    result.log(u'Running plaso as [{0:s}]'.format(' '.join(cmd)))
+    result.log('Running plaso as [{0:s}]'.format(' '.join(cmd)))
 
     self.execute(cmd, result, save_files=[plaso_log],
                  new_evidence=[plaso_evidence], close=True)

--- a/turbinia/workers/psort.py
+++ b/turbinia/workers/psort.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2017 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/turbinia/workers/worker_stat.py
+++ b/turbinia/workers/worker_stat.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright 2015 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In response to #15.

Prepended "# -- coding: utf-8 --" to all the Python files. This line defines the default encoding in those files. For details, see https://www.python.org/dev/peps/pep-0263/.

Added future's unicorn_literals to make strings as unicorn by default.
Removed the trailing letter u from unicorn strings.