### PR TITLE
Refactor output manager to support copying back data

### DIFF
--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -303,6 +303,10 @@ class GCSOutputWriter(OutputWriter):
     full_path = os.path.join(self.local_output_dir, os.path.basename(file_))
     log.info('Writing GCS file {0:s} to local path {1:s}'.format(
         file_, full_path))
-    blob = storage.Blob(full_path, bucket)
-    blob.download_to_filename(file_, client=self.client)
+    blob = storage.Blob(file_, bucket)
+    blob.download_to_filename(full_path, client=self.client)
+    if not os.path.exists(full_path):
+      raise TurbiniaException(
+          'File retrieval from GCS failed: Local file {0:s} does not '
+          'exist'.format(full_path))
     return full_path

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -116,7 +116,7 @@ class OutputManager(object):
     Returns:
       An evidence object
     """
-    (path, path_type) = self.save_local_file(evidence_.local_file, result)
+    (path, path_type) = self.save_local_file(evidence_.local_path, result)
     evidence_.saved_path = path
     evidence_.saved_path_type = path_type
     log.info('Saved copyable evidence data to {0:s}'.format(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -233,7 +233,7 @@ class TurbiniaTask(object):
     else:
       for file_ in save_files:
         result.log('Output file at {0:s}'.format(file_))
-        result.output_manager.save_local_file(file_)
+        result.output_manager.save_local_file(file_, result)
       for evidence in new_evidence:
         result.add_evidence(evidence)
 


### PR DESCRIPTION
Fixes #122 
- Creates new OutputManager object
- Moves output management related functions to new object
- Refactors write() methods into copy_to() and copy_from() to support copying data in both directions
- Adds evidence specific save/retrieve methods
- Adds hooks to copy evidence data back from GCS when it is marked "copyable", and we don't have a shared filesystem.
