### PR TITLE
Auto close result objects after failures

### DIFF
--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -116,7 +116,7 @@ class OutputManager(object):
     Returns:
       An evidence object
     """
-    (path, path_type) = self.save_local_file(evidence_.local_file, result)
+    (path, path_type) = self.save_local_file(evidence_.local_path, result)
     evidence_.saved_path = path
     evidence_.saved_path_type = path_type
     log.info('Saved copyable evidence data to {0:s}'.format(

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -310,10 +310,11 @@ class GCSOutputWriter(OutputWriter):
 
   def copy_from(self, file_):
     bucket = self.client.get_bucket(self.bucket)
+    gcs_path = self._parse_gcs_path(file_)[1]
     full_path = os.path.join(self.local_output_dir, os.path.basename(file_))
     log.info('Writing GCS file {0:s} to local path {1:s}'.format(
         file_, full_path))
-    blob = storage.Blob(file_, bucket)
+    blob = storage.Blob(gcs_path, bucket)
     blob.download_to_filename(full_path, client=self.client)
     if not os.path.exists(full_path):
       raise TurbiniaException(

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -313,6 +313,10 @@ class GCSOutputWriter(OutputWriter):
     full_path = os.path.join(self.local_output_dir, os.path.basename(file_))
     log.info('Writing GCS file {0:s} to local path {1:s}'.format(
         file_, full_path))
-    blob = storage.Blob(full_path, bucket)
-    blob.download_to_filename(file_, client=self.client)
+    blob = storage.Blob(file_, bucket)
+    blob.download_to_filename(full_path, client=self.client)
+    if not os.path.exists(full_path):
+      raise TurbiniaException(
+          'File retrieval from GCS failed: Local file {0:s} does not '
+          'exist'.format(full_path))
     return full_path

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -59,12 +59,10 @@ class OutputManager(object):
 
     writers = [LocalOutputWriter(base_output_dir=result.base_output_dir,
                                  unique_dir=unique_dir)]
-    local_output_dir = writers[0].local_output_dir
     config.LoadConfig()
     if config.GCS_OUTPUT_PATH:
       writer = GCSOutputWriter(
-          unique_dir=unique_dir, gcs_path=config.GCS_OUTPUT_PATH,
-          local_output_dir=local_output_dir)
+          unique_dir=unique_dir, gcs_path=config.GCS_OUTPUT_PATH)
       writers.append(writer)
     return writers
 
@@ -82,15 +80,15 @@ class OutputManager(object):
 
     # Get the local writer
     writer = [w for w in self._output_writers if w.name == 'LocalWriter'][0]
-    if not hasattr(writer, 'local_output_dir'):
+    if not hasattr(writer, 'output_dir'):
       raise TurbiniaException(
-          'Local output writer does not have local_output_dir attribute.')
+          'Local output writer does not have output_dir attribute.')
 
-    if not writer.local_output_dir:
+    if not writer.output_dir:
       raise TurbiniaException(
-          'Local output writer attribute local_output_dir is not set')
+          'Local output writer attribute output_dir is not set')
 
-    return writer.local_output_dir
+    return writer.output_dir
 
   def retrieve_evidence(self, evidence_):
     """Retrieves evidence data from remote location.
@@ -118,7 +116,7 @@ class OutputManager(object):
     Returns:
       An evidence object
     """
-    (path, path_type) = self.save_local_file(evidence_.local_path, result)
+    (path, path_type) = self.save_local_file(evidence_.local_file, result)
     evidence_.saved_path = path
     evidence_.saved_path_type = path_type
     log.info('Saved copyable evidence data to {0:s}'.format(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -233,7 +233,7 @@ class TurbiniaTask(object):
     else:
       for file_ in save_files:
         result.log('Output file at {0:s}'.format(file_))
-        result.output_manager.save_local_file(file_)
+        result.output_manager.save_local_file(file_, result)
       for evidence in new_evidence:
         result.add_evidence(evidence)
 

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -110,7 +110,7 @@ class TurbiniaTaskResult(object):
     for evidence in self.evidence:
       if evidence.local_path:
         self.saved_paths.append(evidence.local_path)
-        self.output_manager.save_evidence(evidence, self)
+        self.save_evidence(evidence)
       if not evidence.request_id:
         evidence.request_id = self.request_id
 
@@ -155,6 +155,46 @@ class TurbiniaTaskResult(object):
         evidence: Evidence object
     """
     self.evidence.append(evidence)
+
+  def save_evidence(self, evidence_):
+    """Saves local evidence files.
+
+    evidence_: Evidence object
+    """
+    (path, path_type) = self.save_local_file(evidence_.local_file)
+    evidence_.saved_path = path
+    evidence_.saved_path_type = path_type
+
+  def retrieve_evidence(self, evidence_):
+    """Retrieves local evidence files.
+
+    evidence_: Evidence object
+    """
+    for writer in self._output_writers:
+      if writer.name == evidence_.saved_path_type:
+        evidence_.local_path = writer.copy_from(evidence_.saved_path)
+
+  def save_local_file(self, file_):
+    """Saves local file by writing to all non-local output writers.
+
+    Args:
+      file_ (string): Path to file to save.
+
+    Returns:
+      Tuple of (String of last written file path,
+                String of last written file destination output type)
+    """
+    saved_path = None
+    saved_path_type = None
+    for writer in self._output_writers:
+      if writer.name != 'LocalOutputWriter':
+        new_path = writer.copy_to(file_)
+        if new_path:
+          self.saved_paths.append(new_path)
+          saved_path = new_path
+          saved_path_type = writer.name
+
+    return (saved_path, saved_path_type)
 
   def set_error(self, error, traceback_):
     """Add error and traceback.
@@ -268,7 +308,7 @@ class TurbiniaTask(object):
     self.output_dir = self.result.output_dir
 
     if evidence.copyable and not config.SHARED_FILESYSTEM:
-      self.result.output_manager.retrieve_evidence(evidence)
+      self.result.retrieve_evidence(evidence)
 
     if evidence.local_path and not os.path.exists(evidence.local_path):
       raise TurbiniaException(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -110,7 +110,7 @@ class TurbiniaTaskResult(object):
     for evidence in self.evidence:
       if evidence.local_path:
         self.saved_paths.append(evidence.local_path)
-        self.save_evidence(evidence)
+        self.output_manager.save_evidence(evidence, self)
       if not evidence.request_id:
         evidence.request_id = self.request_id
 
@@ -155,46 +155,6 @@ class TurbiniaTaskResult(object):
         evidence: Evidence object
     """
     self.evidence.append(evidence)
-
-  def save_evidence(self, evidence_):
-    """Saves local evidence files.
-
-    evidence_: Evidence object
-    """
-    (path, path_type) = self.save_local_file(evidence_.local_file)
-    evidence_.saved_path = path
-    evidence_.saved_path_type = path_type
-
-  def retrieve_evidence(self, evidence_):
-    """Retrieves local evidence files.
-
-    evidence_: Evidence object
-    """
-    for writer in self._output_writers:
-      if writer.name == evidence_.saved_path_type:
-        evidence_.local_path = writer.copy_from(evidence_.saved_path)
-
-  def save_local_file(self, file_):
-    """Saves local file by writing to all non-local output writers.
-
-    Args:
-      file_ (string): Path to file to save.
-
-    Returns:
-      Tuple of (String of last written file path,
-                String of last written file destination output type)
-    """
-    saved_path = None
-    saved_path_type = None
-    for writer in self._output_writers:
-      if writer.name != 'LocalOutputWriter':
-        new_path = writer.copy_to(file_)
-        if new_path:
-          self.saved_paths.append(new_path)
-          saved_path = new_path
-          saved_path_type = writer.name
-
-    return (saved_path, saved_path_type)
 
   def set_error(self, error, traceback_):
     """Add error and traceback.
@@ -273,7 +233,7 @@ class TurbiniaTask(object):
     else:
       for file_ in save_files:
         result.log('Output file at {0:s}'.format(file_))
-        result.output_manager.save_local_file(file_, result)
+        result.output_manager.save_local_file(file_)
       for evidence in new_evidence:
         result.add_evidence(evidence)
 
@@ -308,7 +268,7 @@ class TurbiniaTask(object):
     self.output_dir = self.result.output_dir
 
     if evidence.copyable and not config.SHARED_FILESYSTEM:
-      self.result.retrieve_evidence(evidence)
+      self.result.output_manager.retrieve_evidence(evidence)
 
     if evidence.local_path and not os.path.exists(evidence.local_path):
       raise TurbiniaException(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -369,8 +369,8 @@ class TurbiniaTask(object):
         status = self.result.status
       else:
         status = 'No previous status'
-      msg = 'Task Result was auto-closed from task executor. {0:s}'.format(
-          status)
+      msg = ('Task Result was auto-closed from task executor on {0:s}.'
+             ' {1:s}.'.format(self.worker_name, status))
       self.result.log(msg)
       try:
         self.result.close(False, msg)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -353,30 +353,34 @@ class TurbiniaTask(object):
         self.result.log(msg)
         self.result.log(traceback.format_exc())
         self.result.set_error(e.message, traceback.format_exc())
-        # Trying to close the result if possible, so that we clean up what we
-        # can.  This has a higher liklihood of failing though because we're
-        # already in a failure condition because the task previously failed.
-        if not self.result.closed:
-          msg = 'Attempting to close result after task exception'
-          log.warning(msg)
-          self.result.log(msg)
-          try:
-            self.result.close(success=False, status=msg)
-          # Using broad except here because lots can go wrong due to the reasons
-          # listed above.
-          # pylint: disable=broad-except
-          except Exception as e:
-            log.error('TurbiniaTaskResult close failed: {0!s}'.format(e))
       else:
         log.error(
             'No TurbiniaTaskResult object found after task execution.')
 
+    # Trying to close the result if possible so that we clean up what we can.
+    # This has a higher liklihood of failing because something must have gone
+    # wrong as the Task should have already closed this.
     if self.result and not self.result.closed:
-      msg = 'Task Result was auto-closed from task executor without status'
+      msg = 'Attempting last ditch attempt to close result'
+      log.warning(msg)
       self.result.log(msg)
-      self.result.close(False, msg)
-    result = self.result_check(self.result)
 
+      if self.result.status:
+        status = self.result.status
+      else:
+        status = 'No previous status'
+      msg = 'Task Result was auto-closed from task executor. {0:s}'.format(
+          status)
+      self.result.log(msg)
+      try:
+        self.result.close(False, msg)
+      # Using broad except here because lots can go wrong due to the reasons
+      # listed above.
+      # pylint: disable=broad-except
+      except Exception as e:
+        log.error('TurbiniaTaskResult close failed: {0!s}'.format(e))
+
+    result = self.result_check(self.result)
     return result
 
   def run(self, evidence, result):

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -140,6 +140,7 @@ class TurbiniaTaskResult(object):
     self._output_writers = None
     self.closed = True
     self.status = status
+    log.debug('Result close successful. Status is [{0:s}]'.format(self.status))
 
 
   def log(self, log_msg):
@@ -303,6 +304,7 @@ class TurbiniaTask(object):
     try:
       log.debug('Checking TurbiniaTaskResult for serializability')
       pickle.dumps(result)
+      dump_status = 'Successful'
     except (TypeError, pickle.PicklingError) as e:
       msg = ('Error pickling TurbiniaTaskResult object. Returning a new result '
              'with the pickling error, and all previous result data will be '
@@ -316,7 +318,9 @@ class TurbiniaTask(object):
           request_id=self.request_id)
       result.set_error(e.message, traceback.format_exc())
       result.close(False, status=msg)
+      dump_status = 'Failed, but replaced with new result object'
 
+    log.info('Result check: {0:s}'.format(dump_status))
     return result
 
   def run_wrapper(self, evidence):

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -377,7 +377,7 @@ class TurbiniaTask(object):
       else:
         status = 'No previous status'
       msg = ('Task Result was auto-closed from task executor on {0:s}.'
-             ' {1:s}.'.format(self.worker_name, status))
+             ' {1:s}'.format(self.worker_name, status))
       self.result.log(msg)
       try:
         self.result.close(False, msg)


### PR DESCRIPTION
We want to close results if possible, but it can also cause errors.  Generally this adds more error handling and logging to the process