### PR TITLE
Fix config and output_writer tests

### DIFF
--- a/tests/config/config.py
+++ b/tests/config/config.py
@@ -29,6 +29,9 @@ class TestTurbiniaConfig(unittest.TestCase):
     # tests start by turbinia __init__.
     # pylint: disable=expression-not-assigned
     [delattr(config, a) for a in config.CONFIGVARS if hasattr(config, a)]
+    cls.CONFIGPATH_SAVE = config.CONFIGPATH
+    cls.CONFIGFILES_SAVE = config.CONFIGFILES
+    cls.CONFIGVARS_SAVE = config.CONFIGVARS
 
   def setUp(self):
     # Record the module attributes so we can remove them after the test to
@@ -39,6 +42,12 @@ class TestTurbiniaConfig(unittest.TestCase):
     config.CONFIGPATH = [os.path.dirname(self.config_file)]
     config.CONFIGFILES = [os.path.basename(self.config_file)]
     config.CONFIGVARS = []
+
+  @classmethod
+  def tearDownClass(cls):
+    config.CONFIGPATH = cls.CONFIGPATH_SAVE
+    config.CONFIGFILES = cls.CONFIGFILES_SAVE
+    config.CONFIGVARS = cls.CONFIGVARS_SAVE
 
   def tearDown(self):
     os.remove(self.config_file)

--- a/tests/output_manager.py
+++ b/tests/output_manager.py
@@ -58,7 +58,7 @@ class TestLocalOutputWriter(unittest.TestCase):
     with open(src, 'w') as file_handle:
       file_handle.write(contents)
 
-    self.assertTrue(writer.write(src))
+    self.assertTrue(writer.copy_to(src))
     self.assertTrue(os.path.exists(dst))
     self.assertEqual(contents, open(dst).read())
 
@@ -72,7 +72,7 @@ class TestLocalOutputWriter(unittest.TestCase):
     src = os.path.join(self.base_output_dir, test_file)
     dst = os.path.join(output_dir, test_file)
 
-    self.assertFalse(writer.write(src))
+    self.assertFalse(writer.copy_to(src))
     self.assertFalse(os.path.exists(dst))
 
   def testFileExistsWrite(self):
@@ -94,5 +94,5 @@ class TestLocalOutputWriter(unittest.TestCase):
     with open(dst, 'w') as file_handle:
       file_handle.write(other_contents)
 
-    self.assertFalse(writer.write(src))
+    self.assertFalse(writer.copy_to(src))
     self.assertEqual(other_contents, open(dst).read())


### PR DESCRIPTION
This is to prevent future tests from being affected since they are module level attributes.