### PR TITLE
Explicitly set empty config in tests

### DIFF
--- a/tests/config/config.py
+++ b/tests/config/config.py
@@ -39,6 +39,7 @@ class TestTurbiniaConfig(unittest.TestCase):
     # when it has a other references.
     self.config_attrs = dir(config)
     self.config_file = tempfile.mkstemp()[1]
+    config.CONFIG = None
     config.CONFIGPATH = [os.path.dirname(self.config_file)]
     config.CONFIGFILES = [os.path.basename(self.config_file)]
     config.CONFIGVARS = []


### PR DESCRIPTION
This ensures that the config tests aren't affected by other tests that may have pre-loaded the config.