### PR TITLE
Install Plaso only for workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 /build/
 
 # And don't care about the 'egg'.
-/Turbinia.egg-info
+/turbinia.egg-info
 
 # Test files
 .coverage

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-plaso>=20171118
 psq==0.5.0
 google-api-python-client>=1.6.2
 google-cloud-pubsub==0.26.0

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""This is the setup file for the project.
+"""This is the setup file for the project."""
 
-The standard setup rules apply:
-python setup.py build
-sudo python setup.py install 
-"""
+from __future__ import unicode_literals
 
 from setuptools import find_packages
 from setuptools import setup
@@ -32,17 +29,39 @@ except ImportError:  # for pip <= 9.0.3
   from pip.req import parse_requirements
 
 
+turbinia_version = '20180620'
+
+turbinia_description = (
+  'Turbinia is an open-source framework for deploying, managing, and running'
+  'forensic workloads on cloud platforms. It is intended to automate running of'
+  'common forensic processing tools (i.e. Plaso, TSK, strings, etc) to help'
+  'with processing evidence in the Cloud, scaling the processing of large'
+  'amounts of evidence, and decreasing response time by parallelizing'
+  'processing where possible.')
+
 setup(
-    name='Turbinia',
-    version='20170801',
-    long_description=__doc__,
-    packages=find_packages(),
-    include_package_data=True,
-    zip_safe=False,
-    scripts=['turbiniactl'],
-    install_requires=[str(req.req) for req in parse_requirements(
-        'requirements.txt', session=PipSession())
-    ],
-    extras_require={
-      'worker': ['plaso>=20171118']
-    })
+  name='turbinia',
+  version=turbinia_version,
+  description='Automation and Scaling of Digital Forensics Tools',
+  long_description=turbinia_description,
+  license='Apache License, Version 2.0',
+  url='http://turbinia.plumbing/',
+  maintainer='Turbinia development team',
+  maintainer_email='turbinia-dev@googlegroups.com',
+  classifiers=[
+    'Development Status :: 4 - Beta',
+    'Environment :: Console',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python',
+  ],
+  packages=find_packages(),
+  include_package_data=True,
+  zip_safe=False,
+  scripts=['turbiniactl'],
+  install_requires=[str(req.req) for req in parse_requirements(
+    'requirements.txt', session=PipSession())
+  ],
+  extras_require={
+    'worker': ['plaso>=20171118']
+  }
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
-#!/usr/bin/python
 #
 # Copyright 2017 Google Inc.
 #
@@ -18,18 +18,19 @@
 
 The standard setup rules apply:
 python setup.py build
-sudo python setup.py install
+sudo python setup.py install 
 """
 
 from setuptools import find_packages
 from setuptools import setup
 
-try: # for pip >= 10
+try:  # for pip >= 10
   from pip._internal.download import PipSession
   from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
+except ImportError:  # for pip <= 9.0.3
   from pip.download import PipSession
   from pip.req import parse_requirements
+
 
 setup(
     name='Turbinia',
@@ -42,6 +43,6 @@ setup(
     install_requires=[str(req.req) for req in parse_requirements(
         'requirements.txt', session=PipSession())
     ],
-    extras_require = {
-      'worker': ['plaso>=20171118'],
+    extras_require={
+      'worker': ['plaso>=20171118']
     })

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,13 @@ sudo python setup.py install
 
 from setuptools import find_packages
 from setuptools import setup
-from pip.req import parse_requirements
-from pip.download import PipSession
+
+try: # for pip >= 10
+  from pip._internal.download import PipSession
+  from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+  from pip.download import PipSession
+  from pip.req import parse_requirements
 
 setup(
     name='Turbinia',
@@ -36,4 +41,7 @@ setup(
     scripts=['turbiniactl'],
     install_requires=[str(req.req) for req in parse_requirements(
         'requirements.txt', session=PipSession())
-    ])
+    ],
+    extras_require = {
+      'worker': ['plaso>=20171118'],
+    })


### PR DESCRIPTION
This PR remove the dependency on Plaso for the client only install. If you are installing a worker you now need to do: pip install turbinia[worker]

Also, this PR fixes a bug where pip v10.x couldn install the package.