### PR TITLE
Update setup.py to use newer 'entry_points' param

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    scripts=['turbiniactl'],
+    entry_points={"console_scripts": ["turbiniactl=turbinia.turbiniactl:main"]},
     install_requires=[str(req.req) for req in parse_requirements(
         'requirements.txt', session=PipSession())
     ])

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -36,7 +36,7 @@ log = logging.getLogger('turbinia')
 logger.setup()
 
 
-if __name__ == '__main__':
+def main():
   # TODO(aarontp): Allow for single run mode when specifying evidence
   #                which will also terminate the task manager after evidence has
   #                been processed.

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -367,3 +367,6 @@ def main():
 
   log.info('Done.')
   sys.exit(0)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
- `entry_points / console_scripts` seems to be the suggested replacement for `scripts` (and is more flexible): https://python-packaging.readthedocs.io/en/latest/command-line-scripts.html#the-console-scripts-entry-point

My motivation for this change was to allow importing of `turbiniactl` directly. This doesn't change anything about running `turbiniactl` -- everything is exactly the same (i.e. you still get a `turbiniactl` in your path after a `python setup.py install`). But now with the added benefit of *also* being able to do `from turbinia import turbiniactl` (which makes building turbinia in our build system easier, since we use par files to self-contain python packages & their imports; and I'm sticking some python management on top of `turbiniactl`).