### PR TITLE
Update PubSub and PSQ to the latest packages 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-psq==0.5.0
+psq
 google-api-python-client>=1.6.2
-google-cloud-pubsub==0.26.0
-google-cloud-storage==1.6.0
-google-cloud-core==0.26.0
+google-cloud-pubsub
+google-cloud-storage
+google-cloud-core
+oauth2client
 urllib3[secure]

--- a/tests/pubsub.py
+++ b/tests/pubsub.py
@@ -49,14 +49,6 @@ class MockPubSubMessage(object):
     self.message_id = message_id
 
 
-class MockPubSubResults(list):
-  """Mock of a PubSub Results list that can contain MockPubSubMessages."""
-
-  def __init__(self, ack_id='54321', message='fake message'):
-    super(MockPubSubResults, self).__init__()
-    self.append((ack_id, message))
-
-
 class TestTurbiniaRequest(unittest.TestCase):
   """Test TurbiniaRequest class."""
 
@@ -99,10 +91,9 @@ class TestTurbiniaPubSub(unittest.TestCase):
   def setUp(self):
     request = getTurbiniaRequest()
     self.pubsub = pubsub.TurbiniaPubSub('fake_topic')
-    results = MockPubSubResults(
-        ack_id='1234', message=MockPubSubMessage(request.to_json(), 'msg id'))
-    self.pubsub.subscription = mock.MagicMock()
-    self.pubsub.subscription.pull.return_value = results
+    message = MockPubSubMessage(request.to_json(), 'msg id')
+    self.pubsub._queue.put(message)
+    self.pubsub.topic_path = 'faketopicpath'
 
   def testCheckMessages(self):
     """Test check_messages to make sure it returns the expected results."""
@@ -117,22 +108,21 @@ class TestTurbiniaPubSub(unittest.TestCase):
     self.assertTrue(isinstance(request_new.evidence[0], evidence.RawDisk))
     self.assertEqual(request_new.evidence[0].name, 'My Evidence')
 
-    # Make sure that the test message was acknowledged
-    self.pubsub.subscription.acknowledge.assert_called_with(['1234'])
-
   def testBadCheckMessages(self):
     """Test check_messages returns empty list for an invalid message."""
-    results = MockPubSubResults(
-        ack_id='2345', message=MockPubSubMessage('non-json-data', 'msg id2'))
-    self.pubsub.subscription.pull.return_value = results
+    message = MockPubSubMessage('non-json-data', 'msg id2')
+    # Clear the queue so we can add an invalid message
+    self.pubsub._queue.get()
+    self.pubsub._queue.put(message)
 
     self.assertListEqual(self.pubsub.check_messages(), [])
 
   def testSendMessage(self):
     """Test sending a message."""
-    self.pubsub.topic = mock.MagicMock()
+    self.pubsub.publisher = mock.MagicMock()
     self.pubsub.send_message('test message text')
-    self.pubsub.topic.publish.assert_called_with('test message text')
+    self.pubsub.publisher.publish.assert_called_with(
+        'faketopicpath', 'test message text')
 
 
 class TestTurbiniaKombu(unittest.TestCase):

--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -49,25 +49,29 @@ class TurbiniaPubSub(TurbiniaMessageBase):
     self.topic_name = topic_name
     self.topic_path = None
 
-  def setup_publisher(self):
-    """Set up the pubsub publisher client."""
+  def setup(self):
+    """Set up the pubsub clients."""
     config.LoadConfig()
+    # Start with setting up the publisher
     self.publisher = pubsub.PublisherClient()
     self.topic_path = self.publisher.topic_path(
         config.PROJECT, self.topic_name)
     log.debug('Setup PubSub publisher at {0:s}'.format(self.topic_path))
 
-  def setup_subscriber(self):
-    """Set up the pubsub subscriber client."""
-    config.LoadConfig()
+    # Set up the subscriber
     self.subscriber = pubsub.SubscriberClient()
     subscription_path = self.subscriber.subscription_path(
         config.PROJECT, self.topic_path)
 
+    # TODO FIXME try/excpt protect this.
+    log.debug('Trying to create subscription {0:s} on topic {1:s}'.format(
+        subscription_path, self.topic_path))
+    self.subscriber.create_subscription(subscription_path, self.topic_path)
+
     log.debug('Setup PubSub Subscription {0:s}'.format(
         subscription_path))
-    self.subscription = self.subscriber.subscribe(subscription_path)
-    self.subscription.open(self._callback)
+    self.subscription = self.subscriber.subscribe(
+        subscription_path, self._callback)
 
   def _callback(self, message):
     """Callback function that places messages in the queue.

--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 import logging
+from Queue import Queue
 
 from google.cloud import pubsub
 
@@ -31,25 +32,54 @@ class TurbiniaPubSub(TurbiniaMessageBase):
   """PubSub client object for Google Cloud.
 
   Attributes:
-    topic: The pubsub topic object
-    topic_name: The pubsub topic name
+    _queue: A Queue object for storing pubsub messages
+    topic_name (str): The full pubsub topic name
+    topic_subpath (str): The partial name of the last
+    subscriber: The pubsub subscriber client object
+    publisher: The pubsub publisher client object
     subscription: The pubsub subscription object
   """
 
-  def __init__(self, topic_name):
+  def __init__(self, topic_subpath):
     """Initialization for PubSubClient."""
-    self.topic_name = topic_name
-    self.topic = None
+    self._queue = Queue()
+    self.publisher = None
+    self.subscriber = None
     self.subscription = None
+    self.subscription_name = None
+    self.topic_name = None
+    self.topic_subpath = topic_subpath
 
-  def setup(self):
-    """Set up the client."""
+  def setup_publisher(self):
+    """Set up the pubsub publisher client."""
     config.LoadConfig()
-    client = pubsub.Client(project=config.PROJECT)
-    self.topic = client.topic(self.topic_name)
-    log.debug('Connecting to PubSub Subscription on {0:s}'.format(
-        self.topic_name))
-    self.subscription = self.topic.subscription(self.topic_name)
+    print "DEBUG: in setup_publisher()"
+    self.publisher = pubsub.PublisherClient()
+    self.topic_name = self.publisher.topic_path(
+        config.PROJECT, self.topic_subpath)
+    log.debug('Setup PubSub publisher {0:s}'.format(self.topic_name))
+
+  def setup_subscriber(self):
+    """Set up the pubsub subscriber client."""
+    config.LoadConfig()
+    self.subscriber = pubsub.SubscriberClient()
+    self.subscription_name = self.subscriber.subscription_path(
+        config.PROJECT, self.topic_subpath)
+
+    log.debug('Setup PubSub Subscription {0:s}'.format(
+        self.subscription_name))
+    self.subscription = self.subscriber.subscribe(self.subscription_name)
+    self.subscription.open(self._callback)
+
+  def _callback(self, message):
+    """Callback function that places messages in the queue.
+
+    Args:
+      message: A pubsub message object
+    """
+    log.debug('Recieved pubsub message: {0:s}'.format(message.data))
+    message.ack()
+    self._queue.put(message)
 
   def check_messages(self):
     """Checks for pubsub messages.
@@ -57,26 +87,19 @@ class TurbiniaPubSub(TurbiniaMessageBase):
     Returns:
       A list of any TurbiniaRequest objects received, else an empty list
     """
-    results = self.subscription.pull(return_immediately=True)
-
-    ack_ids = []
     requests = []
-    for ack_id, message in results:
+    for _ in xrange(self._queue.qsize()):
+      message = self._queue.get()
       data = message.data
-      log.info('Processing PubSub Message {0:s}'.format(message.message_id))
-      log.debug('PubSub Message body: {0:s}'.format(data))
+      log.info('Processing PubSub message {0:s}'.format(message.message_id))
+      log.debug('PubSub message body: {0:s}'.format(data))
 
       request = self._validate_message(data)
       if request:
         requests.append(request)
-        ack_ids.append(ack_id)
       else:
         log.error('Error processing PubSub message: {0:s}'.format(data))
 
-    if results:
-      self.subscription.acknowledge(ack_ids)
-
-    log.debug('Recieved {0:d} pubsub messages'.format(len(requests)))
     return requests
 
   def send_message(self, message):
@@ -85,7 +108,15 @@ class TurbiniaPubSub(TurbiniaMessageBase):
     message: The message to send.
     """
     data = message.encode('utf-8')
-    msg_id = self.topic.publish(data)
-    log.info(
-        'Published message {0:s} to topic {1:s}'.format(
-            msg_id, self.topic_name))
+    future = self.publisher.publish(self.topic_name, data)
+    msg_id = future.result()
+    log.info('Published message {0:s} to topic {1:s}'.format(
+        msg_id, self.topic_name))
+
+  def send_request(self, request):
+    """Sends a TurbiniaRequest message.
+
+    Args:
+      request: A TurbiniaRequest object.
+    """
+    self.send_message(request.to_json())

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -347,11 +347,13 @@ class PSQTaskManager(BaseTaskManager):
             config.PROJECT))
     self.server_pubsub = turbinia_pubsub.TurbiniaPubSub(config.PUBSUB_TOPIC)
     self.server_pubsub.setup()
+    psq_publisher = pubsub.PublisherClient()
+    psq_subscriber = pubsub.SubscriberClient()
     datastore_client = datastore.Client(project=config.PROJECT)
     try:
       self.psq = psq.Queue(
-          self.server_pubsub.publisher,
-          self.server_pubsub.subscriber,
+          psq_publisher,
+          psq_subscriber,
           config.PROJECT,
           storage=psq.DatastoreStorage(datastore_client))
     except exceptions.GoogleAPIError as e:

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -25,7 +25,7 @@ import psq
 
 from google.cloud import datastore
 from google.cloud import pubsub
-from google.gax.errors import GaxError
+from google.cloud import exceptions
 
 import turbinia
 from turbinia import evidence
@@ -346,8 +346,7 @@ class PSQTaskManager(BaseTaskManager):
         'Setting up PSQ Task Manager requirements on project {0:s}'.format(
             config.PROJECT))
     self.server_pubsub = turbinia_pubsub.TurbiniaPubSub(config.PUBSUB_TOPIC)
-    self.server_pubsub.setup_subscriber()
-    self.server_pubsub.setup_publisher()
+    self.server_pubsub.setup()
     psq_pubsub_client = pubsub.PublisherClient()
     datastore_client = datastore.Client(project=config.PROJECT)
     try:
@@ -355,7 +354,7 @@ class PSQTaskManager(BaseTaskManager):
           psq_pubsub_client,
           config.PSQ_TOPIC,
           storage=psq.DatastoreStorage(datastore_client))
-    except GaxError as e:
+    except exceptions.GoogleAPIError as e:
       msg = 'Error creating PSQ Queue: {0:s}'.format(str(e))
       log.error(msg)
       raise turbinia.TurbiniaException(msg)

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -346,8 +346,9 @@ class PSQTaskManager(BaseTaskManager):
         'Setting up PSQ Task Manager requirements on project {0:s}'.format(
             config.PROJECT))
     self.server_pubsub = turbinia_pubsub.TurbiniaPubSub(config.PUBSUB_TOPIC)
-    self.server_pubsub.setup()
-    psq_pubsub_client = pubsub.Client(project=config.PROJECT)
+    self.server_pubsub.setup_subscriber()
+    self.server_pubsub.setup_publisher()
+    psq_pubsub_client = pubsub.PublisherClient()
     datastore_client = datastore.Client(project=config.PROJECT)
     try:
       self.psq = psq.Queue(

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -25,7 +25,7 @@ import psq
 
 from google.cloud import datastore
 from google.cloud import pubsub
-from google.cloud import exceptions
+from google.api_core import exceptions
 
 import turbinia
 from turbinia import evidence
@@ -347,12 +347,12 @@ class PSQTaskManager(BaseTaskManager):
             config.PROJECT))
     self.server_pubsub = turbinia_pubsub.TurbiniaPubSub(config.PUBSUB_TOPIC)
     self.server_pubsub.setup()
-    psq_pubsub_client = pubsub.PublisherClient()
     datastore_client = datastore.Client(project=config.PROJECT)
     try:
       self.psq = psq.Queue(
-          psq_pubsub_client,
-          config.PSQ_TOPIC,
+          self.server_pubsub.publisher,
+          self.server_pubsub.subscriber,
+          config.PROJECT,
           storage=psq.DatastoreStorage(datastore_client))
     except exceptions.GoogleAPIError as e:
       msg = 'Error creating PSQ Queue: {0:s}'.format(str(e))


### PR DESCRIPTION
PubSub no longer supports a pull mechanism, so this creates a small callback that adds incoming pubsub messages to a queue that can be checked similar to how we were doing it before.  It also separates out the publisher/subscriber clients and will auto-create the topics and subscriptions.  