### PR TITLE
Use non-private exceptions

### DIFF
--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -19,7 +19,7 @@ from __future__ import unicode_literals
 import logging
 from Queue import Queue
 
-from google.api_core import exceptions
+from google.cloud import exceptions
 from google.cloud import pubsub
 
 # Turbinia
@@ -60,7 +60,7 @@ class TurbiniaPubSub(TurbiniaMessageBase):
     try:
       log.debug('Trying to create pubsub topic {0:s}'.format(self.topic_path))
       self.publisher.create_topic(self.topic_path)
-    except exceptions.AlreadyExists:
+    except exceptions.Conflict:
       log.debug('PubSub topic {0:s} already exists.'.format(self.topic_path))
     log.debug('Setup PubSub publisher at {0:s}'.format(self.topic_path))
 
@@ -72,7 +72,7 @@ class TurbiniaPubSub(TurbiniaMessageBase):
       log.debug('Trying to create subscription {0:s} on topic {1:s}'.format(
           subscription_path, self.topic_path))
       self.subscriber.create_subscription(subscription_path, self.topic_path)
-    except exceptions.AlreadyExists:
+    except exceptions.Conflict:
       log.debug('Subscription {0:s} already exists.'.format(subscription_path))
 
     log.debug('Setup PubSub Subscription {0:s}'.format(

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -26,9 +26,9 @@ except ImportError:
 
 import psq
 
+from google.cloud import exceptions
 from google.cloud import datastore
 from google.cloud import pubsub
-from google.api_core import exceptions
 
 import turbinia
 from turbinia import evidence


### PR DESCRIPTION
Apparently using google.api_core directly is bad since it's considered an internal/private interface, and the proper exception classes are in google.cloud.exceptions.