### PR TITLE
Load only required pubsub features per component type

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -245,7 +245,11 @@ class TurbiniaCeleryClient(TurbiniaClient):
 
 
 class TurbiniaServer(object):
-  """Turbinia Server class."""
+  """Turbinia Server class.
+
+  Attributes:
+    task_manager (TaskManager): An object to manage turbinia tasks.
+  """
 
   def __init__(self):
     """Initialize Turbinia Server."""

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -25,6 +25,10 @@ import time
 # TODO(aarontp): Selectively load dependencies based on configured backends
 import psq
 
+from google.cloud import exceptions
+from google.cloud import datastore
+from google.cloud import pubsub
+
 from turbinia import config
 from turbinia.config import logger
 from turbinia.lib.google_cloud import GoogleCloudFunction
@@ -42,13 +46,16 @@ class TurbiniaClient(object):
   Attributes:
     task_manager (TaskManager): Turbinia task manager
   """
+
   def __init__(self):
     config.LoadConfig()
     self.task_manager = task_manager.get_task_manager()
-    self.task_manager.setup()
+    self.task_manager.setup(server=False)
 
   def list_jobs(self):
     """List the available jobs."""
+    # TODO(aarontp): Refactor this out so that we don't need to depend on
+    # the task manager from the client.
     log.info('Available Jobs:')
     for job in self.task_manager.jobs:
       log.info('\t{0:s}'.format(job.name))
@@ -99,6 +106,7 @@ class TurbiniaClient(object):
       days (int): The number of days we want history for.
       task_id (string): The Id of the task.
       request_id (string): The Id of the request we want tasks for.
+      function_name (string): The GCF function we want to call
 
     Returns:
       List of Task dict objects.
@@ -136,7 +144,6 @@ class TurbiniaClient(object):
 
     return results[0]
 
-
   def format_task_status(self, instance, project, region, days=0, task_id=None,
                          request_id=None, all_fields=False):
     """Formats the recent history for Turbinia Tasks.
@@ -152,7 +159,8 @@ class TurbiniaClient(object):
       all_fields (bool): Include all fields for the task, including task,
           request ids and saved file paths.
 
-    Returns: String of task status
+    Returns:
+      String of task status
     """
     task_results = self.get_task_data(instance, project, region, days, task_id,
                                       request_id)
@@ -204,6 +212,7 @@ class TurbiniaCeleryClient(TurbiniaClient):
   Attributes:
     redis (RedisStateManager): Redis datastore object
   """
+
   def __init__(self, *args, **kwargs):
     super(TurbiniaCeleryClient, self).__init__(*args, **kwargs)
     self.redis = RedisStateManager()
@@ -218,8 +227,9 @@ class TurbiniaCeleryClient(TurbiniaClient):
 
   def get_task_data(self, instance, _, __, days=0, task_id=None,
                     request_id=None, function_name=None):
-    """Gets task data from Redis. We keep the same function signature,
-        but ignore arguments passed for GCP.
+    """Gets task data from Redis.
+
+    We keep the same function signature, but ignore arguments passed for GCP.
 
     Args:
       instance (string): The Turbinia instance name (by default the same as the
@@ -234,8 +244,15 @@ class TurbiniaCeleryClient(TurbiniaClient):
     return self.redis.get_task_data(instance, days, task_id, request_id)
 
 
-class TurbiniaServer(TurbiniaClient):
+class TurbiniaServer(object):
   """Turbinia Server class."""
+
+  def __init__(self):
+    """Initialize Turbinia Server."""
+    config.LoadConfig()
+    self.task_manager = task_manager.get_task_manager()
+    self.task_manager.setup()
+
   def start(self):
     """Start Turbinia Server."""
     log.info('Running Turbinia Server.')
@@ -252,6 +269,7 @@ class TurbiniaCeleryWorker(TurbiniaClient):
   Attributes:
     worker (celery.app): Celery worker app
   """
+
   def __init__(self, *args, **kwargs):
     """Initialization for Celery worker."""
     super(TurbiniaCeleryWorker, self).__init__(*args, **kwargs)
@@ -267,19 +285,34 @@ class TurbiniaCeleryWorker(TurbiniaClient):
     self.worker.start(argv)
 
 
-class TurbiniaPsqWorker(TurbiniaClient):
+class TurbiniaPsqWorker(object):
   """Turbinia PSQ Worker class.
 
   Attributes:
     worker (psq.Worker): PSQ Worker object
+    psq (psq.Queue): A Task queue object
   """
+
   def __init__(self, *args, **kwargs):
     """Initialization for PSQ Worker."""
-    super(TurbiniaPsqWorker, self).__init__(*args, **kwargs)
-    log.info(
-        'Starting PSQ listener on queue {0:s}'.format(
-            self.task_manager.psq.name))
-    self.worker = psq.Worker(queue=self.task_manager.psq)
+    config.LoadConfig()
+    psq_publisher = pubsub.PublisherClient()
+    psq_subscriber = pubsub.SubscriberClient()
+    datastore_client = datastore.Client(project=config.PROJECT)
+    try:
+      self.psq = psq.Queue(
+          psq_publisher,
+          psq_subscriber,
+          config.PROJECT,
+          name=config.PSQ_TOPIC,
+          storage=psq.DatastoreStorage(datastore_client))
+    except exceptions.GoogleAPIError as e:
+      msg = 'Error creating PSQ Queue: {0:s}'.format(str(e))
+      log.error(msg)
+      raise TurbiniaException(msg)
+
+    log.info('Starting PSQ listener on queue {0:s}'.format(self.psq.name))
+    self.worker = psq.Worker(queue=self.psq)
 
   def start(self):
     """Start Turbinia PSQ Worker."""

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -85,9 +85,10 @@ class TestTurbiniaServer(unittest.TestCase):
 class TestTurbiniaPsqWorker(unittest.TestCase):
   """Test Turbinia PSQ Worker class."""
 
-  @mock.patch('turbinia.client.task_manager.PSQTaskManager')
+  @mock.patch('turbinia.client.pubsub')
+  @mock.patch('turbinia.client.datastore.Client')
   @mock.patch('turbinia.client.psq.Worker')
-  def testTurbiniaPsqWorkerInit(self, _, __):
-    """Basic test for client."""
+  def testTurbiniaPsqWorkerInit(self, _, __, ___):
+    """Basic test for PSQ worker."""
     worker = TurbiniaPsqWorker()
     self.assertTrue(hasattr(worker, 'worker'))

--- a/turbinia/pubsub.py
+++ b/turbinia/pubsub.py
@@ -52,8 +52,12 @@ class TurbiniaPubSub(TurbiniaMessageBase):
 
   def setup(self):
     """Set up the pubsub clients."""
+    self.setup_publisher()
+    self.setup_subscriber()
+
+  def setup_publisher(self):
+    """Set up the pubsub publisher."""
     config.LoadConfig()
-    # Start with setting up the publisher
     self.publisher = pubsub.PublisherClient()
     self.topic_path = self.publisher.topic_path(
         config.PROJECT, self.topic_name)
@@ -64,10 +68,15 @@ class TurbiniaPubSub(TurbiniaMessageBase):
       log.debug('PubSub topic {0:s} already exists.'.format(self.topic_path))
     log.debug('Setup PubSub publisher at {0:s}'.format(self.topic_path))
 
-    # Set up the subscriber
+  def setup_subscriber(self):
+    """Set up the pubsub subscriber."""
+    config.LoadConfig()
     self.subscriber = pubsub.SubscriberClient()
     subscription_path = self.subscriber.subscription_path(
         config.PROJECT, self.topic_name)
+    if not self.topic_path:
+      self.topic_path = self.subscriber.topic_path(
+          config.PROJECT, self.topic_name)
     try:
       log.debug('Trying to create subscription {0:s} on topic {1:s}'.format(
           subscription_path, self.topic_path))
@@ -101,7 +110,6 @@ class TurbiniaPubSub(TurbiniaMessageBase):
       message = self._queue.get()
       data = message.data
       log.info('Processing PubSub message {0:s}'.format(message.message_id))
-      log.debug('PubSub message body: {0:s}'.format(data))
 
       request = self._validate_message(data)
       if request:

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -219,7 +219,8 @@ def main():
       required=False)
 
   # Celery Worker
-  parser_celeryworker = subparsers.add_parser('celeryworker', help='Run Celery worker')
+  parser_celeryworker = subparsers.add_parser(
+      'celeryworker', help='Run Celery worker')
 
   # Parser options for Turbinia status command
   parser_status = subparsers.add_parser(
@@ -258,10 +259,13 @@ def main():
 
   # Client
   config.LoadConfig()
-  if args.use_celery:
-    client = TurbiniaCeleryClient()
+  if args.command not in ('psqworker', 'server'):
+    if args.use_celery:
+      client = TurbiniaCeleryClient()
+    else:
+      client = TurbiniaClient()
   else:
-    client = TurbiniaClient()
+    client = None
 
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir


### PR DESCRIPTION
This does a few things, but the net result is that we only load:

- pubsub publisher from the client
- pubsub subscriber from the server
- No pubsub in psqworker
- No client object in turbiniactl when we are running server or psqworker

It also:

- Starts to pull things out of the task manager, but there are still a few other components, so I filed #205.
- Separated the Server/PSQWorker client objects from TurbiniaClient 
- Also cleaned up some lint errors along the way