### PR TITLE
State manager and run_wrapper fixes

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -309,7 +309,7 @@ class TurbiniaPsqWorker(object):
           config.PROJECT,
           name=config.PSQ_TOPIC,
           storage=psq.DatastoreStorage(datastore_client))
-    except exceptions.GoogleAPIError as e:
+    except exceptions.GoogleCloudError as e:
       msg = 'Error creating PSQ Queue: {0:s}'.format(str(e))
       log.error(msg)
       raise TurbiniaException(msg)

--- a/turbinia/state_manager_test.py
+++ b/turbinia/state_manager_test.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests the state manager module."""
+
+from __future__ import unicode_literals
+
+import copy
+import os
+import tempfile
+import unittest
+import mock
+
+from turbinia import config
+from turbinia.workers import TurbiniaTask
+from turbinia.workers import TurbiniaTaskResult
+
+from turbinia import state_manager
+
+
+class TestPSQStateManager(unittest.TestCase):
+  """Test PSQStateManager class."""
+
+  def setUp(self):
+    self.remove_files = []
+    self.remove_dirs = []
+
+    config.LoadConfig()
+    self.state_manager_save = config.STATE_MANAGER
+    config.STATE_MANAGER = 'Datastore'
+    self.state_manager = state_manager.get_state_manager()
+
+    self.test_data = {
+        'name': 'TestTask',
+        'request_id': 'TestRequestId',
+        'status': 'TestStatus',
+        'saved_paths': ['testpath1', 'testpath2']
+    }
+
+    # Set up TurbiniaTask
+    self.base_output_dir = tempfile.mkdtemp()
+    self.task = TurbiniaTask(
+        base_output_dir=self.base_output_dir, name=self.test_data['name'],
+        request_id=self.test_data['request_id'])
+    self.task.output_manager = mock.MagicMock()
+
+    # Set up TurbiniaTaskResult
+    self.result = TurbiniaTaskResult(
+        task=self.task, base_output_dir=self.base_output_dir)
+    self.result.status = self.test_data['status']
+    self.result.saved_paths = self.test_data['saved_paths']
+    self.task.result = self.result
+
+    self.result.output_dir = self.base_output_dir
+
+  def tearDown(self):
+    config.STATE_MANAGER = self.state_manager_save
+    [os.remove(f) for f in self.remove_files if os.path.exists(f)]
+    [os.rmdir(d) for d in self.remove_dirs if os.path.exists(d)]
+    os.rmdir(self.base_output_dir)
+
+  def testStateManagerGetTaskDict(self):
+    """Test State Manger get_task_dict()."""
+    task_dict = self.state_manager.get_task_dict(self.task)
+
+    # Make the returned task_dict contains all of our test data
+    self.assertEqual(task_dict['name'], self.test_data['name'])
+    self.assertEqual(task_dict['request_id'], self.test_data['request_id'])
+    self.assertEqual(task_dict['status'], self.test_data['status'])
+    self.assertEqual(len(task_dict['saved_paths']), 2)
+    self.assertTrue(task_dict.has_key('instance'))
+    self.assertIn(
+        self.test_data['saved_paths'][0], task_dict['saved_paths'])
+
+  def testStateManagerValidateDataValidDict(self):
+    """Test State Manger _validate_data() base case."""
+    test_data = self.state_manager._validate_data(self.test_data)
+    self.assertDictEqual(test_data, self.test_data)
+
+  def testStateManagerValidateDataInvalidDict(self):
+    """Test State Manger _validate_data() base case."""
+    invalid_dict = copy.deepcopy(self.test_data)
+    invalid_dict['status'] = 'A' * state_manager.MAX_DATASTORE_STRLEN + 'BORKEN'
+    test_data = self.state_manager._validate_data(invalid_dict)
+    self.assertListEqual(test_data.keys(), self.test_data.keys())
+    self.assertNotEqual(test_data['status'], self.test_data['status'])
+    self.assertLessEqual(
+        len(test_data['status']), state_manager.MAX_DATASTORE_STRLEN)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -371,9 +371,16 @@ class TurbiniaTask(object):
       self.result = self.setup(evidence)
       original_result_id = self.result.id
       self._evidence_config = evidence.config
-      self.result = self.run(evidence, self.result)
+      # Passing the result through the run function explicitly, but failing back
+      # to the original result object if there is a problem.
+      tmp_result = self.run(evidence, self.result)
+      if not isinstance(tmp_result, TurbiniaTaskResult):
+        raise TurbiniaException(
+            'Task returned type [{0:s}] instead of TurbiniaTaskResult.').format(
+                type(tmp_result))
+      self.result = tmp_result
     # pylint: disable=broad-except
-    except Exception as e:
+    except (TurbiniaException, Exception) as e:
       msg = 'Task failed with exception: [{0!s}]'.format(e)
       log.error(msg)
       log.error(traceback.format_exc())

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -34,6 +34,7 @@ from turbinia import TurbiniaException
 
 log = logging.getLogger('turbinia')
 
+
 class TurbiniaTaskResult(object):
   """Object to store task results to be returned by a TurbiniaTask.
 
@@ -145,7 +146,6 @@ class TurbiniaTaskResult(object):
     self.closed = True
     log.debug('Result close successful. Status is [{0:s}]'.format(self.status))
 
-
   def log(self, log_msg):
     """Add a log message to the result object.
 
@@ -177,7 +177,7 @@ class TurbiniaTaskResult(object):
 
     Args:
         error: Short string describing the error.
-        traceback: Traceback of the error.
+        traceback_: Traceback of the error.
     """
     self.error['error'] = error
     self.error['traceback'] = traceback_
@@ -263,7 +263,23 @@ class TurbiniaTask(object):
         result.log('Output file at {0:s}'.format(file_))
         self.output_manager.save_local_file(file_, result)
       for evidence in new_evidence:
-        result.add_evidence(evidence, self._evidence_config)
+        # If the local path is set in the Evidence, we check to make sure that
+        # the path exists and is not empty before adding it.
+        if evidence.local_path and not os.path.exists(evidence.local_path):
+          msg = (
+              'Evidence {0:s} local_path {1:s} does not exist. Not returning '
+              'empty Evidence.'.format(evidence.name, evidence.local_path))
+          result.log(msg)
+          log.warning(msg)
+        elif (evidence.local_path and os.path.exists(evidence.local_path) and
+              os.path.getsize(evidence.local_path) == 0):
+          msg = (
+              'Evidence {0:s} local_path {1:s} is empty. Not returning '
+              'empty new Evidence.'.format(evidence.name, evidence.local_path))
+          result.log(msg)
+          log.warning(msg)
+        else:
+          result.add_evidence(evidence, self._evidence_config)
 
       if close:
         result.close(self, success=True)
@@ -345,7 +361,7 @@ class TurbiniaTask(object):
           request_id=self.request_id)
       result.status = '{0:s}. Previous status: [{1:s}]'.format(msg, old_status)
       result.set_error(e.message, traceback.format_exc())
-      result.close(self, False, status=msg)
+      result.close(self, success=False, status=msg)
       dump_status = 'Failed, but replaced with new result object'
 
     log.info('Result check: {0:s}'.format(dump_status))
@@ -381,7 +397,7 @@ class TurbiniaTask(object):
       self.result = tmp_result
     # pylint: disable=broad-except
     except (TurbiniaException, Exception) as e:
-      msg = 'Task failed with exception: [{0!s}]'.format(e)
+      msg = '{0:s} Task failed with exception: [{1!s}]'.format(self.name, e)
       log.error(msg)
       log.error(traceback.format_exc())
       if self.result:

--- a/turbinia/workers/grep.py
+++ b/turbinia/workers/grep.py
@@ -40,7 +40,8 @@ class GrepTask(TurbiniaTask):
 
     patterns = evidence.config.get('filter_patterns')
     if not patterns:
-      result.close(self, False, status='No patterns supplied, exit task')
+      result.close(
+          self, success=False, status='No patterns supplied, exit task')
       return result
 
     # Create temporary file to write patterns to.

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for workers __init__."""
+
+from __future__ import unicode_literals
+
+import json
+import mock
+import os
+import tempfile
+import unittest
+
+from turbinia import evidence
+from turbinia import TurbiniaException
+from turbinia.workers import TurbiniaTask
+from turbinia.workers import TurbiniaTaskResult
+
+
+class TestTurbiniaTask(unittest.TestCase):
+  """Test TurbiniaTask class."""
+
+  def setUp(self):
+    self.remove_files = []
+    self.remove_dirs = []
+
+    # Set up TurbiniaTask
+    self.base_output_dir = tempfile.mkdtemp()
+    self.task = TurbiniaTask(base_output_dir=self.base_output_dir)
+    self.task.output_manager = mock.MagicMock()
+
+    # Set up RawDisk Evidence
+    test_disk_path = tempfile.mkstemp(dir=self.base_output_dir)[1]
+    self.remove_files.append(test_disk_path)
+    self.evidence = evidence.RawDisk(local_path=test_disk_path)
+
+    # Set up TurbiniaTaskResult
+    self.result = TurbiniaTaskResult(
+        task=self.task, base_output_dir=self.base_output_dir)
+
+    self.result.output_dir = self.base_output_dir
+
+  def tearDown(self):
+    [os.remove(f) for f in self.remove_files if os.path.exists(f)]
+    [os.rmdir(d) for d in self.remove_dirs if os.path.exists(d)]
+    os.rmdir(self.base_output_dir)
+
+  @mock.patch('turbinia.workers.subprocess.Popen')
+  def testTurbiniaTaskExecute(self, popen_mock):
+    """Test execution with success case."""
+    cmd = 'test cmd'
+    output = ('test stdout', 'test stderr')
+
+    self.result.close = mock.MagicMock()
+    proc_mock = mock.MagicMock()
+    proc_mock.communicate.return_value = output
+    proc_mock.returncode = 0
+    popen_mock.return_value = proc_mock
+
+    self.task.execute(cmd, self.result, close=True)
+
+    # Command was executed, has the correct output saved and
+    # TurbiniaTaskResult.close() was called with successful status.
+    popen_mock.assert_called_with(cmd)
+    self.assertEqual(self.result.error['stdout'], output[0])
+    self.assertEqual(self.result.error['stderr'], output[1])
+    self.result.close.assert_called_with(self.task, success=True)
+
+  @mock.patch('turbinia.workers.subprocess.Popen')
+  def testTurbiniaTaskExecuteFailure(self, popen_mock):
+    """Test execution with failure case."""
+    cmd = 'test cmd'
+    output = ('test stdout', 'test stderr')
+
+    self.result.close = mock.MagicMock()
+    proc_mock = mock.MagicMock()
+    proc_mock.communicate.return_value = output
+    proc_mock.returncode = 1
+    popen_mock.return_value = proc_mock
+
+    self.task.execute(cmd, self.result, close=True)
+
+    # Command was executed and TurbiniaTaskResult.close() was called with
+    # unsuccessful status.
+    popen_mock.assert_called_with(cmd)
+    self.result.close.assert_called_with(
+        self.task, success=False, status=mock.ANY)
+
+  @mock.patch('turbinia.workers.subprocess.Popen')
+  def testTurbiniaTaskExecuteEvidenceExists(self, popen_mock):
+    """Test execution with new evidence that has valid a local_path."""
+    cmd = 'test cmd'
+    output = ('test stdout', 'test stderr')
+
+    self.result.close = mock.MagicMock()
+    proc_mock = mock.MagicMock()
+    proc_mock.communicate.return_value = output
+    proc_mock.returncode = 0
+    popen_mock.return_value = proc_mock
+
+    # Create our evidence local path file
+    with open(self.evidence.local_path, 'w') as evidence_path:
+      evidence_path.write('test')
+
+    self.task.execute(cmd, self.result, new_evidence=[self.evidence],
+                      close=True)
+    self.assertIn(self.evidence, self.result.evidence)
+
+  @mock.patch('turbinia.workers.subprocess.Popen')
+  def testTurbiniaTaskExecuteEvidenceDoesNotExist(self, popen_mock):
+    """Test execution with new evidence that does not have a local_path."""
+    cmd = 'test cmd'
+    output = ('test stdout', 'test stderr')
+
+    self.result.close = mock.MagicMock()
+    proc_mock = mock.MagicMock()
+    proc_mock.communicate.return_value = output
+    proc_mock.returncode = 0
+    popen_mock.return_value = proc_mock
+
+    os.remove(self.evidence.local_path)
+
+    self.task.execute(cmd, self.result, new_evidence=[self.evidence],
+                      close=True)
+    self.assertNotIn(self.evidence, self.result.evidence)
+
+  @mock.patch('turbinia.workers.subprocess.Popen')
+  def testTurbiniaTaskExecuteEvidenceExistsButEmpty(self, popen_mock):
+    """Test execution with new evidence local_path that exists but is empty."""
+    cmd = 'test cmd'
+    output = ('test stdout', 'test stderr')
+
+    self.result.close = mock.MagicMock()
+    proc_mock = mock.MagicMock()
+    proc_mock.communicate.return_value = output
+    proc_mock.returncode = 0
+    popen_mock.return_value = proc_mock
+
+    # Exists and is empty
+    self.assertTrue(os.path.exists(self.evidence.local_path))
+    self.assertEqual(os.path.getsize(self.evidence.local_path), 0)
+
+    self.task.execute(cmd, self.result, new_evidence=[self.evidence],
+                      close=True)
+    self.assertNotIn(self.evidence, self.result.evidence)


### PR DESCRIPTION
This PR does a few things:
- Catches a few errors/exceptions within the Datastore State manager (Datastore has a small string size limit)
- Handles invalid return values from the Task run() function
- Verifies that Evidence to be added in the Task execution() helper method has a valid and non-empty local path before adding it to be created
- Adds some more tests for affected modules
- Fixes up a few lint errors along the way