### PR TITLE
Selectively import modules

### DIFF
--- a/turbinia/celery.py
+++ b/turbinia/celery.py
@@ -19,16 +19,13 @@ Handles worker communication and new evidence requests.
 
 # fix celery naming collision (this file vs. module)
 from __future__ import absolute_import
-import Queue
 
 import logging
+import Queue
 
-try:
-  import celery
-  import kombu
-  from amqp.exceptions import ChannelError
-except ImportError:
-  pass
+import celery
+import kombu
+from amqp.exceptions import ChannelError
 
 from turbinia import config
 from turbinia.message import TurbiniaMessageBase

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -22,19 +22,23 @@ import json
 import logging
 import time
 
-# TODO(aarontp): Selectively load dependencies based on configured backends
-import psq
-
-from google.cloud import exceptions
-from google.cloud import datastore
-from google.cloud import pubsub
-
 from turbinia import config
 from turbinia.config import logger
-from turbinia.lib.google_cloud import GoogleCloudFunction
-from turbinia.state_manager import RedisStateManager
 from turbinia import task_manager
 from turbinia import TurbiniaException
+
+config.LoadConfig()
+if config.TASK_MANAGER == 'PSQ':
+  # TODO(aarontp): Selectively load dependencies based on configured backends
+  import psq
+
+  from google.cloud import exceptions
+  from google.cloud import datastore
+  from google.cloud import pubsub
+
+  from turbinia.lib.google_cloud import GoogleCloudFunction
+elif config.TASK_MANAGER == 'Celery':
+  from turbinia.state_manager import RedisStateManager
 
 log = logging.getLogger('turbinia')
 logger.setup()

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -20,10 +20,13 @@ import json
 import os
 import sys
 
+from turbinia import config
 from turbinia import TurbiniaException
-from turbinia.processors import google_cloud
 from turbinia.processors import mount_local
 
+config.LoadConfig()
+if config.TASK_MANAGER == 'PSQ':
+  from turbinia.processors import google_cloud
 
 def evidence_decode(evidence_dict):
   """Decode JSON into appropriate Evidence object.

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -26,7 +26,9 @@ import time
 from turbinia import config
 from turbinia import TurbiniaException
 
-from google.cloud import storage
+config.LoadConfig()
+if config.TASK_MANAGER == 'PSQ':
+  from google.cloud import storage
 
 log = logging.getLogger('turbinia')
 

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -26,18 +26,17 @@ import sys
 from datetime import datetime
 from datetime import timedelta
 
-try:
-  import redis
-except ImportError:
-  pass
-
-from google.cloud import datastore
-from google.cloud import exceptions
-
 from turbinia import config
 from turbinia import TurbiniaException
 from turbinia.workers import TurbiniaTask
 from turbinia.workers import TurbiniaTaskResult
+
+config.LoadConfig()
+if config.TASK_MANAGER == 'PSQ':
+  from google.cloud import datastore
+  from google.cloud import exceptions
+elif config.TASK_MANAGER == 'Celery':
+  import redis
 
 DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 MAX_DATASTORE_STRLEN = 1500

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -19,29 +19,25 @@ from __future__ import unicode_literals, absolute_import
 import logging
 import time
 
-try:
-  from celery import states as celery_states
-except ImportError:
-  pass
-
-import psq
-
-from google.cloud import exceptions
-from google.cloud import datastore
-from google.cloud import pubsub
-
 import turbinia
 from turbinia import evidence
 from turbinia import config
 from turbinia import jobs
-from turbinia import pubsub as turbinia_pubsub
-
-try:
-  from turbinia import celery as turbinia_celery
-except ImportError:
-  pass
-
 from turbinia import state_manager
+
+config.LoadConfig()
+if config.TASK_MANAGER == 'PSQ':
+  import psq
+
+  from google.cloud import exceptions
+  from google.cloud import datastore
+  from google.cloud import pubsub
+
+  from turbinia import pubsub as turbinia_pubsub
+elif config.TASK_MANAGER == 'Celery':
+  from celery import states as celery_states
+
+  from turbinia import celery as turbinia_celery
 
 log = logging.getLogger('turbinia')
 


### PR DESCRIPTION
Addresses #201. If/else clauses around any GCloud-only or Celery-only imports. I left the pubsub and celery modules alone, since we only import them in specific cases already.

Tested by commenting out GCloud dependencies (requirements.txt) and installing `turbinia[local]` fresh; processing works as expected without any import errors. Tests pass -- except the GCloud ones and the client tests (written for PSQ), can you test those?