### PR TITLE
Pre&Post processors are passed only the required parameters

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -170,7 +170,7 @@ class RawDisk(Evidence):
     size:  The size of the disk in bytes.
   """
 
-  def __init__(self, mount_path=None, mount_partition=1, size=None, *args,
+  def __init__(self, mount_path=None, mount_partition=None, size=None, *args,
                **kwargs):
     """Initialization for raw disk evidence object."""
     self.losetup_path = None

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -24,6 +24,8 @@ from turbinia import config
 from turbinia import TurbiniaException
 from turbinia.processors import mount_local
 
+# pylint: disable=keyword-arg-before-vararg
+
 config.LoadConfig()
 if config.TASK_MANAGER == 'PSQ':
   from turbinia.processors import google_cloud

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -162,14 +162,16 @@ class RawDisk(Evidence):
   """Evidence object for Disk based evidence.
 
   Attributes:
+    losetup_path: Path to the losetup device for this disk.
     mount_path: The mount path for this disk (if any).
     mount_partition: The mount partition for this disk (if any).
     size:  The size of the disk in bytes.
   """
 
-  def __init__(self, mount_path=None, mount_partition=None, size=None, *args,
+  def __init__(self, mount_path=None, mount_partition=1, size=None, *args,
                **kwargs):
     """Initialization for raw disk evidence object."""
+    self.losetup_path = None
     self.mount_path = mount_path
     self.mount_partition = mount_partition
     self.size = size

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -72,6 +72,7 @@ def PreprocessMountDisk(evidence):
   # If evidence.local_path points to something with a partition table, we have
   # block devices at /dev/loopXpY.
   if not os.path.exists(path_to_partition):
+    log.info("Could not find {0:s}, trying {1:s}".format(path_to_partition, evidence.losetup_device))
     # Else, we only have /dev/loopX
     path_to_partition = evidence.losetup_device
 

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -51,15 +51,32 @@ def PreprocessMountDisk(evidence):
 
   evidence.mount_path = tempfile.mkdtemp(prefix='turbinia', dir=mount_prefix)
 
-  if hasattr(evidence, 'mount_partition') and evidence.mount_partition:
-    src_path = '{0:s}-part{1:d}'.format(
-        evidence.local_path, evidence.mount_partition)
-  else:
-    src_path = evidence.local_path
+  # Two steps: first use losetup to parse the RawDisk eventual partition table
+  # and make block devices per partitions.
+  # Then we mount the partition provideed, or the first one we find.
 
   # TODO(aarontp): Remove hard-coded sudo in commands:
   # https://github.com/google/turbinia/issues/73
-  mount_cmd = ['sudo', 'mount', src_path, evidence.mount_path]
+  losetup_command = 'sudo losetup --show --nooverlap --find -P "{0:s}"'.format(
+      evidence.local_path)
+  log('Running command '+losetup_command)
+  try:
+    losetup_device, _ = subprocess.Popen(losetup_command).communicate()
+  except subprocess.CalledProcessError as e:
+    raise TurbiniaException('Could not set losetup devices {0!s}'.format(e))
+  evidence.losetup_device = losetup_device.strip()
+
+  # Here, evidence.losetup_device is something like '/dev/loopX'.
+
+  path_to_partition = '{0:s}p{0:d}'.format(
+      evidence.losetup_device, evidence.mount_partition)
+  # If evidence.local_path points to something with a partition table, we have
+  # block devices at /dev/loopXpY.
+  if not os.path.exists(path_to_partition):
+    # Else, we only have /dev/loopX
+    path_to_partition = evidence.losetup_device
+
+  mount_cmd = ['sudo', 'mount', path_to_partition, evidence.mount_path]
   log.info('Running: {0:s}'.format(' '.join(mount_cmd)))
   try:
     subprocess.check_call(mount_cmd)
@@ -81,6 +98,13 @@ def PostprocessUnmountDisk(evidence):
     subprocess.check_call(umount_cmd)
   except subprocess.CalledProcessError as e:
     raise TurbiniaException('Could not unmount directory {0!s}'.format(e))
+
+  losetup_cmd = ['losetup', '-d', evidence.losetup_device]
+  log.info('Running: {0:s}'.format(' '.join(losetup_cmd)))
+  try:
+    subprocess.check_call(losetup_cmd)
+  except subprocess.CalledProcessError as e:
+    raise TurbiniaException('Could not delete losetup device {0!s}'.format(e))
 
   log.info('Removing mount path {0:s}'.format(evidence.mount_path))
   try:

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -69,6 +69,10 @@ def PreprocessMountDisk(evidence):
 
   # Here, evidence.losetup_device is something like '/dev/loopX'.
 
+  if not evidence.mount_partition:
+    # The first partition loop-device made by losetup is loopXp1
+    evidence.mount_partition = 1
+
   path_to_partition = '{0:s}p{1:d}'.format(
       evidence.losetup_device, evidence.mount_partition)
   # If evidence.local_path points to something with a partition table, we have

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -57,7 +57,7 @@ def PreprocessMountDisk(evidence):
 
   # TODO(aarontp): Remove hard-coded sudo in commands:
   # https://github.com/google/turbinia/issues/73
-  losetup_command = ['sudo', 'losetup', '--show', '--nooverlap', '--find', '-P,'  evidence.local_path]
+  losetup_command = ['sudo', 'losetup', '--show', '--nooverlap', '--find', '-P',  evidence.local_path]
   log.info('Running command {0:s}'.format(' '.join(losetup_command)))
   try:
     losetup_device = subprocess.check_output(losetup_command)

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -59,7 +59,7 @@ def PreprocessMountDisk(evidence):
   # https://github.com/google/turbinia/issues/73
   losetup_command = 'sudo losetup --show --nooverlap --find -P "{0:s}"'.format(
       evidence.local_path)
-  log('Running command '+losetup_command)
+  log.info('Running command '+losetup_command)
   try:
     losetup_device, _ = subprocess.Popen(losetup_command).communicate()
   except subprocess.CalledProcessError as e:

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -68,7 +68,7 @@ def PreprocessMountDisk(evidence):
 
   # Here, evidence.losetup_device is something like '/dev/loopX'.
 
-  path_to_partition = '{0:s}p{0:d}'.format(
+  path_to_partition = '{0:s}p{1:d}'.format(
       evidence.losetup_device, evidence.mount_partition)
   # If evidence.local_path points to something with a partition table, we have
   # block devices at /dev/loopXpY.

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -57,7 +57,9 @@ def PreprocessMountDisk(evidence):
 
   # TODO(aarontp): Remove hard-coded sudo in commands:
   # https://github.com/google/turbinia/issues/73
-  losetup_command = ['sudo', 'losetup', '--show', '--nooverlap', '--find', '-P',  evidence.local_path]
+  losetup_command = [
+      'sudo', 'losetup', '--show', '--nooverlap', '--find', '-P',
+      evidence.local_path]
   log.info('Running command {0:s}'.format(' '.join(losetup_command)))
   try:
     losetup_device = subprocess.check_output(losetup_command)
@@ -72,7 +74,8 @@ def PreprocessMountDisk(evidence):
   # If evidence.local_path points to something with a partition table, we have
   # block devices at /dev/loopXpY.
   if not os.path.exists(path_to_partition):
-    log.info("Could not find {0:s}, trying {1:s}".format(path_to_partition, evidence.losetup_device))
+    log.info('Could not find {0:s}, trying {1:s}'.format(
+        path_to_partition, evidence.losetup_device))
     # Else, we only have /dev/loopX
     path_to_partition = evidence.losetup_device
 

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -57,11 +57,10 @@ def PreprocessMountDisk(evidence):
 
   # TODO(aarontp): Remove hard-coded sudo in commands:
   # https://github.com/google/turbinia/issues/73
-  losetup_command = 'sudo losetup --show --nooverlap --find -P "{0:s}"'.format(
-      evidence.local_path)
-  log.info('Running command '+losetup_command)
+  losetup_command = ['sudo', 'losetup', '--show', '--nooverlap', '--find', '-P,'  evidence.local_path]
+  log.info('Running command {0:s}'.format(' '.join(losetup_command)))
   try:
-    losetup_device, _ = subprocess.Popen(losetup_command).communicate()
+    losetup_device = subprocess.check_output(losetup_command)
   except subprocess.CalledProcessError as e:
     raise TurbiniaException('Could not set losetup devices {0!s}'.format(e))
   evidence.losetup_device = losetup_device.strip()

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -51,7 +51,7 @@ def PreprocessMountDisk(evidence):
 
   evidence.mount_path = tempfile.mkdtemp(prefix='turbinia', dir=mount_prefix)
 
-  # Two steps: first use losetup to parse the RawDisk eventual partition table
+  # Two steps: first use losetup to parse the RawDisk potential partition table
   # and make block devices per partitions.
   # Then we mount the partition provideed, or the first one we find.
 

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -99,7 +99,7 @@ def PostprocessUnmountDisk(evidence):
   except subprocess.CalledProcessError as e:
     raise TurbiniaException('Could not unmount directory {0!s}'.format(e))
 
-  losetup_cmd = ['losetup', '-d', evidence.losetup_device]
+  losetup_cmd = ['sudo', 'losetup', '-d', evidence.losetup_device]
   log.info('Running: {0:s}'.format(' '.join(losetup_cmd)))
   try:
     subprocess.check_call(losetup_cmd)

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -58,8 +58,7 @@ def PreprocessMountDisk(evidence):
   # TODO(aarontp): Remove hard-coded sudo in commands:
   # https://github.com/google/turbinia/issues/73
   losetup_command = [
-      'sudo', 'losetup', '--show', '--nooverlap', '--find', '-P',
-      evidence.local_path]
+      'sudo', 'losetup', '--show', '--find', '-P', evidence.local_path]
   log.info('Running command {0:s}'.format(' '.join(losetup_command)))
   try:
     losetup_device = subprocess.check_output(losetup_command)

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -138,7 +138,7 @@ def main():
   parser_rawdisk.add_argument(
       '-P',
       '--mount_partition',
-      default=0,
+      default=1,
       type=int,
       help='The partition number to use when mounting this disk.  Defaults to '
       'the entire raw disk.  Only affects mounting, and not what gets '


### PR DESCRIPTION
When calling pre/post processors, we stop passing the whole Evidence object.

This will later help keeping explicit state & properties in Evidences (and will make stacking pre/post processor calls possible)