### PR TITLE
Pin google-cloud-pubsub==0.35.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 filelock
 google-api-python-client>=1.6.2
-google-cloud-pubsub
+google-cloud-pubsub==0.35.4
 google-cloud-storage
 google-cloud-core
 oauth2client


### PR DESCRIPTION
Pinning this for now until this is fixed (the upstream dependency requirements seem to be incorrect):
https://github.com/GoogleCloudPlatform/google-cloud-python/issues/6128

This will allow us to move forward with the dftimewolf integration which has dependencies (grr-client-api) which depend on an incompatible version of protobuf.