### PR TITLE
Pin google-api-core so we can use older protobuf version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 filelock
+google-api-core>=1.2.1,<=1.4.0
 google-api-python-client>=1.6.2
 google-cloud-pubsub==0.35.4
 google-cloud-storage


### PR DESCRIPTION
google-api-core also depends directly on the protobuf library, and the latest version requires >=3.4.0, and we need ==3.3.0 in order to be compatible with other libraries (grr-client-api) so that we can use Turbinia with dftimewolf.  We previously pinned google-cloud-pubsub in #265 , and since then there has been another release of google-api-core, so we need to pin this as well.