### PR TITLE
Increase version because Pypi doesn't like dupe filenames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except ImportError:  # for pip <= 9.0.3
   from pip.req import parse_requirements
 
 
-turbinia_version = '20181003'
+turbinia_version = '20181004'
 
 turbinia_description = (
   'Turbinia is an open-source framework for deploying, managing, and running'

--- a/turbinia/__init__.py
+++ b/turbinia/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Main Turbinia application."""
 
-VERSION = '20181003'
+VERSION = '20181004'
 
 
 class TurbiniaException(Exception):


### PR DESCRIPTION
Apparently Pypi won't let you upload packages with the same name even if the previous package has been deleted.  Since I already deleted the previous version I'm creating a full new release rather than recreating the version and adding a minor-version bump.