### PR TITLE
Consolidate location where version is defined

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@
 
 from __future__ import unicode_literals
 
+import sys
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -29,7 +31,10 @@ except ImportError:  # for pip <= 9.0.3
   from pip.req import parse_requirements
 
 
-turbinia_version = '20181004'
+# make sure turbinia is in path
+sys.path.insert(0, '.')
+
+import turbinia  # pylint: disable=wrong-import-position
 
 turbinia_description = (
   'Turbinia is an open-source framework for deploying, managing, and running'
@@ -41,7 +46,7 @@ turbinia_description = (
 
 setup(
   name='turbinia',
-  version=turbinia_version,
+  version=turbinia.__version__,
   description='Automation and Scaling of Digital Forensics Tools',
   long_description=turbinia_description,
   license='Apache License, Version 2.0',

--- a/turbinia/__init__.py
+++ b/turbinia/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Main Turbinia application."""
 
-VERSION = '20181004'
+__version__ = '20181004'
 
 
 class TurbiniaException(Exception):

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -33,7 +33,7 @@ from turbinia.client import TurbiniaPsqWorker
 from turbinia import config
 from turbinia.config import logger
 from turbinia import evidence
-from turbinia import VERSION
+from turbinia import __version__
 from turbinia.message import TurbiniaRequest
 
 log = logging.getLogger('turbinia')
@@ -90,7 +90,7 @@ def main():
       '-V',
       '--version',
       action='version',
-      version=VERSION,
+      version=__version__,
       help='Show the version')
   parser.add_argument(
       '-D',


### PR DESCRIPTION
Fixes #270 

Pylint seems clean for the files edited - only an issue with `setup.py` where the description text is too long. Attempted to fix, but it seems moving a word to the next line causes _that_ line to be too long, so I've left it as is for that to be addressed another time.

Yapf doesn't like `setup.py` spacing - had to revert+squash a commit that caused spacing in `setup.py` to be impacted as any major changes to that file seemed out of scope for this issue. Aside from that, doesn't seem to have changed much else.

`run_tests.py` does not run in my testing as I'm lacking nosetest/ in the repository. Didn't see anything in contributing guidelines indicating what I should do here other than just run `run_tests.py` so please let me know if I need to do something there before this PR can be reviewed. The change is minor, so I can't imagine having broken anything.

```
FileNotFoundError: [Errno 2] No such file or directory: 'nosetests': 'nosetests'
```