### PR TITLE
Add config option to store evidence locally, move after processing completes

### DIFF
--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -43,6 +43,7 @@ CONFIGVARS = [
     'SINGLE_RUN',
     'MOUNT_DIR_PREFIX',
     'SHARED_FILESYSTEM',
+    'WORKERS_USE_TMP',
     # TODO(aarontp): Move this to the recipe config when it's available.
     'DEBUG_TASKS',
     # GCE CONFIG

--- a/turbinia/config/turbinia_config.py
+++ b/turbinia/config/turbinia_config.py
@@ -57,6 +57,12 @@ MOUNT_DIR_PREFIX = '/mnt/turbinia-mounts'
 # NFS or a SAN for Evidence objects.
 SHARED_FILESYSTEM = False
 
+# This will cause workers to output data to a temporary directory and then upon
+# completion, copy it to the expected OUTPUT_DIR. Useful when your output
+# directory is an NFS mount, since Plaso and other tools that operate on
+# sqlite files will not work over NFS.
+WORKERS_USE_TMP = True
+
 # This will set debugging flags for processes executed by Tasks (for
 # Tasks/binaries that support it).  This could cause performance issues with
 # some tasks, so it is recommended to only set this to True when debugging

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -64,7 +64,7 @@ class OutputManager(object):
                                  unique_dir=unique_dir)]
     local_output_dir = writers[0].local_output_dir
     config.LoadConfig()
-    if config.GCS_OUTPUT_PATH:
+    if config.GCS_OUTPUT_PATH != 'None':
       writer = GCSOutputWriter(
           unique_dir=unique_dir, gcs_path=config.GCS_OUTPUT_PATH,
           local_output_dir=local_output_dir)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -25,6 +25,7 @@ import logging
 import os
 import pickle
 import platform
+import shutil
 import subprocess
 import time
 import traceback
@@ -242,7 +243,8 @@ class TurbiniaTask(object):
               save_files=None,
               new_evidence=None,
               close=False,
-              shell=False):
+              shell=False,
+              tmp_dir=None):
     """Executes a given binary and saves output.
 
     Args:
@@ -254,6 +256,8 @@ class TurbiniaTask(object):
           If the task is successful, they will be added to the result.
       close (bool): Whether to close out the result.
       shell (bool): Whether the cmd is in the form of a string or a list.
+      tmp_dir (string): If set, this worker placed output files here. We'll
+          move them from here to the true output directory.
 
     Returns:
       Tuple of the return code, and the TurbiniaTaskResult object
@@ -268,6 +272,11 @@ class TurbiniaTask(object):
     result.error['stdout'] = stdout
     result.error['stderr'] = stderr
     ret = proc.returncode
+
+    if tmp_dir:
+      for name in os.listdir(tmp_dir):
+        srcname = os.path.join(tmp_dir, name)
+        shutil.move(srcname, self.output_dir)
 
     if ret:
       msg = 'Execution failed with status {0:d}'.format(ret)

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 import os
+import tempfile
 
 from turbinia import config
 from turbinia.evidence import PlasoFile
@@ -39,6 +40,10 @@ class PlasoTask(TurbiniaTask):
     config.LoadConfig()
     plaso_evidence = PlasoFile()
 
+    if config.WORKERS_USE_TMP:
+      orig_output = self.output_dir
+      self.output_dir = tempfile.mkdtemp()
+
     plaso_file = os.path.join(self.output_dir, '{0:s}.plaso'.format(self.id))
     plaso_evidence.local_path = plaso_file
     plaso_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
@@ -54,7 +59,16 @@ class PlasoTask(TurbiniaTask):
 
     result.log('Running plaso as [{0:s}]'.format(' '.join(cmd)))
 
+    if config.WORKERS_USE_TMP:
+      tmp_output = self.output_dir
+      self.output_dir = orig_output
+
+      plaso_file = os.path.join(self.output_dir, '{0:s}.plaso'.format(self.id))
+      plaso_evidence.local_path = plaso_file
+      plaso_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
+
+
     self.execute(cmd, result, save_files=[plaso_log],
-                 new_evidence=[plaso_evidence], close=True)
+                 new_evidence=[plaso_evidence], close=True, tmp_dir=tmp_output)
 
     return result


### PR DESCRIPTION
Looking for your suggestions on this.

The use-case is that when running Turbinia locally, with OUTPUT_DIR pointing to an NFS mount (Gluster in my case), Plaso runs into problems due to sqlite & file-locking ([Reference (Section 6, ctrl-f NFS)](https://www.sqlite.org/lockingv3.html); [Reference](https://lists.gluster.org/pipermail/gluster-users/2015-May/021927.html)).

Ideally this would happen higher up, so we can just substitute `self.output_dir` before passing it, and then we don't need to mess around in the task itself. I was looking at adding it in the `TurbiniaTask` class or the `run_wrapper` method, but things quickly got a bit complicated due to passing around result objects / file path references.

If there isn't a good way around that, this could stay as a one-off (though not ideal) in the plaso worker, since I'm not sure of any other instances where we'll be operating on sqlite files.