### PR TITLE
Update turbinia@.service

### DIFF
--- a/tools/turbinia@.service
+++ b/tools/turbinia@.service
@@ -22,14 +22,12 @@
 # sudo systemctl stop turbinia@psqworker
 # sudo systemctl daemon-reload
 
-
 [Unit]
 Description=Turbinia %i Daemon
 Documentation=https://github.com/google/turbinia
 Before=multi-user.target
 After=network.target
 After=remote-fs.target
-
 
 [Service]
 Type=simple
@@ -38,14 +36,9 @@ User=turbinia
 Group=turbinia
 Restart=always
 RestartSec=10
-ExecStartPre=+/bin/sh -c '/bin/systemctl set-environment GOOGLE_APPLICATION_CREDENTIALS=$(turbinia_config_parser.py GCE_SERVICE_ACCOUNT_KEYS_FILE)'
-ExecStartPre=+/bin/sh -c '/bin/systemctl set-environment TURBINIA_TMPDIR=$(turbinia_config_parser.py TMP_DIR)'
-ExecStart=/bin/sh -c '/usr/local/turbinia/turbiniactl -L $TURBINIA_TMPDIR/turbinia-%i.log -S -o $TURBINIA_TMPDIR %i 2>> $TURBINIA_TMPDIR/turbinia-%i.stdout.log'
-ExecStopPost=+/bin/sh -c 'systemctl unset-environment TURBINIA_TMPDIR'
-ExecStopPost=+/bin/sh -c 'systemctl unset-environment GOOGLE_APPLICATION_CREDENTIALS'
+ExecStart=/bin/sh -c '/usr/local/bin/turbiniactl %i'
 KillMode=control-group
 KillSignal=SIGINT
-
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
systemd sends stdout/err to syslog by default. We don't need to redirect those.