### PR TITLE
Force celery workers to be single threaded

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -385,7 +385,7 @@ class TurbiniaCeleryWorker(TurbiniaClient):
   def start(self):
     """Start Turbinia Celery Worker."""
     log.info('Running Turbinia Celery Worker.')
-    argv = ['celery', 'worker', '--loglevel=info']
+    argv = ['celery', 'worker', '--loglevel=info', '--pool=solo']
     self.worker.start(argv)
 
 


### PR DESCRIPTION
While testing internally, we encountered an issue documented here: https://github.com/celery/celery/issues/4113. Forcing celery workers to be single threaded (by adding `--pool=solo`) fixes this issue.