### PR TITLE
Pin Datastore to work around upstream bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 filelock
 google-api-core>=1.2.1,<=1.4.0
+google-cloud-datastore==1.7.0
 google-api-python-client>=1.6.2
 google-cloud-pubsub==0.35.4
 google-cloud-storage


### PR DESCRIPTION
The minimum library versions are not set correctly for some of the upstream cloud libraries so we'll need to pin them for now.  See the following for more details on the bug: 
https://github.com/googleapis/google-cloud-python/issues/6390

This can be removed once grr-client-api updates its pinned version of protobuf.  The grr-client-api library gets pulled in from dfTimewolf, which also has Turbinia as a dependency.   The bug referenced above gets tickled when both of these libraries are installed at the same time (because the Datastore package doesn't correctly limit the minimum versions of its dependencies, an incompatible version gets installed).