### PR TITLE
Fix output manager copying tmp file

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -303,6 +303,10 @@ class TurbiniaTask(object):
           result.log(msg)
           log.warning(msg)
         else:
+          new_path, _ = self.output_manager.save_local_file(
+              evidence.local_path, result)
+          if new_path:
+            evidence.local_path = new_path
           result.add_evidence(evidence, self._evidence_config)
 
       if close:

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -40,6 +40,7 @@ class TestTurbiniaTask(unittest.TestCase):
     self.task = TurbiniaTask(base_output_dir=self.base_output_dir)
     self.task.output_manager = mock.MagicMock()
     self.task.output_manager.get_local_output_dirs.return_value = (None, None)
+    self.task.output_manager.save_local_file.return_value = (None, None)
 
     # Set up RawDisk Evidence
     test_disk_path = tempfile.mkstemp(dir=self.base_output_dir)[1]


### PR DESCRIPTION
While the plaso file is put into the tmp directory it is not copied to the original output folder after task execution. This fix handles that (and updates the local evidence path to the output directory). I'm not sure if there is a nicer way to determine if we used a tmp dir or not, instead of trying in every instance...

This is probably fine even for local runs, so evidence ends up in the expected place right? I'm not sure about side-effects for GCS since I'm not entirely clear on how that file copying happens.

Prior to fix:
```
[INFO] Running plaso as [log2timeline.py --status_view none --hashers all --partition all --vss_stores all --logfile /evidence/output/1542396446-b3580c49c1444ee59fca5e82da78fc66-PlasoTask/b3580c49c1444ee59fca5e82da78fc66.log \
/tmp/1542396446-b3580c49c1444ee59fca5e82da78fc66-PlasoTask/b3580c49c1444ee59fca5e82da78fc66.plaso /Users/ericwz/tmp/usbcopy/osdfc.dd.raw]
<snip ... >
[INFO] Running psort as [psort.py --status_view none --logfile /evidence/output/1542399748-0cfbfd52b6e74242b1b1ddc355a7ae77-PsortTask/0cfbfd52b6e74242b1b1ddc355a7ae77.log -w /evidence/output/1542399748-0cfbfd52b6e74242b1b1ddc355a7ae77-PsortTask/0cfbfd52b6e74242b1b1ddc355a7ae77.csv \
/tmp/1542396446-b3580c49c1444ee59fca5e82da78fc66-PlasoTask/b3580c49c1444ee59fca5e82da78fc66.plaso]
```

After fix:
```
[INFO] Running plaso as [log2timeline.py --status_view none --hashers all --partition all --vss_stores all --logfile /evidence/output/1542407550-9961049d072a4f648007ca64be90c3fb-PlasoTask/9961049d072a4f648007ca64be90c3fb.log \
/tmp/1542407550-9961049d072a4f648007ca64be90c3fb-PlasoTask/9961049d072a4f648007ca64be90c3fb.plaso /Users/ericwz/SCHARDT.dd]
<snip ... >
[INFO] Running psort as [psort.py --status_view none --logfile /evidence/output/1542407794-250d20304cc14727b1b793420b383a57-PsortTask/250d20304cc14727b1b793420b383a57.log -w /evidence/output/1542407794-250d20304cc14727b1b793420b383a57-PsortTask/250d20304cc14727b1b793420b383a57.csv \
/evidence/output/1542407550-9961049d072a4f648007ca64be90c3fb-PlasoTask/9961049d072a4f648007ca64be90c3fb.plaso]