### PR TITLE
Pin Celery/Kombu/Redis major versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     ],
     extras_require={
         'dev': ['mock', 'nose'],
-        'local': ['celery>=4.1.0', 'kombu>=4.1.0', 'redis>=2.10.6'],
+        'local': ['celery~=4.1', 'kombu~=4.1', 'redis~=2.10'],
         'worker': ['plaso>=20171118']
     }
 )


### PR DESCRIPTION
Redis had a major version bump (to 3.x) yesterday and I spent a while scratching my head trying to figure out why some datastore things I didn't touch had broken 😄 

This pins the major version of each lib, while allowing newer minor versions.