### PR TITLE
Fix version of google-cloud-core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ google-cloud-datastore==1.7.0
 google-api-python-client>=1.6.2
 google-cloud-pubsub==0.35.4
 google-cloud-storage
-google-cloud-core
+google-cloud-core==0.28.1
 oauth2client
 psq
 six


### PR DESCRIPTION
Current pypi version of google-cloud-storage (1.13.0) requires google-cloud-core 0.28.1 (before the rename of google.cloud.iam (core) to google.api_core.iam) while the latest version on pypi is 0.29