### PR TITLE
Pin google-cloud-storage to 1.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ google-api-core>=1.2.1,<=1.4.0
 google-cloud-datastore==1.7.0
 google-api-python-client>=1.6.2
 google-cloud-pubsub==0.35.4
-google-cloud-storage
+google-cloud-storage==1.13.0
 google-cloud-core==0.28.1
 oauth2client
 psq


### PR DESCRIPTION
Fixes #325

Looks like google-cloud-storage was updated in:
https://github.com/googleapis/google-cloud-python/pull/6741

Which just got released as 1.13.1:
https://pypi.org/project/google-cloud-storage/#history