### PR TITLE
Error when worker version doesn't match server #307

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -25,6 +25,7 @@ import platform
 import pprint
 import subprocess
 import traceback
+import turbinia
 import uuid
 
 import filelock
@@ -245,6 +246,7 @@ class TurbiniaTask(object):
     self.state_key = None
     self.stub = None
     self.tmp_dir = None
+    self.turbina_version = turbinia.__version__
     self.user = user if user else getpass.getuser()
     self._evidence_config = {}
 


### PR DESCRIPTION
Fixes #307 

[ ] Add `turbina.__version__` to the `TurbinaTask` class as an attribute
[ ] Validate versions in `TurbiniaTask.run_wrapper()` before `TurbiniaTask.run()` is ever ran