### PR TITLE
Undefined name: Define 'unicode' in Python 3

### DIFF
--- a/tools/turbinia_job_graph.py
+++ b/tools/turbinia_job_graph.py
@@ -21,6 +21,11 @@ import graphviz
 
 from turbinia.jobs import manager as jobs_manager
 
+try:
+  unicode
+except NameError:
+  unicode = str
+
 
 def create_graph():
   """Create graph of relationships between Turbinia jobs and evidence.


### PR DESCRIPTION
__unicode()__ was removed in Python 3 because all __str__ are Unicode.

[flake8](http://flake8.pycqa.org) testing of https://github.com/google/turbinia on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tools/turbinia_job_graph.py:47:40: F821 undefined name 'unicode'
  parser.add_argument('filename', type=unicode, help='where to save the file')
                                       ^
1     F821 undefined name 'unicode'
1
```