### PR TITLE
Update redis to 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     ],
     extras_require={
         'dev': ['mock', 'nose', 'yapf'],
-        'local': ['celery~=4.1', 'kombu~=4.1', 'redis~=2.10'],
+        'local': ['celery~=4.1', 'kombu~=4.1', 'redis~=3.0'],
         'worker': ['plaso>=20171118']
     }
 )


### PR DESCRIPTION
Python Redis module v3 is released. There are some breaking changes, but luckily they don't affect our implementation.

Local testing completed successfully.

