### PR TITLE
Celery: Handle unusual queue exceptions; disable 'pool=solo'

### DIFF
--- a/turbinia/celery.py
+++ b/turbinia/celery.py
@@ -142,6 +142,11 @@ class TurbiniaKombu(TurbiniaMessageBase):
         break
       except ChannelError:
         break
+      except Exception as e:
+        log.warning(
+            "Caught unexpected exception while fetching from queue: {0!s}"
+            .format(e))
+        break
 
     log.debug('Received {0:d} messages'.format(len(requests)))
     return requests

--- a/turbinia/celery.py
+++ b/turbinia/celery.py
@@ -145,8 +145,8 @@ class TurbiniaKombu(TurbiniaMessageBase):
         break
       except OperationalError as e:
         log.warning(
-            "Caught recoverable message transport connection error when " +
-            "fetching from queue: {0!s}".format(e))
+            'Caught recoverable message transport connection error when ' +
+            'fetching from queue: {0!s}'.format(e))
         break
 
     log.debug('Received {0:d} messages'.format(len(requests)))

--- a/turbinia/celery.py
+++ b/turbinia/celery.py
@@ -27,6 +27,7 @@ from six.moves import queue
 
 import celery
 import kombu
+from kombu.exceptions import OperationalError
 from amqp.exceptions import ChannelError
 
 from turbinia import config
@@ -142,10 +143,10 @@ class TurbiniaKombu(TurbiniaMessageBase):
         break
       except ChannelError:
         break
-      except Exception as e:
+      except OperationalError as e:
         log.warning(
-            "Caught unexpected exception while fetching from queue: {0!s}"
-            .format(e))
+            "Caught recoverable message transport connection error when " +
+            "fetching from queue: {0!s}".format(e))
         break
 
     log.debug('Received {0:d} messages'.format(len(requests)))

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -439,7 +439,7 @@ class TurbiniaCeleryWorker(TurbiniaClient):
   def start(self):
     """Start Turbinia Celery Worker."""
     log.info('Running Turbinia Celery Worker.')
-    argv = ['celery', 'worker', '--loglevel=info', '--pool=solo']
+    argv = ['celery', 'worker', '--loglevel=info']
     self.worker.start(argv)
 
 


### PR DESCRIPTION
- If something weird happens when pulling items off of the queue, log it and continue.
- Turns out we cannot use `pool=solo`. This forces Celery to be single threaded and even disables the heartbeat (which is required for the server to know workers are alive)... so any task which takes longer than the heartbeat timeout to process will be duplicated. Solution for this coming in a following PR.