### PR TITLE
[Not ready] Add support for Bitlocker evidence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ oauth2client
 psq
 six
 urllib3[secure]
+libbde-python==20190102

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -273,7 +273,7 @@ class TurbiniaClient(object):
       else:
         success = 'Failed'
 
-      status = task.get('status', 'No task status')
+      status = task.get('status') or 'No task status'
       if all_fields:
         results.append(
             '{0:s} request: {1:s} task: {2:s} {3:s} {4:s} {5:s} {6:s}: {7:s}'
@@ -287,6 +287,7 @@ class TurbiniaClient(object):
         for path in saved_paths:
           results.append('\t{0:s}'.format(path))
       else:
+        print(task.get('last_update'), task.get('name'), success, status)
         results.append(
             '{0:s} {1:s} {2:s}: {3:s}'.format(
                 task.get('last_update'), task.get('name'), success, status))

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -287,7 +287,6 @@ class TurbiniaClient(object):
         for path in saved_paths:
           results.append('\t{0:s}'.format(path))
       else:
-        print(task.get('last_update'), task.get('name'), success, status)
         results.append(
             '{0:s} {1:s} {2:s}: {3:s}'.format(
                 task.get('last_update'), task.get('name'), success, status))

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -18,8 +18,8 @@ from __future__ import unicode_literals
 
 import json
 import os
-import pybde
 import sys
+import pybde
 
 from turbinia import config
 from turbinia import TurbiniaException
@@ -265,10 +265,9 @@ class BitlockerDisk(EncryptedDisk):
     self.password = password
     self.encrypted_path = encrypted_path
     self.unencrypted_path = unencrypted_path
-    super(EncryptedDisk, self).__init__(*args, **kwargs)
+    super(BitlockerDisk, self).__init__(*args, **kwargs)
 
   def _preprocess(self):
-    print("Decrypting Bitlocker image: {0:s}".format(self.encrypted_path))
     with open(self.encrypted_path, 'rb') as src_enc:
       src = pybde.volume()
       if self.recovery_key:
@@ -295,7 +294,6 @@ class BitlockerDisk(EncryptedDisk):
         raise TurbiniaException(
           'Failed to decrypt a given Bitlocker evidence: {0:s}'
           .format(e))
-    print("Decrypted {0:s} successfully".format(self.encrypted_path))
 
     self.local_path = self.unencrypted_path
 

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -261,9 +261,6 @@ class BitlockerDisk(EncryptedDisk):
       self, recovery_key=None, password=None, encrypted_path=None,
       unencrypted_path=None, *args, **kwargs):
     """Initialization for Bitlocker disk evidence object"""
-    #if not recovery_key and not password:
-    #  raise TurbiniaException(
-    #    'Neither recovery key nor password was provided')
     self.recovery_key = recovery_key
     self.password = password
     self.encrypted_path = encrypted_path

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -238,11 +238,12 @@ class EncryptedDisk(RawDisk):
 
   def __init__(
       self, encryption_type=None, encryption_key=None, unencrypted_path=None,
-      *args, **kwargs):
+      encrypted_path=None, *args, **kwargs):
     """Initialization for Encrypted disk evidence objects."""
     # TODO(aarontp): Make this an enum, or limited list
     self.encryption_type = encryption_type
     self.encryption_key = encryption_key
+    self.encrypted_path = encrypted_path
     self.unencrypted_path = unencrypted_path
     super(EncryptedDisk, self).__init__(*args, **kwargs)
 
@@ -257,14 +258,10 @@ class BitlockerDisk(EncryptedDisk):
     unencrypted_path: A string to the unencrypted local path
   """
 
-  def __init__(
-      self, recovery_key=None, password=None, encrypted_path=None,
-      unencrypted_path=None, *args, **kwargs):
+  def __init__(self, recovery_key=None, password=None, *args, **kwargs):
     """Initialization for Bitlocker disk evidence object"""
     self.recovery_key = recovery_key
     self.password = password
-    self.encrypted_path = encrypted_path
-    self.unencrypted_path = unencrypted_path
     super(BitlockerDisk, self).__init__(*args, **kwargs)
 
   def _preprocess(self):
@@ -292,8 +289,7 @@ class BitlockerDisk(EncryptedDisk):
           pass
 
         raise TurbiniaException(
-          'Failed to decrypt a given Bitlocker evidence: {0:s}'
-          .format(e))
+            'Failed to decrypt a given Bitlocker evidence: {0:s}'.format(e))
 
     self.local_path = self.unencrypted_path
 

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -268,7 +268,7 @@ class BitlockerDisk(EncryptedDisk):
     super(EncryptedDisk, self).__init__(*args, **kwargs)
 
   def _preprocess(self):
-    print("Decrypting Bitlocker image: {}".format(self.encrypted_path))
+    print("Decrypting Bitlocker image: {0:s}".format(self.encrypted_path))
     with open(self.encrypted_path, 'rb') as src_enc:
       src = pybde.volume()
       if self.recovery_key:
@@ -293,9 +293,9 @@ class BitlockerDisk(EncryptedDisk):
           pass
 
         raise TurbiniaException(
-          'Failed to decrypt a given Bitlocker evidence: {}'
+          'Failed to decrypt a given Bitlocker evidence: {0:s}'
           .format(e))
-    print("Decrypted {} successfully".format(self.encrypted_path))
+    print("Decrypted {0:s} successfully".format(self.encrypted_path))
 
     self.local_path = self.unencrypted_path
 

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -261,9 +261,9 @@ class BitlockerDisk(EncryptedDisk):
       self, recovery_key=None, password=None, encrypted_path=None,
       unencrypted_path=None, *args, **kwargs):
     """Initialization for Bitlocker disk evidence object"""
-    if not recovery_key and not password:
-      raise TurbiniaException(
-        'Neither recovery key nor password was provided')
+    #if not recovery_key and not password:
+    #  raise TurbiniaException(
+    #    'Neither recovery key nor password was provided')
     self.recovery_key = recovery_key
     self.password = password
     self.encrypted_path = encrypted_path
@@ -271,6 +271,7 @@ class BitlockerDisk(EncryptedDisk):
     super(EncryptedDisk, self).__init__(*args, **kwargs)
 
   def _preprocess(self):
+    print("Decrypting Bitlocker image: {}".format(self.encrypted_path))
     with open(self.encrypted_path, 'rb') as src_enc:
       src = pybde.volume()
       if self.recovery_key:
@@ -297,6 +298,7 @@ class BitlockerDisk(EncryptedDisk):
         raise TurbiniaException(
           'Failed to decrypt a given Bitlocker evidence: {}'
           .format(e))
+    print("Decrypted {} successfully".format(self.encrypted_path))
 
     self.local_path = self.unencrypted_path
 

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -242,10 +242,35 @@ class EncryptedDisk(RawDisk):
     # TODO(aarontp): Make this an enum, or limited list
     self.encryption_type = encryption_type
     self.encryption_key = encryption_key
-    # self.local_path will be the encrypted path
     self.unencrypted_path = unencrypted_path
     super(EncryptedDisk, self).__init__(*args, **kwargs)
 
+
+class BitlockerDisk(EncryptedDisk):
+  """Bitlocker encrypted disk file evidence.
+
+  Attributes:
+    recovery_key: A string of the recovery key for this disk
+    password: A string of the password used for this disk. If recovery key
+        is used, this argument is ignored
+    unencrypted_path: A string to the unencrypted local path
+  """
+
+  def __init__(
+      self, recovery_key=None, password=None, encrypted_path=None,
+      unencrypted_path=None, *args, **kwargs):
+    """Initialization for Bitlocker disk evidence object"""
+    self.recovery_key = recovery_key
+    self.password = password
+    self.encrypted_path = encrypted_path
+    self.unencrypted_path = unencrypted_path
+    super(EncryptedDisk, self).__init__(*args, **kwargs)
+
+  def _preprocess(self):
+    pass
+
+  def _postprocess(self):
+    pass
 
 class GoogleCloudDisk(RawDisk):
   """Evidence object for Google Cloud Disks.

--- a/turbinia/jobs/hadoop.py
+++ b/turbinia/jobs/hadoop.py
@@ -30,7 +30,7 @@ class HadoopAnalysisJob(interface.TurbiniaJob):
   """Analyzes Hadoop AppRoot files."""
 
   evidence_input = [
-    GoogleCloudDisk, GoogleCloudDiskRawEmbedded, RawDisk, BitlockerDisk
+      GoogleCloudDisk, GoogleCloudDiskRawEmbedded, RawDisk, BitlockerDisk
   ]
   evidence_output = [ReportText]
 

--- a/turbinia/jobs/hadoop.py
+++ b/turbinia/jobs/hadoop.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.evidence import RawDisk
@@ -28,7 +29,9 @@ from turbinia.workers.hadoop import HadoopAnalysisTask
 class HadoopAnalysisJob(interface.TurbiniaJob):
   """Analyzes Hadoop AppRoot files."""
 
-  evidence_input = [GoogleCloudDisk, GoogleCloudDiskRawEmbedded, RawDisk]
+  evidence_input = [
+    GoogleCloudDisk, GoogleCloudDiskRawEmbedded, RawDisk, BitlockerDisk
+  ]
   evidence_output = [ReportText]
 
   NAME = 'HadoopAnalysisJob'

--- a/turbinia/jobs/http_access_logs.py
+++ b/turbinia/jobs/http_access_logs.py
@@ -37,8 +37,8 @@ class HTTPAccessLogExtractionJob(interface.TurbiniaJob):
   """HTTP Access log extraction job."""
 
   evidence_input = [
-    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-    BitlockerDisk
+      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      BitlockerDisk
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/http_access_logs.py
+++ b/turbinia/jobs/http_access_logs.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals
 
 from turbinia.workers import artifact
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import Directory
 from turbinia.evidence import RawDisk
 from turbinia.evidence import GoogleCloudDisk
@@ -36,7 +37,8 @@ class HTTPAccessLogExtractionJob(interface.TurbiniaJob):
   """HTTP Access log extraction job."""
 
   evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
+    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+    BitlockerDisk
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/jenkins.py
+++ b/turbinia/jobs/jenkins.py
@@ -30,8 +30,8 @@ class JenkinsAnalysisJob(interface.TurbiniaJob):
   """Jenkins analysis job."""
 
   evidence_input = [
-    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-    BitlockerDisk
+      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      BitlockerDisk
   ]
   evidence_output = [ReportText]
 

--- a/turbinia/jobs/jenkins.py
+++ b/turbinia/jobs/jenkins.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import Directory
 from turbinia.evidence import RawDisk
 from turbinia.evidence import GoogleCloudDisk
@@ -29,7 +30,8 @@ class JenkinsAnalysisJob(interface.TurbiniaJob):
   """Jenkins analysis job."""
 
   evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
+    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+    BitlockerDisk
   ]
   evidence_output = [ReportText]
 

--- a/turbinia/jobs/plaso.py
+++ b/turbinia/jobs/plaso.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import Directory
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
@@ -30,7 +31,8 @@ class PlasoJob(interface.TurbiniaJob):
   """Runs Plaso on some evidence to generate a Plaso file."""
   # The types of evidence that this Job will process
   evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
+    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+    BitlockerDisk
   ]
   evidence_output = [PlasoFile]
 

--- a/turbinia/jobs/plaso.py
+++ b/turbinia/jobs/plaso.py
@@ -31,8 +31,8 @@ class PlasoJob(interface.TurbiniaJob):
   """Runs Plaso on some evidence to generate a Plaso file."""
   # The types of evidence that this Job will process
   evidence_input = [
-    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-    BitlockerDisk
+      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      BitlockerDisk
   ]
   evidence_output = [PlasoFile]
 

--- a/turbinia/jobs/sshd.py
+++ b/turbinia/jobs/sshd.py
@@ -34,8 +34,8 @@ class SSHDExtractionJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-    BitlockerDisk
+      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      BitlockerDisk
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/sshd.py
+++ b/turbinia/jobs/sshd.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.workers import artifact
 from turbinia.workers import sshd
 from turbinia.evidence import Directory
@@ -33,7 +34,8 @@ class SSHDExtractionJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
+    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+    BitlockerDisk
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/strings.py
+++ b/turbinia/jobs/strings.py
@@ -36,7 +36,7 @@ class StringsJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-    RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, BitlockerDisk
+      RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, BitlockerDisk
   ]
   evidence_output = [TextFile]
 

--- a/turbinia/jobs/strings.py
+++ b/turbinia/jobs/strings.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.evidence import RawDisk
@@ -34,7 +35,9 @@ class StringsJob(interface.TurbiniaJob):
   """
 
   # The types of evidence that this Job will process
-  evidence_input = [RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded]
+  evidence_input = [
+    RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, BitlockerDisk
+  ]
   evidence_output = [TextFile]
 
   NAME = 'StringsJob'

--- a/turbinia/jobs/tomcat.py
+++ b/turbinia/jobs/tomcat.py
@@ -32,8 +32,8 @@ class TomcatExtractionJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-    BitlockerDisk
+      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      BitlockerDisk
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/tomcat.py
+++ b/turbinia/jobs/tomcat.py
@@ -16,6 +16,7 @@
 from __future__ import unicode_literals
 from turbinia.workers import artifact
 from turbinia.workers import tomcat
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import Directory
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
@@ -31,7 +32,8 @@ class TomcatExtractionJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
+    Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+    BitlockerDisk
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/worker_stat.py
+++ b/turbinia/jobs/worker_stat.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import Directory
 from turbinia.evidence import RawDisk
 from turbinia.evidence import ReportText
@@ -28,7 +29,7 @@ class StatJob(interface.TurbiniaJob):
   """Job to run Stat."""
 
   # The types of evidence that this Job will process
-  evidence_input = [RawDisk, Directory]
+  evidence_input = [RawDisk, Directory, BitlockerDisk]
   evidence_output = [ReportText]
 
   NAME = 'StatJob'

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -472,8 +472,8 @@ def main():
           'Creating request {0:s} with evidence {1:s}'.format(
               request.request_id, evidence_.name))
       log.info(
-          'Run command "turbiniactl {0:s} status -r {1:s}" to see the status of '
-          'this request and associated tasks'
+          'Run command "turbiniactl {0:s} status -r {1:s}" to see the status of'
+          ' this request and associated tasks'
           .format("-C" if args.use_celery else "", request.request_id))
       if not args.run_local:
         client.send_request(request)

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -154,13 +154,16 @@ def main():
       required=True)
   parser_bitlocker.add_argument(
       '-u', '--unencrypted_path', help='Local path to the unencrypted evidence.'
-      'Defaults to a temporary file.',
+      '  Defaults to a temporary file.  This file will be deleted after all '
+      'tasks are completed.',
       required=False)
   parser_bitlocker.add_argument(
-      '-r', '--recovery_key', help='Recovery key for the Bitlocker evidence',
+      '-r', '--recovery_key', help='Recovery key for the Bitlocker evidence.  '
+      'Either recovery key or password must be specified.',
       required=False)
   parser_bitlocker.add_argument(
-      '-p', '--password', help='Password for the Bitlocker evidence',
+      '-p', '--password', help='Password for the Bitlocker evidence.  '
+      'If a recovery key is specified concurrently, password will be ignored.',
       required=False)
   parser_bitlocker.add_argument(
       '-s', '--source', help='Description of the source of the evidence',
@@ -333,10 +336,15 @@ def main():
         name=args.name, local_path=local_path,
         mount_partition=args.mount_partition, source=args.source)
   elif args.command == 'bitlocker':
+    if not args.password and not args.recovery_key:
+      log.error("Neither recovery key nor password is specified.")
+      sys.exit(1)
     args.name = args.name if args.name else args.encrypted_path
     encrypted_path = os.path.abspath(args.encrypted_path)
     unencrypted_path = args.unencrypted_path \
-      if args.unencrypted_path else tempfile.mkstemp()
+      if args.unencrypted_path else tempfile.mkstemp()[1]
+    log.info("Decrypted Bitlocker disk will be at {0:s}"
+             .format(unencrypted_path))
     evidence_ = evidence.BitlockerDisk(
         name=args.name, encrypted_path=encrypted_path,
         unencrypted_path=unencrypted_path, recovery_key=args.recovery_key,
@@ -464,8 +472,9 @@ def main():
           'Creating request {0:s} with evidence {1:s}'.format(
               request.request_id, evidence_.name))
       log.info(
-          'Run command "turbiniactl status -r {0:s}" to see the status of '
-          'this request and associated tasks'.format(request.request_id))
+          'Run command "turbiniactl {0:s} status -r {1:s}" to see the status of '
+          'this request and associated tasks'
+          .format("-C" if args.use_celery else "", request.request_id))
       if not args.run_local:
         client.send_request(request)
       else:

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -155,12 +155,10 @@ def main():
   parser_bitlocker.add_argument(
       '-u', '--unencrypted_path', help='Local path to the unencrypted evidence.'
       '  Defaults to a temporary file.  This file will be deleted after all '
-      'tasks are completed.',
-      required=False)
+      'tasks are completed.', required=False)
   parser_bitlocker.add_argument(
       '-r', '--recovery_key', help='Recovery key for the Bitlocker evidence.  '
-      'Either recovery key or password must be specified.',
-      required=False)
+      'Either recovery key or password must be specified.', required=False)
   parser_bitlocker.add_argument(
       '-p', '--password', help='Password for the Bitlocker evidence.  '
       'If a recovery key is specified concurrently, password will be ignored.',
@@ -343,8 +341,8 @@ def main():
     encrypted_path = os.path.abspath(args.encrypted_path)
     unencrypted_path = args.unencrypted_path \
       if args.unencrypted_path else tempfile.mkstemp()[1]
-    log.info("Decrypted Bitlocker disk will be at {0:s}"
-             .format(unencrypted_path))
+    log.info(
+        "Decrypted Bitlocker disk will be at {0:s}".format(unencrypted_path))
     evidence_ = evidence.BitlockerDisk(
         name=args.name, encrypted_path=encrypted_path,
         unencrypted_path=unencrypted_path, recovery_key=args.recovery_key,
@@ -473,8 +471,8 @@ def main():
               request.request_id, evidence_.name))
       log.info(
           'Run command "turbiniactl {0:s} status -r {1:s}" to see the status of'
-          ' this request and associated tasks'
-          .format("-C" if args.use_celery else "", request.request_id))
+          ' this request and associated tasks'.format(
+              "-C" if args.use_celery else "", request.request_id))
       if not args.run_local:
         client.send_request(request)
       else:


### PR DESCRIPTION
Tested locally with BitlockerGo image by running 
* turbiniactl -C bitlocker -e /evidence/incoming/test.dd -r [recovery key]
* turbiniactl -C bitlocker -e /evidence/incoming/test.dd -p [password]

It is inefficient because Turbinia decrypts the disk as preprocess for every task. I will fix this in the next commit.