### PR TITLE
Fix grep status

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -125,7 +125,7 @@ class TurbiniaTaskResult(object):
       status = 'Completed successfully in {0:s} on {1:s}'.format(
           str(self.run_time), self.worker_name)
     elif not status and not self.successful:
-      status = 'Completed unsuccessfully in {0:s} on {1:s}'.format(
+      status = 'Run failed in {0:s} on {1:s}'.format(
           str(self.run_time), self.worker_name)
     self.log(status)
     self.status = status

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -121,8 +121,11 @@ class TurbiniaTaskResult(object):
       return
     self.successful = success
     self.run_time = datetime.now() - self.start_time
-    if not status:
+    if not status and self.successful:
       status = 'Completed successfully in {0:s} on {1:s}'.format(
+          str(self.run_time), self.worker_name)
+    elif not status and not self.successful:
+      status = 'Completed unsuccessfully in {0:s} on {1:s}'.format(
           str(self.run_time), self.worker_name)
     self.log(status)
     self.status = status
@@ -267,7 +270,7 @@ class TurbiniaTask(object):
 
   def execute(
       self, cmd, result, save_files=None, log_files=None, new_evidence=None,
-      close=False, shell=False):
+      close=False, shell=False, success_codes=None):
     """Executes a given binary and saves output.
 
     Args:
@@ -280,6 +283,7 @@ class TurbiniaTask(object):
           If the task is successful, they will be added to the result.
       close (bool): Whether to close out the result.
       shell (bool): Whether the cmd is in the form of a string or a list.
+      success_codes (list(int)): Which return codes are considered successful.
 
     Returns:
       Tuple of the return code, and the TurbiniaTaskResult object
@@ -287,6 +291,7 @@ class TurbiniaTask(object):
     save_files = save_files if save_files else []
     log_files = log_files if log_files else []
     new_evidence = new_evidence if new_evidence else []
+    success_codes = success_codes if success_codes else [0]
     if shell:
       proc = subprocess.Popen(cmd, shell=True)
     else:
@@ -306,12 +311,13 @@ class TurbiniaTask(object):
       if not self.run_local:
         self.output_manager.save_local_file(file_, result)
 
-    if ret:
-      msg = 'Execution failed with status {0:d}'.format(ret)
+    if ret not in success_codes:
+      msg = 'Execution of [{0!s}] failed with status {1:d}'.format(cmd, ret)
       result.log(msg)
       if close:
         result.close(self, success=False, status=msg)
     else:
+      result.log('Execution of [{0!s}] succeeded'.format(cmd))
       for file_ in save_files:
         result.log('Output file at {0:s}'.format(file_))
         if not self.run_local:

--- a/turbinia/workers/grep.py
+++ b/turbinia/workers/grep.py
@@ -60,7 +60,19 @@ class GrepTask(TurbiniaTask):
         patterns_file_path, evidence.local_path, output_file_path)
 
     result.log('Running [{0:s}]'.format(cmd))
-    self.execute(
-        cmd, result, new_evidence=[output_evidence], close=True, shell=True)
+    ret, result = self.execute(
+        cmd, result, new_evidence=[output_evidence], shell=True,
+        success_codes=[0, 1])
+
+    # Grep returns 0 on success and 1 if no results are found.
+    if ret == 0:
+      status = 'Grep Task found results in {0:s}'.format(evidence.name)
+      result.close(self, success=True, status=status)
+    elif ret == 1:
+      status = 'Grep Task did not find any results in {0:s}'.format(
+          evidence.name)
+      result.close(self, success=True, status=status)
+    else:
+      result.close(self, success=False)
 
     return result


### PR DESCRIPTION
Also adds success_codes parameter to TurbiniaTask.execute() to allow specification of multiple acceptable return codes for a "successful" status.