### PR TITLE
Update GCF deploy for new gcloud options

### DIFF
--- a/tools/gcf_init/deploy_gcf.py
+++ b/tools/gcf_init/deploy_gcf.py
@@ -21,13 +21,13 @@ config.LoadConfig()
 for cloud_function in function_names:
   print('Deploying function {0:s}'.format(cloud_function))
   cmd = (
-      'gcloud --project {0:s} beta functions deploy {1:s} --stage-bucket {2:s} '
-      '--region {3:s} --trigger-http'.format(
+      'gcloud --project {0:s} functions deploy {1:s} --stage-bucket {2:s} '
+      '--region {3:s} --runtime nodejs6 --trigger-http'.format(
           config.TURBINIA_PROJECT, cloud_function, config.BUCKET_NAME,
           config.TURBINIA_REGION))
   print(subprocess.check_call(cmd, shell=True))
 
 print('/nCreating Datastore index from {0:s}'.format(index_file))
-cmd = 'gcloud --quiet --project {0:s} datastore create-indexes {1:s}'.format(
+cmd = 'gcloud --quiet --project {0:s} datastore indexes create {1:s}'.format(
     config.TURBINIA_PROJECT, index_file)
 subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
- `--runtime` is now required
- `gcloud functions` is no longer in beta
- datastore index creation syntax changed as well