### PR TITLE
Fix updated Docker artifact name

### DIFF
--- a/turbinia/jobs/http_access_logs.py
+++ b/turbinia/jobs/http_access_logs.py
@@ -28,7 +28,7 @@ from turbinia.jobs import manager
 from turbinia.workers.analysis import wordpress
 
 ACCESS_LOG_ARTIFACTS = [
-    'DockerContainerLogs', 'NginxAccessLogs', 'ApacheAccessLogs'
+    'GKEDockerContainerLogs', 'NginxAccessLogs', 'ApacheAccessLogs'
 ]
 
 


### PR DESCRIPTION
I had fixed this a while back in the release branch, but I guess I forgot to push this to master.

Tests should be fixed after https://github.com/google/turbinia/pull/353 is in.