### PR TITLE
Set default value for artifact_name

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -369,7 +369,7 @@ class FilteredTextFile(TextFile):
 class ExportedFileArtifact(Evidence):
   """Exported file artifact."""
 
-  def __init__(self, artifact_name):
+  def __init__(self, artifact_name=None):
     """Initializes an exported file artifact."""
     super(ExportedFileArtifact, self).__init__()
     self.artifact_name = artifact_name


### PR DESCRIPTION
... otherwise deserialization fails in [evidence_decode](https://github.com/google/turbinia/blob/master/turbinia/evidence.py#L60) when instantiating a new ExportedFileArtifact object with no parameters