### PR TITLE
Fix debug flag

### DIFF
--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -276,12 +276,10 @@ def main():
   args = parser.parse_args()
   if args.quiet:
     log.setLevel(logging.ERROR)
-  elif args.verbose:
-    log.setLevel(logging.INFO)
   elif args.debug:
     log.setLevel(logging.DEBUG)
   else:
-    log.setLevel(logging.WARNING)
+    log.setLevel(logging.INFO)
 
   log.info('Turbinia version: {0:s}'.format(__version__))
 


### PR DESCRIPTION
Log level is set to INFO or verbose by default.  This was overriding the debug flag, so I changed it to just fall through to the default intead.