### PR TITLE
Load storage only when GCS is configured

### DIFF
--- a/turbinia/config/turbinia_config.py
+++ b/turbinia/config/turbinia_config.py
@@ -98,7 +98,8 @@ PUBSUB_TOPIC = INSTANCE_ID
 
 # GCS Path to copy worker results and Evidence output to.
 # Otherwise, set this as 'None' if output will be stored in shared storage.
-GCS_OUTPUT_PATH = 'gs://%s/output' % BUCKET_NAME
+# GCS_OUTPUT_PATH = 'gs://%s/output' % BUCKET_NAME
+GCS_OUTPUT_PATH = None
 
 ################################################################################
 #                           Celery / Redis / Kombu

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -27,7 +27,7 @@ from turbinia import config
 from turbinia import TurbiniaException
 
 config.LoadConfig()
-if config.TASK_MANAGER.lower() == 'psq':
+if config.GCS_OUTPUT_PATH and config.GCS_OUTPUT_PATH.lower() is not 'none':
   from google.cloud import storage
 
 log = logging.getLogger('turbinia')

--- a/turbinia/output_manager_test.py
+++ b/turbinia/output_manager_test.py
@@ -59,6 +59,7 @@ class TestLocalOutputManager(unittest.TestCase):
 
   def testGetOutputWriters(self):
     """Tests get_output_writers function for valid response."""
+    output_manager.storage = mock.MagicMock()
     writers = output_manager.OutputManager.get_output_writers(self.task)
     self.assertEquals(len(writers), 2)
     for writer in writers:
@@ -66,6 +67,7 @@ class TestLocalOutputManager(unittest.TestCase):
 
   def testGetLocalOutputDirs(self):
     """Tests get_local_output_dirs function for valid response."""
+    output_manager.storage = mock.MagicMock()
     self.task.output_manager.setup(self.task)
     tmp_dir, local_dir = self.task.output_manager.get_local_output_dirs()
 


### PR DESCRIPTION
The cloud storage modules were only loading if the task_manager was set to PSQ, but it should have been checking whether GCS was actually set in the config.  Also setting GCS_OUTPUT_PATH to default in the config so that it doesn't accidentally get loaded (otherwise we'd just see other errors later).

Fixes #375