### PR TITLE
 Fix setting and querying for user/requester

### DIFF
--- a/tools/gcf_init/index.js
+++ b/tools/gcf_init/index.js
@@ -67,7 +67,7 @@ exports.gettasks = function gettasks(req, res) {
   }
   if (req.body.user) {
     console.log('Getting Turbinia Tasks by user: ' + req.body.user);
-    query = query.filter('user', '=', req.body.user);
+    query = query.filter('requester', '=', req.body.user);
   }
   if (req.body.start_time) {
     try {
@@ -150,8 +150,8 @@ exports.closetasks = function closetasks(req, res) {
         '__key__', '=', datastore.key([turbiniaKind, req.body.task_id]))
   }
   if (req.body.user) {
-    console.log('Adding filter - user: ' + req.body.user);
-    query = query.filter('user', '=', req.body.user)
+    console.log('Adding filter - requester: ' + req.body.user);
+    query = query.filter('requester', '=', req.body.user)
   }
 
   console.log(query);

--- a/tools/gcf_init/index.yaml
+++ b/tools/gcf_init/index.yaml
@@ -45,7 +45,7 @@ indexes:
 - kind: TurbiniaTask
   ancestor: no
   properties:
-  - name: user
+  - name: requester
   - name: last_update
     direction: desc
 
@@ -54,7 +54,7 @@ indexes:
   properties:
   - name: instance
   - name: id
-  - name: user
+  - name: requester
   - name: last_update
     direction: desc
 
@@ -63,7 +63,7 @@ indexes:
   properties:
   - name: instance
   - name: request_id
-  - name: user
+  - name: requester
   - name: last_update
     direction: desc
 

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -356,8 +356,10 @@ class TurbiniaClient(object):
     # Generate report header
     report.append('\n')
     report.append(fmt.heading1('Turbinia report {0:s}'.format(request_id)))
-    report.append(fmt.bullet('Processed {0:d} Tasks for user {1:s}'.format(
-        num_results, requester)))
+    report.append(
+        fmt.bullet(
+            'Processed {0:d} Tasks for user {1:s}'.format(
+                num_results, requester)))
 
     # Print report data for tasks
     for success_type in success_types:

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -339,7 +339,7 @@ class TurbiniaClient(object):
 
     # Build up data
     report = []
-    user = task_results[0].get('user')
+    requester = task_results[0].get('requester')
     request_id = task_results[0].get('request_id')
     success_types = ['Successful', 'Failed', 'Scheduled or Running']
     success_values = [True, False, None]
@@ -356,9 +356,8 @@ class TurbiniaClient(object):
     # Generate report header
     report.append('\n')
     report.append(fmt.heading1('Turbinia report {0:s}'.format(request_id)))
-    report.append(
-        fmt.bullet(
-            'Processed {0:d} Tasks for user {1:s}'.format(num_results, user)))
+    report.append(fmt.bullet('Processed {0:d} Tasks for user {1:s}'.format(
+        num_results, requester)))
 
     # Print report data for tasks
     for success_type in success_types:

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -127,7 +127,7 @@ class TestTurbiniaClient(unittest.TestCase):
             'saved_paths': ['/no/path/', '/fake/path'],
             'status': 'This fake task executed',
             'successful': True,
-            'user': 'myuser',
+            'requester': 'myuser',
             'worker_name': 'fake_worker'
         }, {
             'id': '0xfakeTaskId2',
@@ -140,7 +140,7 @@ class TestTurbiniaClient(unittest.TestCase):
             'saved_paths': ['/no/path/2', '/fake/path/2'],
             'status': 'This second fake task executed',
             'successful': True,
-            'user': 'myuser',
+            'requester': 'myuser',
             'worker_name': 'fake_worker'
         }, {
             'id': '0xfakeTaskId3',
@@ -153,7 +153,7 @@ class TestTurbiniaClient(unittest.TestCase):
             'saved_paths': ['/no/path/3', '/fake/path/3'],
             'status': 'Third Task Failed...',
             'successful': False,
-            'user': 'myuser',
+            'requester': 'myuser',
             'worker_name': 'fake_worker'
         }
     ] # yapf: disable

--- a/turbinia/message.py
+++ b/turbinia/message.py
@@ -35,16 +35,19 @@ class TurbiniaRequest(object):
   """An object to request evidence to be processed.
 
   Attributes:
-    request_id: A client specified ID for this request.
-    recipe: Recipe to use when processing this request.
-    context: A Dict of context data to be passed around with this request.
-    evidence: A list of Evidence objects.
+    request_id(str): A client specified ID for this request.
+    requestor(str): The username of who made the request.
+    recipe(dict): Recipe to use when processing this request.
+    context(dict): A Dict of context data to be passed around with this request.
+    evidence(list): A list of Evidence objects.
   """
 
   def __init__(
-      self, request_id=None, recipe=None, context=None, evidence_=None):
+      self, request_id=None, requester=None, recipe=None, context=None,
+      evidence_=None):
     """Initialization for TurbiniaRequest."""
     self.request_id = request_id if request_id else uuid.uuid4().hex
+    self.requester = requester if requester else 'user_unspecified'
     self.recipe = recipe if recipe else {}
     self.context = context if context else {}
     self.evidence = evidence_ if evidence_ else []

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -168,6 +168,7 @@ class BaseTaskManager(object):
         job_count += 1
         for task in job.create_tasks([evidence_]):
           task.base_output_dir = config.OUTPUT_DIR
+          task.requester = evidence_.config.get('requester')
           self.add_task(task, evidence_)
 
     if not job_count:
@@ -352,6 +353,7 @@ class CeleryTaskManager(BaseTaskManager):
         if not evidence_.request_id:
           evidence_.request_id = request.request_id
         evidence_.config = request.recipe
+        evidence_.config['requester'] = request.requester
         log.info(
             'Received evidence [{0:s}] from Kombu message.'.format(
                 str(evidence_)))
@@ -436,6 +438,7 @@ class PSQTaskManager(BaseTaskManager):
         if not evidence_.request_id:
           evidence_.request_id = request.request_id
         evidence_.config = request.recipe
+        evidence_.config['requester'] = request.requester
         log.info(
             'Received evidence [{0:s}] from PubSub message.'.format(
                 str(evidence_)))

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -456,9 +456,7 @@ def main():
     server.start()
   elif evidence_:
     request = TurbiniaRequest(
-        #  request_id=args.request_id, requester=getpass.getuser())
-        # DEBUG DONOTSUBMIT
-        request_id=args.request_id, requester='morty')
+        request_id=args.request_id, requester=getpass.getuser())
     request.evidence.append(evidence_)
     if filter_patterns:
       request.recipe['filter_patterns'] = filter_patterns

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -455,7 +455,10 @@ def main():
     server.add_evidence(evidence_)
     server.start()
   elif evidence_:
-    request = TurbiniaRequest(request_id=args.request_id)
+    request = TurbiniaRequest(
+        #  request_id=args.request_id, requester=getpass.getuser())
+        # DEBUG DONOTSUBMIT
+        request_id=args.request_id, requester='morty')
     request.evidence.append(evidence_)
     if filter_patterns:
       request.recipe['filter_patterns'] = filter_patterns

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -62,7 +62,7 @@ class TurbiniaTaskResult(object):
       successful: Bool indicating success status.
       task_id: Task ID of the parent task.
       task_name: Name of parent task.
-      user: The user who requested the task.
+      requester: The user who requested the task.
       worker_name: Name of worker task executed on.
       _log: A list of log messages
   """
@@ -87,7 +87,7 @@ class TurbiniaTaskResult(object):
 
     self.task_id = None
     self.task_name = None
-    self.user = None
+    self.requester = None
     self.output_dir = None
 
     self.report_data = None
@@ -117,7 +117,7 @@ class TurbiniaTaskResult(object):
 
     self.task_id = task.id
     self.task_name = task.name
-    self.user = task.user
+    self.requester = task.requester
     if task.output_manager.is_setup:
       _, self.output_dir = task.output_manager.get_local_output_dirs()
     else:
@@ -293,16 +293,16 @@ class TurbiniaTask(object):
           this is a task result object, but other implementations have their
           own stub objects.
       tmp_dir: Temporary directory for Task to write to.
-      user: The user who requested the task.
+      requester: The user who requested the task.
       _evidence_config (dict): The config that we want to pass to all new
             evidence created from this task.
   """
 
   # The list of attributes that we will persist into storage
-  STORED_ATTRIBUTES = ['id', 'last_update', 'name', 'request_id', 'user']
+  STORED_ATTRIBUTES = ['id', 'last_update', 'name', 'request_id', 'requester']
 
   def __init__(
-      self, name=None, base_output_dir=None, request_id=None, user=None):
+      self, name=None, base_output_dir=None, request_id=None, requester=None):
     """Initialization for TurbiniaTask."""
     if base_output_dir:
       self.base_output_dir = base_output_dir
@@ -320,7 +320,7 @@ class TurbiniaTask(object):
     self.stub = None
     self.tmp_dir = None
     self.turbinia_version = turbinia.__version__
-    self.user = user if user else getpass.getuser()
+    self.requester = requester if requester else 'user_unspecified'
     self._evidence_config = {}
 
   def serialize(self):


### PR DESCRIPTION
This makes it so that `turbiniactl status -u user` actually works to query for all Tasks for that user.  Previously the user was being set server-side, so it wasn't actually setting the original requester.

This also changes most of the code/storage references from 'user' to 'requester' to be a little clearer in the code what is being referenced (because in some of the Google Cloud Functions both are used).