### PR TITLE
Check for empty files before saving

### DIFF
--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -29,6 +29,7 @@ from turbinia import TurbiniaException
 config.LoadConfig()
 if config.GCS_OUTPUT_PATH and config.GCS_OUTPUT_PATH.lower() is not 'none':
   from google.cloud import storage
+  from google.cloud import exceptions
 
 log = logging.getLogger('turbinia')
 
@@ -251,6 +252,10 @@ class OutputWriter(object):
 
     Returns:
       The path the file was saved to, or None if file was not written.
+
+    Raises:
+      TurbiniaException: When the source file is empty or there are problems
+          saving the file.
     """
     raise NotImplementedError
 
@@ -265,6 +270,9 @@ class OutputWriter(object):
 
     Returns:
       The path the file was saved to, or None if file was not written.
+
+    Raises:
+      TurbiniaException: When there are problems copying from storage.
     """
     raise NotImplementedError
 
@@ -383,13 +391,24 @@ class GCSOutputWriter(OutputWriter):
     pass
 
   def copy_to(self, source_path):
+    if os.path.getsize(source_path) == 0:
+      msg = 'Local source file {0:s} is empty.  Not uploading to GCS'.format(
+          source_path)
+      log.error(msg)
+      raise TurbiniaException(msg)
+
     bucket = self.client.get_bucket(self.bucket)
     destination_path = os.path.join(
         self.base_output_dir, self.unique_dir, os.path.basename(source_path))
     log.info(
         'Writing {0:s} to GCS path {1:s}'.format(source_path, destination_path))
-    blob = storage.Blob(destination_path, bucket, chunk_size=self.CHUNK_SIZE)
-    blob.upload_from_filename(source_path, client=self.client)
+    try:
+      blob = storage.Blob(destination_path, bucket, chunk_size=self.CHUNK_SIZE)
+      blob.upload_from_filename(source_path, client=self.client)
+    except exceptions.GoogleCloudError as e:
+      msg = 'File upload to GCS failed: {0!s}'.format(e)
+      log.error(msg)
+      raise TurbiniaException(msg)
     return os.path.join('gs://', self.bucket, destination_path)
 
   def copy_from(self, source_path):
@@ -414,10 +433,22 @@ class GCSOutputWriter(OutputWriter):
     log.info(
         'Writing GCS file {0:s} to local path {1:s}'.format(
             source_path, destination_path))
-    blob = storage.Blob(gcs_path, bucket, chunk_size=self.CHUNK_SIZE)
-    blob.download_to_filename(destination_path, client=self.client)
+    try:
+      blob = storage.Blob(gcs_path, bucket, chunk_size=self.CHUNK_SIZE)
+      blob.download_to_filename(destination_path, client=self.client)
+    except exceptions.RequestRangeNotSatisfiable as e:
+      msg = 'File retrieval from GCS failed, file may be empty: {0!s}'.format(e)
+      log.error(msg)
+      raise TurbiniaException(msg)
+    except exceptions.GoogleCloudError as e:
+      msg = 'File retrieval from GCS failed: {0!s}'.format(e)
+      log.error(msg)
+      raise TurbiniaException(msg)
+
     if not os.path.exists(destination_path):
-      raise TurbiniaException(
+      msg = (
           'File retrieval from GCS failed: Local file {0:s} does not '
           'exist'.format(destination_path))
+      log.error(msg)
+      raise TurbiniaException(msg)
     return destination_path

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -300,12 +300,12 @@ class LocalOutputWriter(OutputWriter):
       try:
         log.debug('Creating new directory {0:s}'.format(output_dir))
         os.makedirs(output_dir)
-      except OSError as e:
-        if e.errno == errno.EACCES:
-          msg = 'Permission error ({0:s})'.format(str(e))
+      except OSError as exception:
+        if exception.errno == errno.EACCES:
+          message = 'Permission error ({0:s})'.format(str(exception))
         else:
-          msg = str(e)
-        raise TurbiniaException(msg)
+          message = str(exception)
+        raise TurbiniaException(message)
 
     return output_dir
 
@@ -392,10 +392,11 @@ class GCSOutputWriter(OutputWriter):
 
   def copy_to(self, source_path):
     if os.path.getsize(source_path) == 0:
-      msg = 'Local source file {0:s} is empty.  Not uploading to GCS'.format(
-          source_path)
-      log.error(msg)
-      raise TurbiniaException(msg)
+      message = (
+          'Local source file {0:s} is empty.  Not uploading to GCS'.format(
+              source_path))
+      log.error(message)
+      raise TurbiniaException(message)
 
     bucket = self.client.get_bucket(self.bucket)
     destination_path = os.path.join(
@@ -405,10 +406,10 @@ class GCSOutputWriter(OutputWriter):
     try:
       blob = storage.Blob(destination_path, bucket, chunk_size=self.CHUNK_SIZE)
       blob.upload_from_filename(source_path, client=self.client)
-    except exceptions.GoogleCloudError as e:
-      msg = 'File upload to GCS failed: {0!s}'.format(e)
-      log.error(msg)
-      raise TurbiniaException(msg)
+    except exceptions.GoogleCloudError as exception:
+      message = 'File upload to GCS failed: {0!s}'.format(exception)
+      log.error(message)
+      raise TurbiniaException(message)
     return os.path.join('gs://', self.bucket, destination_path)
 
   def copy_from(self, source_path):
@@ -436,19 +437,21 @@ class GCSOutputWriter(OutputWriter):
     try:
       blob = storage.Blob(gcs_path, bucket, chunk_size=self.CHUNK_SIZE)
       blob.download_to_filename(destination_path, client=self.client)
-    except exceptions.RequestRangeNotSatisfiable as e:
-      msg = 'File retrieval from GCS failed, file may be empty: {0!s}'.format(e)
-      log.error(msg)
-      raise TurbiniaException(msg)
-    except exceptions.GoogleCloudError as e:
-      msg = 'File retrieval from GCS failed: {0!s}'.format(e)
-      log.error(msg)
-      raise TurbiniaException(msg)
+    except exceptions.RequestRangeNotSatisfiable as exception:
+      message = (
+          'File retrieval from GCS failed, file may be empty: {0!s}'.format(
+              exception))
+      log.error(message)
+      raise TurbiniaException(message)
+    except exceptions.GoogleCloudError as exception:
+      message = 'File retrieval from GCS failed: {0!s}'.format(exception)
+      log.error(message)
+      raise TurbiniaException(message)
 
     if not os.path.exists(destination_path):
-      msg = (
+      message = (
           'File retrieval from GCS failed: Local file {0:s} does not '
           'exist'.format(destination_path))
-      log.error(msg)
-      raise TurbiniaException(msg)
+      log.error(message)
+      raise TurbiniaException(message)
     return destination_path

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -170,10 +170,10 @@ class TurbiniaTaskResult(object):
     # to clean things up even after other failures in the task, so this could
     # also fail.
     # pylint: disable=broad-except
-    except Exception as e:
-      msg = 'Evidence post-processing for {0:s} failed: {1!s}'.format(
-          self.input_evidence.name, e)
-      self.log(msg, level=logging.ERROR)
+    except Exception as exception:
+      message = 'Evidence post-processing for {0:s} failed: {1!s}'.format(
+          self.input_evidence.name, exception)
+      self.log(message, level=logging.ERROR)
 
     # Write result log info to file
     logfile = os.path.join(self.output_dir, 'worker-log.txt')
@@ -359,11 +359,11 @@ class TurbiniaTask(object):
     try:
       task = getattr(sys.modules['turbinia.client'], type_)()
     except AttributeError:
-      msg = (
+      message = (
           "Could not import {0:s} object! Make sure it is imported where "
           "this method is defined.".format(type_))
-      log.error(msg)
-      raise TurbiniaException(msg)
+      log.error(message)
+      raise TurbiniaException(message)
     task.__dict__.update(input_dict)
     task.output_manager = output_manager.OutputManager()
     task.output_manager.__dict__.update(input_dict['output_manager'])
@@ -420,10 +420,10 @@ class TurbiniaTask(object):
         self.output_manager.save_local_file(file_, result)
 
     if ret not in success_codes:
-      msg = 'Execution of [{0!s}] failed with status {1:d}'.format(cmd, ret)
-      result.log(msg)
+      message = 'Execution of [{0!s}] failed with status {1:d}'.format(cmd, ret)
+      result.log(message)
       if close:
-        result.close(self, success=False, status=msg)
+        result.close(self, success=False, status=message)
     else:
       result.log('Execution of [{0!s}] succeeded'.format(cmd))
       for file_ in save_files:
@@ -440,16 +440,16 @@ class TurbiniaTask(object):
         # If the local path is set in the Evidence, we check to make sure that
         # the path exists and is not empty before adding it.
         if evidence.local_path and not os.path.exists(evidence.local_path):
-          msg = (
+          message = (
               'Evidence {0:s} local_path {1:s} does not exist. Not returning '
               'empty Evidence.'.format(evidence.name, evidence.local_path))
-          result.log(msg, level=logging.WARN)
+          result.log(message, level=logging.WARN)
         elif (evidence.local_path and os.path.exists(evidence.local_path) and
               os.path.getsize(evidence.local_path) == 0):
-          msg = (
+          message = (
               'Evidence {0:s} local_path {1:s} is empty. Not returning '
               'empty new Evidence.'.format(evidence.name, evidence.local_path))
-          result.log(msg, level=logging.WARN)
+          result.log(message, level=logging.WARN)
         else:
           result.add_evidence(evidence, self._evidence_config)
 
@@ -524,11 +524,11 @@ class TurbiniaTask(object):
       try:
         log.debug('Checking TurbiniaTaskResult for serializability')
         pickle.dumps(result)
-      except (TypeError, pickle.PicklingError) as e:
+      except (TypeError, pickle.PicklingError) as exception:
         bad_message = (
             'Error pickling TurbiniaTaskResult object. Returning a new result '
             'with the pickling error, and all previous result data will be '
-            'lost. Pickle Error: {0!s}'.format(e))
+            'lost. Pickle Error: {0!s}'.format(exception))
 
     if bad_message:
       log.error(bad_message)
@@ -581,30 +581,32 @@ class TurbiniaTask(object):
         original_result_id = self.result.id
 
         if self.turbinia_version != turbinia.__version__:
-          msg = (
+          message = (
               'Worker and Server versions do not match: {0:s} != {1:s}'.format(
                   self.turbinia_version, turbinia.__version__))
-          self.result.log(msg, level=logging.ERROR)
-          self.result.status = msg
+          self.result.log(message, level=logging.ERROR)
+          self.result.status = message
           return self.result
 
         self._evidence_config = evidence.config
         self.result = self.run(evidence, self.result)
       # pylint: disable=broad-except
-      except Exception as e:
-        msg = '{0:s} Task failed with exception: [{1!s}]'.format(self.name, e)
+      except Exception as exception:
+        message = (
+            '{0:s} Task failed with exception: [{1!s}]'.format(
+                self.name, exception))
         # Logging explicitly here because the result is in an unknown state
         trace = traceback.format_exc()
-        log.error(msg)
+        log.error(message)
         log.error(trace)
         if self.result:
-          self.result.log(msg, level=logging.ERROR)
+          self.result.log(message, level=logging.ERROR)
           self.result.log(trace)
-          if hasattr(e, 'message'):
-            self.result.set_error(e.message, traceback.format_exc())
+          if hasattr(exception, 'message'):
+            self.result.set_error(exception.message, traceback.format_exc())
           else:
-            self.result.set_error(e.__class__, traceback.format_exc())
-          self.result.status = msg
+            self.result.set_error(exception.__class__, traceback.format_exc())
+          self.result.status = message
         else:
           log.error('No TurbiniaTaskResult object found after task execution.')
 
@@ -614,28 +616,28 @@ class TurbiniaTask(object):
       # This has a higher likelihood of failing because something must have gone
       # wrong as the Task should have already closed this.
       if self.result and not self.result.closed:
-        msg = 'Trying last ditch attempt to close result'
-        log.warning(msg)
-        self.result.log(msg)
+        message = 'Trying last ditch attempt to close result'
+        log.warning(message)
+        self.result.log(message)
 
         if self.result.status:
           status = self.result.status
         else:
           status = 'No previous status'
-        msg = (
+        message = (
             'Task Result was auto-closed from task executor on {0:s} likely '
             'due to previous failures.  Previous status: [{1:s}]'.format(
                 self.result.worker_name, status))
-        self.result.log(msg)
+        self.result.log(message)
         try:
-          self.result.close(self, False, msg)
+          self.result.close(self, False, message)
         # Using broad except here because lots can go wrong due to the reasons
         # listed above.
         # pylint: disable=broad-except
-        except Exception as e:
-          log.error('TurbiniaTaskResult close failed: {0!s}'.format(e))
+        except Exception as exception:
+          log.error('TurbiniaTaskResult close failed: {0!s}'.format(exception))
           if not self.result.status:
-            self.result.status = msg
+            self.result.status = message
         # Check the result again after closing to make sure it's still good.
         self.result = self.validate_result(self.result)
 


### PR DESCRIPTION
This should prevent an empty file from ever getting saved, and should also give a better error message in case they do, or in case an empty file is passed in in the initial processing request from a user.  Also catch exceptions when copying to/from GCS.   This adds checks for empty files at the output_manager layer so that when this happens that a more sane exception/error is thrown/logged in case things fall through.  I'm also capturing this condition at the worker for the non-fatal cases.