### PR TITLE
Add Encrypted APFS support for Plaso

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -265,6 +265,24 @@ class BitlockerDisk(EncryptedDisk):
     self.encryption_type = self.__class__.__name__
 
 
+class APFSEncryptedDisk(EncryptedDisk):
+  """APFS encrypted disk file evidence.
+
+  Attributes:
+    recovery_key: A string of the recovery key for this disk
+    password: A string of the password used for this disk. If recovery key
+        is used, this argument is ignored
+    unencrypted_path: A string to the unencrypted local path
+  """
+
+  def __init__(self, recovery_key=None, password=None, *args, **kwargs):
+    """Initialization for Bitlocker disk evidence object"""
+    self.recovery_key = recovery_key
+    self.password = password
+    super(APFSEncryptedDisk, self).__init__(*args, **kwargs)
+    self.encryption_type = self.__class__.__name__
+
+
 class GoogleCloudDisk(RawDisk):
   """Evidence object for Google Cloud Disks.
 

--- a/turbinia/jobs/plaso.py
+++ b/turbinia/jobs/plaso.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 
+from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import Directory
 from turbinia.evidence import GoogleCloudDisk
@@ -32,7 +33,7 @@ class PlasoJob(interface.TurbiniaJob):
   # The types of evidence that this Job will process
   evidence_input = [
       Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-      BitlockerDisk
+      BitlockerDisk, APFSEncryptedDisk
   ]
   evidence_output = [PlasoFile]
 

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -142,6 +142,25 @@ def main():
   parser_rawdisk.add_argument(
       '-n', '--name', help='Descriptive name of the evidence', required=False)
 
+  # Parser options for APFS Disk Evidence type
+  parser_apfs = subparsers.add_parser(
+      'apfs', help='Process APFSEncryptedDisk as Evidence')
+  parser_apfs.add_argument(
+      '-l', '--local_path',
+      help='Local path to the encrypted APFS evidence', required=True)
+  parser_apfs.add_argument(
+      '-r', '--recovery_key', help='Recovery key for the APFS evidence.  '
+      'Either recovery key or password must be specified.', required=False)
+  parser_apfs.add_argument(
+      '-p', '--password', help='Password for the APFS evidence.  '
+      'If a recovery key is specified concurrently, password will be ignored.',
+      required=False)
+  parser_apfs.add_argument(
+      '-s', '--source', help='Description of the source of the evidence',
+      required=False)
+  parser_apfs.add_argument(
+      '-n', '--name', help='Descriptive name of the evidence', required=False)
+
   # Parser options for Bitlocker Disk Evidence type
   parser_bitlocker = subparsers.add_parser(
       'bitlocker', help='Process Bitlocker Disk as Evidence')
@@ -334,6 +353,15 @@ def main():
     evidence_ = evidence.RawDisk(
         name=args.name, local_path=local_path,
         mount_partition=args.mount_partition, source=args.source)
+  elif args.command == 'apfs':
+    if not args.password and not args.recovery_key:
+      log.error('Neither recovery key nor password is specified.')
+      sys.exit(1)
+    args.name = args.name if args.name else args.local_path
+    local_path = os.path.abspath(args.local_path)
+    evidence_ = evidence.APFSEncryptedDisk(
+        name=args.name, local_path=local_path, recovery_key=args.recovery_key,
+        password=args.password, source=args.source)
   elif args.command == 'bitlocker':
     if not args.password and not args.recovery_key:
       log.error('Neither recovery key nor password is specified.')

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -146,8 +146,8 @@ def main():
   parser_apfs = subparsers.add_parser(
       'apfs', help='Process APFSEncryptedDisk as Evidence')
   parser_apfs.add_argument(
-      '-l', '--local_path',
-      help='Local path to the encrypted APFS evidence', required=True)
+      '-l', '--local_path', help='Local path to the encrypted APFS evidence',
+      required=True)
   parser_apfs.add_argument(
       '-r', '--recovery_key', help='Recovery key for the APFS evidence.  '
       'Either recovery key or password must be specified.', required=False)

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 import os
 
 from turbinia import config
+from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
@@ -53,7 +54,8 @@ class PlasoTask(TurbiniaTask):
     if config.DEBUG_TASKS:
       cmd.append('-d')
 
-    if isinstance(evidence, BitlockerDisk):
+    if isinstance(evidence, BitlockerDisk) or \
+            isinstance(evidence, APFSEncryptedDisk):
       if evidence.recovery_key:
         cmd.extend([
             '--credential', 'recovery_password:{0:s}'.format(

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -54,8 +54,7 @@ class PlasoTask(TurbiniaTask):
     if config.DEBUG_TASKS:
       cmd.append('-d')
 
-    if isinstance(evidence, BitlockerDisk) or \
-            isinstance(evidence, APFSEncryptedDisk):
+    if isinstance(evidence, (APFSEncryptedDisk, BitlockerDisk)):
       if evidence.recovery_key:
         cmd.extend([
             '--credential', 'recovery_password:{0:s}'.format(


### PR DESCRIPTION
Tested locally with the following options
`turbiniactl apfs -l [DISK LOCATION] -p [PASSWORD]`
`turbiniactl apfs -l [DISK LOCATION] -r [RECOVERY KEY]`

Haven't had much chance to work on #346 yet, but this PR provides support for APFS Encrypted disk to be processed by Plaso in the meantime (similar to #349 ). 