### PR TITLE
Fix jenkins analysis task

### DIFF
--- a/turbinia/jobs/jenkins.py
+++ b/turbinia/jobs/jenkins.py
@@ -22,6 +22,7 @@ from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
+from turbinia.jobs import manager
 from turbinia.workers.analysis.jenkins import JenkinsAnalysisTask
 
 
@@ -46,3 +47,5 @@ class JenkinsAnalysisJob(interface.TurbiniaJob):
     """
     tasks = [JenkinsAnalysisTask() for _ in evidence]
     return tasks
+
+manager.JobsManager.RegisterJob(JenkinsAnalysisJob)

--- a/turbinia/jobs/jenkins.py
+++ b/turbinia/jobs/jenkins.py
@@ -48,4 +48,5 @@ class JenkinsAnalysisJob(interface.TurbiniaJob):
     tasks = [JenkinsAnalysisTask() for _ in evidence]
     return tasks
 
+
 manager.JobsManager.RegisterJob(JenkinsAnalysisJob)

--- a/turbinia/workers/analysis/jenkins.py
+++ b/turbinia/workers/analysis/jenkins.py
@@ -51,6 +51,9 @@ class JenkinsAnalysisTask(TurbiniaTask):
     # Set the output file as the data source for the output evidence.
     output_evidence.local_path = output_file_path
 
+    # TODO(aarontp): We should find a more optimal solution for this because
+    # this requires traversing the entire filesystem and extracting more files
+    # than we need.  Tracked in https://github.com/google/turbinia/issues/402
     try:
       collected_artifacts = extract_files(
           file_name='config.xml', disk_path=evidence.local_path,

--- a/turbinia/workers/analysis/jenkins.py
+++ b/turbinia/workers/analysis/jenkins.py
@@ -165,12 +165,6 @@ class JenkinsAnalysisTask(TurbiniaTask):
       version = 'Unknown'
     report.append(fmt.bullet('Jenkins version: {0:s}'.format(version)))
 
-    if credentials_registry or version:
-      # Bump up the priority a bit if we have extracted a version or credentials
-      # even if they are not weak since having jenkins at all can be
-      # interesting.
-      priority = Priority.MEDIUM
-
     if weak_passwords:
       priority = Priority.CRITICAL
       summary = 'Jenkins analysis found potential issues'
@@ -181,8 +175,14 @@ class JenkinsAnalysisTask(TurbiniaTask):
         line = 'User "{0:s}" with password "{1:s}"'.format(
             credentials_registry.get(password_hash), plaintext)
         report.append(fmt.bullet(line, level=2))
+    elif credentials_registry or version != 'Unknown':
+      summary = (
+          'Jenkins version {0:s} found with {1:d} credentials, but no issues '
+          'detected'.format(version, len(credentials_registry)))
+      report.insert(0, fmt.heading4(summary))
+      priority = Priority.MEDIUM
     else:
-      summary = 'Jenkins analysis found no issues'
+      summary = 'No Jenkins instance found'
       report.insert(0, fmt.heading4(summary))
 
     report = '\n'.join(report)

--- a/turbinia/workers/analysis/jenkins_test.py
+++ b/turbinia/workers/analysis/jenkins_test.py
@@ -166,7 +166,7 @@ class JenkinsAnalysisTaskTest(unittest.TestCase):
         self.EXPECTED_VERSION, self.EXPECTED_CREDENTIALS)
 
     self.assertEqual(report, self.JENKINS_ANALYSIS_EMPTY_REPORT)
-    self.assertEqual(priority, 80)
+    self.assertEqual(priority, 50)
     self.assertEqual(summary, 'Jenkins analysis found no issues')
 
 

--- a/turbinia/workers/analysis/jenkins_test.py
+++ b/turbinia/workers/analysis/jenkins_test.py
@@ -111,7 +111,7 @@ class JenkinsAnalysisTaskTest(unittest.TestCase):
     * User \"admin\" with password \"weakpassword\"
 """
 
-  JENKINS_ANALYSIS_EMPTY_REPORT = """#### Jenkins analysis found no issues
+  JENKINS_ANALYSIS_EMPTY_REPORT = """#### Jenkins version 2.121.2 found with 1 credentials, but no issues detected
 * Jenkins version: 2.121.2"""
 
   EXPECTED_VERSION = '2.121.2'
@@ -167,7 +167,10 @@ class JenkinsAnalysisTaskTest(unittest.TestCase):
 
     self.assertEqual(report, self.JENKINS_ANALYSIS_EMPTY_REPORT)
     self.assertEqual(priority, 50)
-    self.assertEqual(summary, 'Jenkins analysis found no issues')
+    self.assertEqual(
+        summary,
+        'Jenkins version 2.121.2 found with 1 credentials, but no issues '
+        'detected')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the jenkins analysis task, but at the cost of running it much more inefficiently.  This extracts all config.xml files and then post filters them to only analyze the files with an interesting path because the Plaso and Forensic Artifacts path filters/regexes are not very flexible.  This means that image_export.py has to iterate through every file on disk because it's only validating the filename and not the path.   It also refactors image_export into it's own method so we can run it independently of extract_artifacts(), and updates the report a bit.