### PR TITLE
Change Volatility binary name

### DIFF
--- a/turbinia/workers/volatility.py
+++ b/turbinia/workers/volatility.py
@@ -54,7 +54,7 @@ class VolatilityTask(TurbiniaTask):
 
     # TODO: Add in config options for Turbinia
     cmd = (
-        'vol2 -f {0:s} --profile={1:s} {2:s} --output=text '
+        'vol.py -f {0:s} --profile={1:s} {2:s} --output=text '
         '--output-file={3:s}').format(
             evidence.local_path, evidence.profile, self.module,
             output_file_path).split()


### PR DESCRIPTION
`vol2` -> `vol.py`

Volatility's `setup.py` [defines it as the latter](https://github.com/volatilityfoundation/volatility/blob/master/setup.py#L59), so I think we should make it match.

FYI @mwatkins-fb