### PR TITLE
Added libfsapfs-tools and removed python-plaso from libcloudforensics

### DIFF
--- a/turbinia/lib/libcloudforensics.py
+++ b/turbinia/lib/libcloudforensics.py
@@ -330,11 +330,22 @@ class GoogleCloudProject(object):
     source_disk_image = ubuntu_image['selfLink']
 
     # Analysis software to install.
+    # yapf: disable
     packages_to_install = [
-        'python-plaso', 'xmount', 'sleuthkit', 'libfvde-tools', 'libbde-tools',
-        'plaso-tools', 'jq', 'ncdu', 'htop', 'binutils', 'upx-ucl',
+        'binutils',
         'docker-explorer-tools'
-    ]
+        'htop',
+        'jq',
+        'libbde-tools',
+        'libfsapfs-tools',
+        'libfvde-tools',
+        'ncdu',
+        'plaso-tools',
+        'sleuthkit',
+        'upx-ucl',
+        'xmount']
+
+    # yapf: enable
 
     startup_script = """
         #!/bin/bash


### PR DESCRIPTION
plaso-tools will install python3-plaso, so unless python-plaso is explicitly needed it does not need to be included in the package list