### PR TITLE
Generate basic task execution time statistics

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -321,7 +321,7 @@ class TurbiniaClient(object):
       results = json.loads(response['result'])
     except (TypeError, ValueError) as e:
       raise TurbiniaException(
-          'Could not deserialize result ({0!s}) from GCF: [{1!s}]'.format(
+          'Could not deserialize result [{0!s}] from GCF: [{1!s}]'.format(
               response.get('result'), e))
 
     # Convert run_time/last_update back into datetime objects

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -315,7 +315,7 @@ class TurbiniaClient(object):
       results = json.loads(response['result'])
     except (TypeError, ValueError) as e:
       raise TurbiniaException(
-          'Could not deserialize result ({0:s}) from GCF: [{1!s}]'.format(
+          'Could not deserialize result ({0!s}) from GCF: [{1!s}]'.format(
               response['result'], e))
 
     # Convert run_time back into timedelta.

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -22,6 +22,7 @@ from datetime import timedelta
 import json
 import logging
 from operator import itemgetter
+from operator import attrgetter
 import os
 import stat
 import time
@@ -158,7 +159,7 @@ class TurbiniaStats(object):
     Returns:
       String of statistics data
     """
-    return '{0:s}: Count: {1:d}, Min: {2:s}, Mean: {3:s}, Max: {4:s}'.format(
+    return '{0:s}: Count: {1:d}, Min: {2!s}, Mean: {3!s}, Max: {4!s}'.format(
         self.description, self.count, self.min, self.mean, self.max)
 
   def format_stats_csv(self):
@@ -167,7 +168,7 @@ class TurbiniaStats(object):
     Returns:
       String of statistics data in CSV format
     """
-    return '{0:s}, {1:d}, {2:s}, {3:s}, {4:s}'.format(
+    return '{0:s}, {1:d}, {2!s}, {3!s}, {4!s}'.format(
         self.description, self.count, self.min, self.mean, self.max)
 
 
@@ -508,11 +509,17 @@ class TurbiniaClient(object):
         'tasks_per_type', 'tasks_per_worker', 'tasks_per_user'
     ]
 
-    report = ['Execution time statistics for Turbinia:', '']
+    if csv:
+      report = ['stat_type, count, min, mean, max']
+    else:
+      report = ['Execution time statistics for Turbinia:', '']
     for stat_name in stats_order:
       stat_obj = task_stats[stat_name]
       if isinstance(stat_obj, dict):
-        for inner_stat_obj in stat_obj.values():
+        # Sort by description so that we get consistent report output
+        inner_stat_objs = sorted(
+            stat_obj.values(), key=attrgetter('description'))
+        for inner_stat_obj in inner_stat_objs:
           if csv:
             report.append(inner_stat_obj.format_stats_csv())
           else:

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -29,6 +29,7 @@ import time
 
 from turbinia import config
 from turbinia.config import logger
+from turbinia.config import DATETIME_FORMAT
 from turbinia import task_manager
 from turbinia import TurbiniaException
 from turbinia.lib import text_formatter as fmt
@@ -290,7 +291,7 @@ class TurbiniaClient(object):
       start_time = datetime.now() - timedelta(days=days)
       # Format this like '1990-01-01T00:00:00z' so we can cast it directly to a
       # javascript Date() object in the cloud function.
-      start_string = start_time.strftime(config.DATETIME_FORMAT)
+      start_string = start_time.strftime(DATETIME_FORMAT)
       func_args.update({'start_time': start_string})
     elif task_id:
       func_args.update({'task_id': task_id})
@@ -325,7 +326,7 @@ class TurbiniaClient(object):
         task['run_time'] = timedelta(seconds=task['run_time'])
       if task.get('last_update'):
         task['last_update'] = datetime.strptime(
-            task['last_update'], config.DATETIME_FORMAT)
+            task['last_update'], DATETIME_FORMAT)
 
     return task_data
 

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -126,7 +126,6 @@ class TurbiniaStats(object):
 
   def __init__(self, description=None):
     self.description = description
-    self.count = 0
     self.min = None
     self.mean = None
     self.max = None
@@ -135,6 +134,15 @@ class TurbiniaStats(object):
   def __str__(self):
     return self.format_stats()
 
+  @property
+  def count(self):
+    """Gets a count of the tasks in this stats object.
+
+    Returns:
+      Int of task count.
+    """
+    return len(self.tasks)
+
   def add_task(self, task):
     """Add a task result dict.
 
@@ -142,7 +150,6 @@ class TurbiniaStats(object):
       task(dict): The task results we want to count stats for.
     """
     self.tasks.append(task)
-    self.count += 1
 
   def calculate_stats(self):
     """Calculates statistics of the current tasks."""

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -111,6 +111,26 @@ def check_directory(directory):
           'Can not add write permissions to {0:s}'.format(directory))
 
 
+class TurbiniaStats(object):
+  """Statistics for Turbinia task execution.
+
+  Attributes:
+    type(str): Can be either 'count' or 'seconds'
+    count(
+  """
+  def __init__(self, description=None):
+    self.description = description
+    self.type = None
+    self.count = None
+    self.min = None
+    self.mean = None
+    self.max = None
+    self.tasks = []
+
+  def calculate_stats(self):
+    pass
+
+
 class TurbiniaClient(object):
   """Client class for Turbinia.
 
@@ -309,6 +329,67 @@ class TurbiniaClient(object):
         report.append(fmt.bullet(fmt.code(path), level=2))
       report.append('')
     return report
+
+  def get_task_statistics(
+      self, instance, project, region, days=0, task_id=None, request_id=None,
+      user=None):
+    """Gathers statistics for Turbinia execution data.
+
+    Args:
+      instance (string): The Turbinia instance name (by default the same as the
+          INSTANCE_ID in the config).
+      project (string): The name of the project.
+      region (string): The name of the zone to execute in.
+      days (int): The number of days we want history for.
+      task_id (string): The Id of the task.
+      request_id (string): The Id of the request we want tasks for.
+      user (string): The user of the request we want tasks for.
+
+    Returns:
+      task_stats(dict): Mapping of statistic names to values
+    """
+    task_results = self.get_task_data(
+        instance, project, region, days, task_id, request_id, user)
+    if not task_results:
+      return 'No tasks found'
+
+    task_stats = {
+        'all_tasks': TurbiniaStats(
+            'Total wall-time for all tasks to complete'),
+        'failed_tasks': TurbiniaStats(
+            'Total wall-time for failed tasks to complete'),
+        'successful_tasks': TurbiniaStats(
+            'Total wall-time for successful tasks to complete'),
+        'requests': TurbiniaStats(
+            'Total wall-time for all tasks in the request to complete'),
+        'users': TurbiniaStats(),
+        'workers': TurbiniaStats(),
+        'tasks_per_type': {},
+        'tasks_per_worker': {},
+        'tasks_per_user': {},
+    }
+
+
+
+  def format_task_statistics(self, task_stats):
+    """Formats statistics for Turbinia execution data.
+
+    Args:
+      task_stats(dict): Mapping of statistics to counts
+
+    Returns:
+      String of task statistics report
+    """
+    task_results = self.get_task_data(
+        instance, project, region, days, task_id, request_id, user)
+    if not task_results:
+      return 'No tasks found'
+
+    # Build up data
+    report = []
+
+
+    return '\n'.join(report)
 
   def format_task_status(
       self, instance, project, region, days=0, task_id=None, request_id=None,

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -154,6 +154,11 @@ class TurbiniaStats(object):
     self.max = sorted_tasks[len(sorted_tasks) - 1]['run_time']
     self.mean = sorted_tasks[len(sorted_tasks) // 2]['run_time']
 
+    # Remove the microseconds to keep things cleaner
+    self.min = self.min - timedelta(microseconds=self.min.microseconds)
+    self.max = self.max - timedelta(microseconds=self.max.microseconds)
+    self.mean = self.mean - timedelta(microseconds=self.mean.microseconds)
+
   def format_stats(self):
     """Formats statistics data.
 

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -32,7 +32,6 @@ from turbinia import task_manager
 from turbinia import TurbiniaException
 from turbinia.lib import text_formatter as fmt
 from turbinia.workers import Priority
-from turbinia.workers import TurbiniaTask
 from turbinia.workers.artifact import FileArtifactExtractionTask
 from turbinia.workers.analysis.wordpress import WordpressAccessLogAnalysisTask
 from turbinia.workers.analysis.jenkins import JenkinsAnalysisTask
@@ -151,7 +150,7 @@ class TurbiniaStats(object):
     sorted_tasks = sorted(self.tasks, key=itemgetter('run_time'))
     self.min = sorted_tasks[0]['run_time']
     self.max = sorted_tasks[len(sorted_tasks) - 1]['run_time']
-    self.mean = sorted_tasks[len(sorted_tasks) / 2]['run_time']
+    self.mean = sorted_tasks[len(sorted_tasks) // 2]['run_time']
 
   def format_stats(self):
     """Formats statistics data.

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -121,29 +121,28 @@ STATISTICS_REPORT = textwrap.dedent(
     Failed Tasks: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
     Total Request Time: Count: 2, Min: 0:03:00, Mean: 0:21:00, Max: 0:21:00
     Task type TaskName: Count: 1, Min: 0:01:00, Mean: 0:01:00, Max: 0:01:00
-    Task type TaskName3: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
     Task type TaskName2: Count: 1, Min: 0:05:00, Mean: 0:05:00, Max: 0:05:00
-    Worker fake_worker2: Count: 1, Min: 0:05:00, Mean: 0:05:00, Max: 0:05:00
+    Task type TaskName3: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
     Worker fake_worker: Count: 2, Min: 0:01:00, Mean: 0:03:00, Max: 0:03:00
-    User myuser2: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
+    Worker fake_worker2: Count: 1, Min: 0:05:00, Mean: 0:05:00, Max: 0:05:00
     User myuser: Count: 2, Min: 0:01:00, Mean: 0:05:00, Max: 0:05:00
+    User myuser2: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
 """)
 
 STATISTICS_REPORT_CSV = textwrap.dedent(
     """\
-    Execution time statistics for Turbinia:
-
+    stat_type, count, min, mean, max
     All Tasks, 3, 0:01:00, 0:03:00, 0:05:00
     Successful Tasks, 2, 0:01:00, 0:05:00, 0:05:00
     Failed Tasks, 1, 0:03:00, 0:03:00, 0:03:00
     Total Request Time, 2, 0:03:00, 0:21:00, 0:21:00
     Task type TaskName, 1, 0:01:00, 0:01:00, 0:01:00
-    Task type TaskName3, 1, 0:03:00, 0:03:00, 0:03:00
     Task type TaskName2, 1, 0:05:00, 0:05:00, 0:05:00
-    Worker fake_worker2, 1, 0:05:00, 0:05:00, 0:05:00
+    Task type TaskName3, 1, 0:03:00, 0:03:00, 0:03:00
     Worker fake_worker, 2, 0:01:00, 0:03:00, 0:03:00
-    User myuser2, 1, 0:03:00, 0:03:00, 0:03:00
+    Worker fake_worker2, 1, 0:05:00, 0:05:00, 0:05:00
     User myuser, 2, 0:01:00, 0:05:00, 0:05:00
+    User myuser2, 1, 0:03:00, 0:03:00, 0:03:00
 """)
 
 

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -302,7 +302,21 @@ class TestTurbiniaClient(unittest.TestCase):
   @mock.patch('turbinia.client.task_manager.PSQTaskManager._backend_setup')
   @mock.patch('turbinia.state_manager.get_state_manager')
   def testClientFormatTaskStatus(self, _, __, ___):
-    """Tests format_task_status() has valid output."""
+    """Tests format_task_status() with empty report_priority."""
+    client = TurbiniaClient()
+    client.get_task_data = mock.MagicMock()
+    self.task_data[0]['report_priority'] = None
+    self.task_data[1]['report_priority'] = ''
+    self.task_data[2].pop('report_priority')
+    client.get_task_data.return_value = self.task_data
+    result = client.format_task_status('inst', 'proj', 'reg')
+    self.assertIn('Processed 3 Tasks', result.strip())
+
+  @mock.patch('turbinia.client.GoogleCloudFunction.ExecuteFunction')
+  @mock.patch('turbinia.client.task_manager.PSQTaskManager._backend_setup')
+  @mock.patch('turbinia.state_manager.get_state_manager')
+  def testClientFormatTaskStatusShortReport(self, _, __, ___):
+    """Tests format_task_status() has valid output with short report."""
     client = TurbiniaClient()
     client.get_task_data = mock.MagicMock()
     client.get_task_data.return_value = self.task_data

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 from datetime import datetime
+from datetime import timedelta
 import unittest
 import os
 import shutil
@@ -28,6 +29,7 @@ import mock
 from turbinia import config
 from turbinia.client import TurbiniaClient
 from turbinia.client import TurbiniaServer
+from turbinia.client import TurbiniaStats
 from turbinia.client import TurbiniaPsqWorker
 from turbinia import TurbiniaException
 
@@ -58,7 +60,7 @@ LONG_REPORT = textwrap.dedent(
     ## TaskName2
     * **Status:** This second fake task executed
     * Task Id: 0xfakeTaskId2
-    * Executed on worker fake_worker
+    * Executed on worker fake_worker2
 
     ### Task Reported Data
     #### Fake High priority Report
@@ -83,7 +85,7 @@ LONG_REPORT_FILES = textwrap.dedent(
     ## TaskName2
     * **Status:** This second fake task executed
     * Task Id: 0xfakeTaskId2
-    * Executed on worker fake_worker
+    * Executed on worker fake_worker2
 
     ### Task Reported Data
     #### Fake High priority Report
@@ -110,20 +112,56 @@ LONG_REPORT_FILES = textwrap.dedent(
     * None
 """)
 
+STATISTICS_REPORT = textwrap.dedent(
+    """\
+    Execution time statistics for Turbinia:
+
+    All Tasks: Count: 3, Min: 0:01:00, Mean: 0:03:00, Max: 0:05:00
+    Successful Tasks: Count: 2, Min: 0:01:00, Mean: 0:05:00, Max: 0:05:00
+    Failed Tasks: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
+    Total Request Time: Count: 2, Min: 0:03:00, Mean: 0:21:00, Max: 0:21:00
+    Task type TaskName: Count: 1, Min: 0:01:00, Mean: 0:01:00, Max: 0:01:00
+    Task type TaskName3: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
+    Task type TaskName2: Count: 1, Min: 0:05:00, Mean: 0:05:00, Max: 0:05:00
+    Worker fake_worker2: Count: 1, Min: 0:05:00, Mean: 0:05:00, Max: 0:05:00
+    Worker fake_worker: Count: 2, Min: 0:01:00, Mean: 0:03:00, Max: 0:03:00
+    User myuser2: Count: 1, Min: 0:03:00, Mean: 0:03:00, Max: 0:03:00
+    User myuser: Count: 2, Min: 0:01:00, Mean: 0:05:00, Max: 0:05:00
+""")
+
+STATISTICS_REPORT_CSV = textwrap.dedent(
+    """\
+    Execution time statistics for Turbinia:
+
+    All Tasks, 3, 0:01:00, 0:03:00, 0:05:00
+    Successful Tasks, 2, 0:01:00, 0:05:00, 0:05:00
+    Failed Tasks, 1, 0:03:00, 0:03:00, 0:03:00
+    Total Request Time, 2, 0:03:00, 0:21:00, 0:21:00
+    Task type TaskName, 1, 0:01:00, 0:01:00, 0:01:00
+    Task type TaskName3, 1, 0:03:00, 0:03:00, 0:03:00
+    Task type TaskName2, 1, 0:05:00, 0:05:00, 0:05:00
+    Worker fake_worker2, 1, 0:05:00, 0:05:00, 0:05:00
+    Worker fake_worker, 2, 0:01:00, 0:03:00, 0:03:00
+    User myuser2, 1, 0:03:00, 0:03:00, 0:03:00
+    User myuser, 2, 0:01:00, 0:05:00, 0:05:00
+""")
+
 
 class TestTurbiniaClient(unittest.TestCase):
   """Test Turbinia client class."""
 
   def setUp(self):
+    last_update = datetime.now()
     self.task_data = [
         {
             'id': '0xfakeTaskId',
             'instance': 'MyTurbiniaInstance',
-            'last_update': datetime.now(),
+            'last_update': last_update,
             'name': 'TaskName',
             'report_data': '#### Fake Low priority Report\n* Fake Bullet',
             'report_priority': 80,
             'request_id': '0xFakeRequestId',
+            'run_time': timedelta(minutes=1),
             'saved_paths': ['/no/path/', '/fake/path'],
             'status': 'This fake task executed',
             'successful': True,
@@ -132,28 +170,30 @@ class TestTurbiniaClient(unittest.TestCase):
         }, {
             'id': '0xfakeTaskId2',
             'instance': 'MyTurbiniaInstance',
-            'last_update': datetime.now(),
+            'last_update': last_update + timedelta(minutes=20),
             'name': 'TaskName2',
             'report_data': '#### Fake High priority Report\n* Fake Bullet',
             'report_priority': 10,
             'request_id': '0xFakeRequestId',
+            'run_time': timedelta(minutes=5),
             'saved_paths': ['/no/path/2', '/fake/path/2'],
             'status': 'This second fake task executed',
             'successful': True,
             'requester': 'myuser',
-            'worker_name': 'fake_worker'
+            'worker_name': 'fake_worker2'
         }, {
             'id': '0xfakeTaskId3',
             'instance': 'MyTurbiniaInstance',
-            'last_update': datetime.now(),
+            'last_update': last_update,
             'name': 'TaskName3',
             'report_data': '',
             'report_priority': 80,
-            'request_id': '0xFakeRequestId',
+            'request_id': '0xFakeRequestId2',
+            'run_time': timedelta(minutes=3),
             'saved_paths': ['/no/path/3', '/fake/path/3'],
             'status': 'Third Task Failed...',
             'successful': False,
-            'requester': 'myuser',
+            'requester': 'myuser2',
             'worker_name': 'fake_worker'
         }
     ] # yapf: disable
@@ -203,16 +243,60 @@ class TestTurbiniaClient(unittest.TestCase):
   @mock.patch('turbinia.client.GoogleCloudFunction.ExecuteFunction')
   @mock.patch('turbinia.client.task_manager.PSQTaskManager._backend_setup')
   @mock.patch('turbinia.state_manager.get_state_manager')
-  def testClientFormatTaskStatus(self, _, __, ___):
-    """Tests format_task_status() with empty report_priority."""
+  def testClientFormatTaskStatistics(self, _, __, ___):
+    """Tests format_task_statistics() report output."""
     client = TurbiniaClient()
     client.get_task_data = mock.MagicMock()
-    self.task_data[0]['report_priority'] = None
-    self.task_data[1]['report_priority'] = ''
-    self.task_data[2].pop('report_priority')
     client.get_task_data.return_value = self.task_data
-    result = client.format_task_status('inst', 'proj', 'reg')
-    self.assertIn('Processed 3 Tasks', result.strip())
+    stats_report = client.format_task_statistics('inst', 'proj', 'reg')
+    self.maxDiff = None
+    self.assertEqual(stats_report, STATISTICS_REPORT)
+
+  @mock.patch('turbinia.client.GoogleCloudFunction.ExecuteFunction')
+  @mock.patch('turbinia.client.task_manager.PSQTaskManager._backend_setup')
+  @mock.patch('turbinia.state_manager.get_state_manager')
+  def testClientFormatTaskStatisticsCsv(self, _, __, ___):
+    """Tests format_task_statistics() CSV report output."""
+    client = TurbiniaClient()
+    client.get_task_data = mock.MagicMock()
+    client.get_task_data.return_value = self.task_data
+    stats_report = client.format_task_statistics(
+        'inst', 'proj', 'reg', csv=True)
+    self.maxDiff = None
+    self.assertEqual(stats_report, STATISTICS_REPORT_CSV)
+
+  @mock.patch('turbinia.client.GoogleCloudFunction.ExecuteFunction')
+  @mock.patch('turbinia.client.task_manager.PSQTaskManager._backend_setup')
+  @mock.patch('turbinia.state_manager.get_state_manager')
+  def testClientGetTaskStatistics(self, _, __, ___):
+    """Tests get_task_statistics() basic functionality."""
+    client = TurbiniaClient()
+    client.get_task_data = mock.MagicMock()
+    client.get_task_data.return_value = self.task_data
+    task_stats = client.get_task_statistics('inst', 'proj', 'reg')
+
+    # Make sure we have the right number of tasks for all sections
+    self.assertEqual(task_stats['all_tasks'].count, 3)
+    self.assertEqual(task_stats['successful_tasks'].count, 2)
+    self.assertEqual(task_stats['failed_tasks'].count, 1)
+    self.assertEqual(task_stats['requests'].count, 2)
+    self.assertEqual(len(task_stats['tasks_per_user']), 2)
+    self.assertEqual(len(task_stats['tasks_per_worker']), 2)
+    self.assertEqual(len(task_stats['tasks_per_type']), 3)
+
+    # Checking min/mean/max
+    self.assertEqual(task_stats['all_tasks'].min, timedelta(minutes=1))
+    self.assertEqual(task_stats['all_tasks'].mean, timedelta(minutes=3))
+    self.assertEqual(task_stats['all_tasks'].max, timedelta(minutes=5))
+    # This is because the last_update for 0xfakeTaskId2 is 20 minutes later than
+    # the first task, and the first task ran for 1 minute.
+    self.assertEqual(task_stats['requests'].max, timedelta(minutes=21))
+    self.assertEqual(
+        task_stats['tasks_per_user']['myuser'].max, timedelta(minutes=5))
+    self.assertEqual(
+        task_stats['tasks_per_worker']['fake_worker'].max, timedelta(minutes=3))
+    self.assertEqual(
+        task_stats['tasks_per_type']['TaskName2'].mean, timedelta(minutes=5))
 
   @mock.patch('turbinia.client.GoogleCloudFunction.ExecuteFunction')
   @mock.patch('turbinia.client.task_manager.PSQTaskManager._backend_setup')
@@ -247,6 +331,75 @@ class TestTurbiniaClient(unittest.TestCase):
     result = client.format_task_status(
         'inst', 'proj', 'reg', all_fields=True, full_report=True)
     self.assertEqual(result.strip(), LONG_REPORT_FILES.strip())
+
+
+class TestTurbiniaStats(unittest.TestCase):
+  """Test TurbiniaStats class."""
+
+  def testTurbiniaStatsAddTask(self):
+    """Tests TurbiniaStats.add_task() method."""
+    test_task = {'run_time': None, 'last_update': None}
+    stats = TurbiniaStats()
+    stats.add_task(test_task)
+    self.assertIn(test_task, stats.tasks)
+    self.assertEqual(stats.count, 1)
+
+  def testTurbiniaStatsCalculateStats(self):
+    """Tests TurbiniaStats.calculateStats() method."""
+    test_task1 = {'run_time': None, 'last_update': None}
+    test_task2 = {'run_time': None, 'last_update': None}
+    test_task3 = {'run_time': None, 'last_update': None}
+    test_task1['last_update'] = datetime.now()
+    test_task1['run_time'] = timedelta(minutes=3)
+    test_task2['last_update'] = test_task1['last_update']
+    test_task2['run_time'] = timedelta(minutes=5)
+    test_task3['last_update'] = test_task1['last_update']
+    test_task3['run_time'] = timedelta(minutes=1)
+    stats = TurbiniaStats()
+    stats.add_task(test_task1)
+    stats.add_task(test_task2)
+    stats.add_task(test_task3)
+    stats.calculate_stats()
+
+    self.assertEqual(stats.min, timedelta(minutes=1))
+    self.assertEqual(stats.mean, timedelta(minutes=3))
+    self.assertEqual(stats.max, timedelta(minutes=5))
+    self.assertEqual(stats.count, 3)
+
+  def testTurbiniaStatsCalculateStatsEmpty(self):
+    """Tests that calculate_stats() works when no tasks are added."""
+    stats = TurbiniaStats()
+    stats.calculate_stats()
+    self.assertEqual(stats.count, 0)
+    self.assertEqual(stats.min, None)
+
+  def testTurbiniaStatsFormatStats(self):
+    """Tests TurbiniaStats.format_stats() returns valid output."""
+    test_output = (
+        'Test Task Results: Count: 1, Min: 0:03:00, Mean: 0:03:00, '
+        'Max: 0:03:00')
+    test_task1 = {
+        'run_time': timedelta(minutes=3),
+        'last_update': datetime.now()
+    }
+    stats = TurbiniaStats('Test Task Results')
+    stats.add_task(test_task1)
+    stats.calculate_stats()
+    report = stats.format_stats()
+    self.assertEqual(report, test_output)
+
+  def testTurbiniaStatsFormatStatsCsv(self):
+    """Tests TurbiniaStats.format_stats() returns valid CSV output."""
+    test_output = ('Test Task Results, 1, 0:03:00, 0:03:00, 0:03:00')
+    test_task1 = {
+        'run_time': timedelta(minutes=3),
+        'last_update': datetime.now()
+    }
+    stats = TurbiniaStats('Test Task Results')
+    stats.add_task(test_task1)
+    stats.calculate_stats()
+    report = stats.format_stats_csv()
+    self.assertEqual(report, test_output)
 
 
 class TestTurbiniaServer(unittest.TestCase):

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -359,15 +359,11 @@ class TestTurbiniaStats(unittest.TestCase):
 
   def testTurbiniaStatsCalculateStats(self):
     """Tests TurbiniaStats.calculateStats() method."""
-    test_task1 = {'run_time': None, 'last_update': None}
-    test_task2 = {'run_time': None, 'last_update': None}
-    test_task3 = {'run_time': None, 'last_update': None}
-    test_task1['last_update'] = datetime.now()
-    test_task1['run_time'] = timedelta(minutes=3)
-    test_task2['last_update'] = test_task1['last_update']
-    test_task2['run_time'] = timedelta(minutes=5)
-    test_task3['last_update'] = test_task1['last_update']
-    test_task3['run_time'] = timedelta(minutes=1)
+    last_update = datetime.now()
+    test_task1 = {'run_time': timedelta(minutes=3), 'last_update': last_update}
+    test_task2 = {'run_time': timedelta(minutes=5), 'last_update': last_update}
+    test_task3 = {'run_time': timedelta(minutes=1), 'last_update': last_update}
+
     stats = TurbiniaStats()
     stats.add_task(test_task1)
     stats.add_task(test_task2)

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -297,8 +297,8 @@ class TestTurbiniaClient(unittest.TestCase):
     self.assertEqual(task_stats['all_tasks'].min, timedelta(minutes=1))
     self.assertEqual(task_stats['all_tasks'].mean, timedelta(minutes=3))
     self.assertEqual(task_stats['all_tasks'].max, timedelta(minutes=5))
-    # This is because the last_update for 0xfakeTaskId2 is 20 minutes later than
-    # the first task, and the first task ran for 1 minute.
+    # Delta for this is 21 minutes because the last_update for 0xfakeTaskId2 is
+    # 20 minutes later than the first task, and the first task ran for 1 minute.
     self.assertEqual(task_stats['requests'].max, timedelta(minutes=21))
     self.assertEqual(
         task_stats['tasks_per_user']['myuser'].max, timedelta(minutes=5))

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -22,7 +22,7 @@ import logging
 import os
 import sys
 
-log = logging.getLogger('turbinia')
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 
 # Look for config files with these names
 CONFIGFILES = ['.turbiniarc', 'turbinia.conf', 'turbinia_config.py']
@@ -79,6 +79,8 @@ OPTIONAL_VARS = [
 ENVCONFIGVAR = 'TURBINIA_CONFIG_PATH'
 
 CONFIG = None
+
+log = logging.getLogger('turbinia')
 
 
 class TurbiniaConfigException(Exception):

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -22,7 +22,7 @@ import logging
 import os
 import sys
 
-DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
 # Look for config files with these names
 CONFIGFILES = ['.turbiniarc', 'turbinia.conf', 'turbinia_config.py']

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -44,7 +44,6 @@ else:
       config.STATE_MANAGER)
   raise TurbiniaException(msg)
 
-DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 MAX_DATASTORE_STRLEN = 1500
 log = logging.getLogger('turbinia')
 
@@ -242,7 +241,7 @@ class RedisStateManager(BaseStateManager):
     for task in tasks:
       if task.get('last_update'):
         task['last_update'] = datetime.strptime(
-            task.get('last_update'), DATETIME_FORMAT)
+            task.get('last_update'), config.DATETIME_FORMAT)
       if task.get('run_time'):
         task['run_time'] = datetime.timedelta(seconds=task['run_time'])
 
@@ -265,7 +264,7 @@ class RedisStateManager(BaseStateManager):
     log.info('Updating task {0:s} in Redis'.format(task.name))
     task_data = self.get_task_dict(task)
     task_data['last_update'] = task_data['last_update'].strftime(
-        DATETIME_FORMAT)
+        config.DATETIME_FORMAT)
     if task_data['run_time']:
       task_data['run_time'] = task_data['run_time'].total_seconds()
     # Need to use json.dumps, else redis returns single quoted string which
@@ -279,7 +278,7 @@ class RedisStateManager(BaseStateManager):
     log.info('Writing new task {0:s} into Redis'.format(task.name))
     task_data = self.get_task_dict(task)
     task_data['last_update'] = task_data['last_update'].strftime(
-        DATETIME_FORMAT)
+        config.DATETIME_FORMAT)
     if task_data['run_time']:
       task_data['run_time'] = task_data['run_time'].total_seconds()
     # nx=True prevents overwriting (i.e. no unintentional task clobbering)

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -289,6 +289,10 @@ def main():
       '-c', '--close_tasks', action='store_true',
       help='Close tasks based on Request ID or Task ID', required=False)
   parser_status.add_argument(
+      '-C', '--csv', action='store_true',
+      help='When used with --statistics, the output will be in CSV format',
+      required=False)
+  parser_status.add_argument(
       '-d', '--days_history', default=0, type=int,
       help='Number of days of history to show', required=False)
   parser_status.add_argument(
@@ -308,6 +312,9 @@ def main():
   parser_status.add_argument(
       '-R', '--full_report',
       help='Generate full markdown report instead of just a summary',
+      action='store_true', required=False)
+  parser_status.add_argument(
+      '-s', '--statistics', help='Generate statistics only',
       action='store_true', required=False)
   parser_status.add_argument(
       '-t', '--task_id', help='Show task for given Task ID', required=False)
@@ -464,6 +471,14 @@ def main():
             '--close_tasks (-c) requires --user, --request_id, or/and --task_id'
         )
         sys.exit(1)
+
+    if args.statistics:
+      print(
+          client.format_task_statistics(
+              instance=config.INSTANCE_ID, project=config.TURBINIA_PROJECT,
+              region=region, days=args.days_history, task_id=args.task_id,
+              request_id=args.request_id, user=args.user, csv=args.csv))
+      sys.exit(0)
 
     if args.wait and args.request_id:
       client.wait_for_request(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -39,7 +39,6 @@ from turbinia.evidence import evidence_decode
 from turbinia import output_manager
 from turbinia import TurbiniaException
 
-
 log = logging.getLogger('turbinia')
 
 
@@ -268,7 +267,7 @@ class TurbiniaTaskResult(object):
       dict: Object dictionary that is JSON serializable.
     """
     self.run_time = self.run_time.total_seconds() if self.run_time else None
-    self.start_time = str(self.start_time)
+    self.start_time = self.start_time.strftime(DATETIME_FORMAT)
     if self.input_evidence:
       self.input_evidence = self.input_evidence.serialize()
     self.evidence = [x.serialize() for x in self.evidence]
@@ -288,8 +287,7 @@ class TurbiniaTaskResult(object):
     result.__dict__.update(input_dict)
     if result.run_time:
       result.run_time = timedelta(seconds=result.run_time)
-    result.start_time = datetime.strptime(
-        result.start_time, DATETIME_FORMAT)
+    result.start_time = datetime.strptime(result.start_time, DATETIME_FORMAT)
     if result.input_evidence:
       result.input_evidence = evidence_decode(result.input_evidence)
     result.evidence = [evidence_decode(x) for x in result.evidence]
@@ -356,7 +354,7 @@ class TurbiniaTask(object):
     """
     task_copy = deepcopy(self.__dict__)
     task_copy['output_manager'] = self.output_manager.__dict__
-    task_copy['last_update'] = str(self.last_update)
+    task_copy['last_update'] = self.last_update.strftime(DATETIME_FORMAT)
     return task_copy
 
   @classmethod

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -38,6 +38,7 @@ from turbinia.evidence import evidence_decode
 from turbinia import output_manager
 from turbinia import TurbiniaException
 
+
 log = logging.getLogger('turbinia')
 
 
@@ -287,7 +288,7 @@ class TurbiniaTaskResult(object):
     if result.run_time:
       result.run_time = timedelta(seconds=result.run_time)
     result.start_time = datetime.strptime(
-        result.start_time, '%Y-%m-%d %H:%M:%S.%f')
+        result.start_time, config.DATETIME_FORMAT)
     if result.input_evidence:
       result.input_evidence = evidence_decode(result.input_evidence)
     result.evidence = [evidence_decode(x) for x in result.evidence]
@@ -382,7 +383,7 @@ class TurbiniaTask(object):
     task.output_manager = output_manager.OutputManager()
     task.output_manager.__dict__.update(input_dict['output_manager'])
     task.last_update = datetime.strptime(
-        input_dict['last_update'], '%Y-%m-%d %H:%M:%S.%f')
+        input_dict['last_update'], config.DATETIME_FORMAT)
     return task
 
   def execute(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -34,6 +34,7 @@ import turbinia
 import filelock
 
 from turbinia import config
+from turbinia.config import DATETIME_FORMAT
 from turbinia.evidence import evidence_decode
 from turbinia import output_manager
 from turbinia import TurbiniaException
@@ -288,7 +289,7 @@ class TurbiniaTaskResult(object):
     if result.run_time:
       result.run_time = timedelta(seconds=result.run_time)
     result.start_time = datetime.strptime(
-        result.start_time, config.DATETIME_FORMAT)
+        result.start_time, DATETIME_FORMAT)
     if result.input_evidence:
       result.input_evidence = evidence_decode(result.input_evidence)
     result.evidence = [evidence_decode(x) for x in result.evidence]
@@ -383,7 +384,7 @@ class TurbiniaTask(object):
     task.output_manager = output_manager.OutputManager()
     task.output_manager.__dict__.update(input_dict['output_manager'])
     task.last_update = datetime.strptime(
-        input_dict['last_update'], config.DATETIME_FORMAT)
+        input_dict['last_update'], DATETIME_FORMAT)
     return task
 
   def execute(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -82,8 +82,8 @@ class TurbiniaTaskResult(object):
 
   # The list of attributes that we will persist into storage
   STORED_ATTRIBUTES = [
-      'worker_name', 'report_data', 'report_priority', 'status', 'saved_paths',
-      'successful'
+      'worker_name', 'report_data', 'report_priority', 'run_time', 'status',
+      'saved_paths', 'successful'
   ]
 
   def __init__(
@@ -330,6 +330,7 @@ class TurbiniaTask(object):
       self.base_output_dir = base_output_dir
     else:
       self.base_output_dir = config.OUTPUT_DIR
+
     self.id = uuid.uuid4().hex
     self.last_update = datetime.now()
     self.name = name if name else self.__class__.__name__


### PR DESCRIPTION
- Adds run_time attribute of Task to be stored in Datastore/Redis
- Also convert all date formatting to use same format
- Also deserializes date output from datastore/redis

Regular stats output looks like:
```
Execution time statistics for Turbinia:

All Tasks: Count: 13, Min: 0:00:00, Mean: 0:00:09, Max: 0:01:36
Successful Tasks: Count: 10, Min: 0:00:01, Mean: 0:00:10, Max: 0:01:36
Failed Tasks: Count: 3, Min: 0:00:00, Mean: 0:00:00, Max: 0:00:08
Total Request Time: Count: 1, Min: 0:02:54, Mean: 0:02:54, Max: 0:02:54
Task type FileArtifactExtractionTask: Count: 5, Min: 0:00:09, Mean: 0:00:09, Max: 0:00:10
Task type GrepTask: Count: 2, Min: 0:00:00, Mean: 0:00:00, Max: 0:00:00
Task type HadoopAnalysisTask: Count: 1, Min: 0:00:10, Mean: 0:00:10, Max: 0:00:10
Task type JenkinsAnalysisTask: Count: 1, Min: 0:00:08, Mean: 0:00:08, Max: 0:00:08
Task type PlasoTask: Count: 1, Min: 0:00:18, Mean: 0:00:18, Max: 0:00:18
Task type PsortTask: Count: 1, Min: 0:00:01, Mean: 0:00:01, Max: 0:00:01
Task type StringsAsciiTask: Count: 1, Min: 0:01:36, Mean: 0:01:36, Max: 0:01:36
Task type StringsUnicodeTask: Count: 1, Min: 0:01:33, Mean: 0:01:33, Max: 0:01:33
Worker turbinia-instance-group-4-2345: Count: 6, Min: 0:00:00, Mean: 0:00:10, Max: 0:01:36
Worker turbinia-instance-group-4-1234: Count: 7, Min: 0:00:00, Mean: 0:00:09, Max: 0:01:33
User aaronp: Count: 13, Min: 0:00:00, Mean: 0:00:09, Max: 0:01:36
```

And CSV stats output looks like
```
stat_type, count, min, mean, max
All Tasks, 13, 0:00:00, 0:00:09, 0:01:36
Successful Tasks, 10, 0:00:01, 0:00:10, 0:01:36
Failed Tasks, 3, 0:00:00, 0:00:00, 0:00:08
Total Request Time, 1, 0:02:54, 0:02:54, 0:02:54
Task type FileArtifactExtractionTask, 5, 0:00:09, 0:00:09, 0:00:10
Task type GrepTask, 2, 0:00:00, 0:00:00, 0:00:00
Task type HadoopAnalysisTask, 1, 0:00:10, 0:00:10, 0:00:10
Task type JenkinsAnalysisTask, 1, 0:00:08, 0:00:08, 0:00:08
Task type PlasoTask, 1, 0:00:18, 0:00:18, 0:00:18
Task type PsortTask, 1, 0:00:01, 0:00:01, 0:00:01
Task type StringsAsciiTask, 1, 0:01:36, 0:01:36, 0:01:36
Task type StringsUnicodeTask, 1, 0:01:33, 0:01:33, 0:01:33
Worker turbinia-instance-group-4-1234, 6, 0:00:00, 0:00:10, 0:01:36
Worker turbinia-instance-group-4-2345, 7, 0:00:00, 0:00:09, 0:01:33
User aaronp, 13, 0:00:00, 0:00:09, 0:01:36
```