### PR TITLE
Remove warnings and set project explicitly

### DIFF
--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -120,7 +120,7 @@ def LoadConfig():
 
   # Set the environment var for this so that we don't see the "No project ID
   # could be determined." warning later.
-  if hasattr(_config, 'TURBINIA_PROJECT'):
+  if hasattr(_config, 'TURBINIA_PROJECT') and _config.TURBINIA_PROJECT:
     os.environ['GOOGLE_CLOUD_PROJECT'] = _config.TURBINIA_PROJECT
 
   CONFIG = _config

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -117,6 +117,12 @@ def LoadConfig():
   _config = imp.load_source('config', config_file)
   _config.configSource = config_file
   ValidateAndSetConfig(_config)
+
+  # Set the environment var for this so that we don't see the "No project ID
+  # could be determined." warning later.
+  if hasattr(_config, 'TURBINIA_PROJECT'):
+    os.environ['GOOGLE_CLOUD_PROJECT'] = _config.TURBINIA_PROJECT
+
   CONFIG = _config
   return _config
 

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -16,6 +16,7 @@
 
 from __future__ import unicode_literals
 import logging
+import warnings
 
 from turbinia import config
 
@@ -28,6 +29,10 @@ def setup():
   however some external modules that are called by Turbinia can use the root
   logger, so we want to be able to optionally configure that as well.
   """
+  # Remove known warning about credentials
+  warnings.filterwarnings(
+      'ignore', 'Your application has authenticated using end user credentials')
+
   # TODO(aarontp): Add a config option to set the log level
   config.LoadConfig()
   logger = logging.getLogger('turbinia')


### PR DESCRIPTION
This cleans up the following annoying warnings:

[WARNING] No project ID could be determined. Consider running `gcloud config set project` or setting the GOOGLE_CLOUD_PROJECT environment variable


UserWarning: Your application has authenticated using end user credentials from Google Cloud SDK. We recommend that most server applications use service accounts instead. If your application continues to use end user credentials from Cloud SDK, you might receive a "quota exceeded" or "API not enabled" error. For more information about service accounts, see https://cloud.google.com/docs/authentication/warnings.warn(_CLOUD_SDK_CREDENTIALS_WARNING)