### PR TITLE
Set project/zone defaults and add config file flag

### DIFF
--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -21,7 +21,7 @@ import warnings
 from turbinia import config
 
 
-def setup():
+def setup(need_file_handler=True, need_stream_handler=True):
   """Set up logging parameters.
 
   This will also set the root logger, which is the default logger when a named
@@ -33,13 +33,9 @@ def setup():
   warnings.filterwarnings(
       'ignore', 'Your application has authenticated using end user credentials')
 
-  # TODO(aarontp): Add a config option to set the log level
-  config.LoadConfig()
   logger = logging.getLogger('turbinia')
   # Eliminate double logging from root logger
   logger.propagate = False
-  need_file_handler = True
-  need_stream_handler = True
 
   # We only need a handler if one of that type doesn't exist already
   if logger.handlers:
@@ -55,11 +51,12 @@ def setup():
       if type(handler) == logging.StreamHandler:
         need_stream_handler = False
 
-  file_handler = logging.FileHandler(config.LOG_FILE)
-  formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
-  file_handler.setFormatter(formatter)
-  file_handler.setLevel(logging.DEBUG)
   if need_file_handler:
+    config.LoadConfig()
+    file_handler = logging.FileHandler(config.LOG_FILE)
+    formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
+    file_handler.setFormatter(formatter)
+    file_handler.setLevel(logging.DEBUG)
     logger.addHandler(file_handler)
 
   console_handler = logging.StreamHandler()
@@ -75,4 +72,5 @@ def setup():
   for handler in root_log.handlers:
     root_log.removeHandler(handler)
   root_log.addHandler(console_handler)
-  root_log.addHandler(file_handler)
+  if need_file_handler:
+    root_log.addHandler(file_handler)

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -25,20 +25,12 @@ import logging
 import os
 import sys
 
-from turbinia.client import TurbiniaClient
-from turbinia.client import TurbiniaCeleryClient
-from turbinia.client import TurbiniaServer
-from turbinia.client import TurbiniaCeleryWorker
-from turbinia.client import TurbiniaPsqWorker
 from turbinia import config
 from turbinia.config import logger
-from turbinia import evidence
 from turbinia import __version__
-from turbinia.message import TurbiniaRequest
-from turbinia.workers import Priority
 
 log = logging.getLogger('turbinia')
-logger.setup()
+logger.setup(need_file_handler=False)
 
 
 def csv_list(string):
@@ -70,6 +62,11 @@ def main():
   parser.add_argument(
       '-a', '--all_fields', action='store_true',
       help='Show all task status fields in output', required=False)
+  parser.add_argument(
+      '-c', '--config_file', help='Load explicit config file. If specified it '
+      'will ignore config files in other default locations '
+      '(/etc/turbinia.conf, ~/.turbiniarc, or in paths referenced in '
+      'environment variable TURBINIA_CONFIG_PATH)', required=False)
   parser.add_argument(
       '-f', '--force_evidence', action='store_true',
       help='Force evidence processing request in potentially unsafe conditions',
@@ -192,15 +189,14 @@ def main():
   parser_googleclouddisk.add_argument(
       '-d', '--disk_name', help='Google Cloud name for disk', required=True)
   parser_googleclouddisk.add_argument(
-      '-p', '--project', help='Project that the disk is associated with',
-      required=True)
+      '-p', '--project', help='Project that the disk is associated with')
   parser_googleclouddisk.add_argument(
       '-P', '--mount_partition', default=0, type=int,
       help='The partition number to use when mounting this disk.  Defaults to '
       'the entire raw disk.  Only affects mounting, and not what gets '
       'processed.')
   parser_googleclouddisk.add_argument(
-      '-z', '--zone', help='Geographic zone the disk exists in', required=True)
+      '-z', '--zone', help='Geographic zone the disk exists in')
   parser_googleclouddisk.add_argument(
       '-s', '--source', help='Description of the source of the evidence',
       required=False)
@@ -219,15 +215,14 @@ def main():
   parser_googleclouddiskembedded.add_argument(
       '-d', '--disk_name', help='Google Cloud name for disk', required=True)
   parser_googleclouddiskembedded.add_argument(
-      '-p', '--project', help='Project that the disk is associated with',
-      required=True)
+      '-p', '--project', help='Project that the disk is associated with')
   parser_googleclouddiskembedded.add_argument(
       '-P', '--mount_partition', default=0, type=int,
       help='The partition number to use when mounting this disk.  Defaults to '
       'the entire raw disk.  Only affects mounting, and not what gets '
       'processed.')
   parser_googleclouddiskembedded.add_argument(
-      '-z', '--zone', help='Geographic zone the disk exists in', required=True)
+      '-z', '--zone', help='Geographic zone the disk exists in')
   parser_googleclouddiskembedded.add_argument(
       '-s', '--source', help='Description of the source of the evidence',
       required=False)
@@ -306,8 +301,10 @@ def main():
   parser_status.add_argument(
       '-r', '--request_id', help='Show tasks with this Request ID',
       required=False)
+  # 20 == Priority.High, but we don't want to load the worker module to grab
+  # this yet.
   parser_status.add_argument(
-      '-p', '--priority_filter', default=Priority.HIGH, type=int,
+      '-p', '--priority_filter', default=20, type=int,
       required=False,
       help='This sets what report sections are shown in full detail in '
       'report output.  Any tasks that have set a report_priority value '
@@ -330,6 +327,20 @@ def main():
   subparsers.add_parser('server', help='Run Turbinia Server')
 
   args = parser.parse_args()
+
+  # Load config before logger setup so that we can find the log file.
+  if args.config_file:
+    config.LoadConfig(config_file=args.config_file)
+  else:
+    config.LoadConfig()
+  if args.log_file:
+    config.LOG_FILE = args.log_file
+  if args.output_dir:
+    config.OUTPUT_DIR = args.output_dir
+
+  # Run logger setup again to get file-handler now that we have the logfile path
+  # from the config.
+  logger.setup()
   if args.quiet:
     log.setLevel(logging.ERROR)
   elif args.debug:
@@ -339,28 +350,21 @@ def main():
 
   log.info('Turbinia version: {0:s}'.format(__version__))
 
-  if args.jobs_whitelist and args.jobs_blacklist:
-    log.error(
-        'A Job filter whitelist and blacklist cannot be specified at the same '
-        'time')
-    sys.exit(1)
+  # Do late import of other needed Turbinia modules.  This needed so that the
+  # config loaded by these modules can be loaded after we parse the args so
+  # that we can use config variables to point to log files and such.
+  from turbinia.client import TurbiniaClient
+  from turbinia.client import TurbiniaCeleryClient
+  from turbinia.client import TurbiniaServer
+  from turbinia.client import TurbiniaCeleryWorker
+  from turbinia.client import TurbiniaPsqWorker
+  from turbinia import evidence
+  from turbinia.message import TurbiniaRequest
 
-  filter_patterns = None
-  if (args.filter_patterns_file and
-      not os.path.exists(args.filter_patterns_file)):
-    log.error('Filter patterns file {0:s} does not exist.')
-    sys.exit(1)
-  elif args.filter_patterns_file:
-    try:
-      filter_patterns = open(args.filter_patterns_file).read().splitlines()
-    except IOError as e:
-      log.warning(
-          'Cannot open file {0:s} [{1!s}]'.format(args.filter_patterns_file, e))
-
-  config.LoadConfig()
+  # Print out config if requested
   if args.command == 'config':
-    print('Config file path is {0:s}\n'.format(config.configSource))
     if args.file_only:
+      log.info('Config file path is {0:s}\n'.format(config.configSource))
       sys.exit(0)
 
     try:
@@ -373,7 +377,26 @@ def main():
               config.configSource, exception))
       sys.exit(1)
 
-  # Client
+  if args.jobs_whitelist and args.jobs_blacklist:
+    log.error(
+        'A Job filter whitelist and blacklist cannot be specified at the same '
+        'time')
+    sys.exit(1)
+
+  # Read set set filter_patterns
+  filter_patterns = None
+  if (args.filter_patterns_file and
+      not os.path.exists(args.filter_patterns_file)):
+    log.error('Filter patterns file {0:s} does not exist.')
+    sys.exit(1)
+  elif args.filter_patterns_file:
+    try:
+      filter_patterns = open(args.filter_patterns_file).read().splitlines()
+    except IOError as e:
+      log.warning(
+          'Cannot open file {0:s} [{1!s}]'.format(args.filter_patterns_file, e))
+
+  # Create Client object
   if args.command not in ('psqworker', 'server'):
     if config.TASK_MANAGER.lower() == 'celery':
       client = TurbiniaCeleryClient()
@@ -384,6 +407,7 @@ def main():
   else:
     client = None
 
+  # Make sure run_local flags aren't conflicting with other server/client flags
   server_flags_set = args.server or args.command == 'server'
   worker_flags_set = args.command in ('psqworker', 'celeryworker')
   if args.run_local and (server_flags_set or worker_flags_set):
@@ -394,11 +418,21 @@ def main():
     log.error('--run_local flag requires --task flag')
     sys.exit(1)
 
-  if args.output_dir:
-    config.OUTPUT_DIR = args.output_dir
-  if args.log_file:
-    config.LOG_FILE = args.log_file
+  # Set zone/project to defaults if flags are not set
+  if args.command in ('googleclouddisk', 'googleclouddiskrawembedded'):
+    if not args.zone and config.TURBINIA_ZONE:
+      args.zone = config.TURBINIA_ZONE
+    elif not args.zone and not config.TURBINIA_ZONE:
+      log.error('Turbinia Zone must be set by --zone or in config')
+      sys.exit(1)
 
+    if not args.project and config.TURBINIA_PROJECT:
+      args.project = config.TURBINIA_PROJECT
+    elif not args.project and not config.TURBINIA_PROJECT:
+      log.error('Turbinia project must be set by --project or in config')
+      sys.exit(1)
+
+  # Start Evidence configuration
   evidence_ = None
   is_cloud_disk = False
   if args.command == 'rawdisk':


### PR DESCRIPTION
This sets the `turbiniactl googleclouddisk --zone --project` flags to what ever is in the config file.  It also allows us to load a specific configuration file via a command line flag.

It ended up being a much larger change than I anticipated, but on the good side this ended up fixing an unrelated bug (#118).   It feels a little bit hacky though because it moves many of the Turbinia imports down into main.  This is because we wanted to delay loading of the config until after the arguments are parsed (so we know where to load the config from), and loading the modules causes this implicitly due to the way the config module makes sure it gets loaded before use.