### PR TITLE
Fix saving files on local instances

### DIFF
--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -350,18 +350,20 @@ class LocalOutputWriter(OutputWriter):
     if self.local_output_dir in os.path.commonprefix([file_path,
                                                       destination_file]):
       log.debug(
-          'Not copying file {0:s} in output dir {1:s}'.format(
+          'Not copying source file {0:s} already in output dir {1:s}'.format(
               file_path, self.local_output_dir))
       return None
     if not os.path.exists(file_path):
-      log.warning('File [{0:s}] does not exist.'.format(file_path))
+      log.warning('Source file [{0:s}] does not exist.'.format(file_path))
       return None
     if os.path.exists(destination_file):
       log.warning(
-          'New file path [{0:s}] already exists.'.format(destination_file))
+          'Target output file path [{0:s}] already exists.'.format(
+              destination_file))
       return None
 
     shutil.copy(file_path, destination_file)
+    log.debug('Copied file {0:s} to {1:s}'.format(file_path, destination_file))
     return destination_file
 
   def copy_to(self, source_file):

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -194,10 +194,15 @@ class OutputManager(object):
     local_path = None
     for writer in self._output_writers:
       new_path = writer.copy_to(file_)
-      if new_path and result:
-        result.saved_paths.append(new_path)
-        saved_path = new_path
-        saved_path_type = writer.name
+      if result:
+        if new_path:
+          result.saved_paths.append(new_path)
+          saved_path = new_path
+          saved_path_type = writer.name
+        elif os.path.exists(file_) and os.path.getsize(file_) > 0:
+          # We want to save the old path if the path is still valid.
+          result.saved_paths.append(file_)
+
       if writer.name == LocalOutputWriter.NAME:
         local_path = new_path
 

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -456,7 +456,7 @@ class TurbiniaTask(object):
               'Output file {0:s} is empty. Not saving'.format(file_),
               level=logging.DEBUG)
           continue
-        result.log('Output file at {0:s}'.format(file_))
+        result.log('Output save file at {0:s}'.format(file_))
         if not self.run_local:
           self.output_manager.save_local_file(file_, result)
 

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -170,9 +170,8 @@ class TurbiniaTaskResult(object):
     for evidence in self.evidence:
       if evidence.local_path and os.path.exists(evidence.local_path):
         self.saved_paths.append(evidence.local_path)
-        if not task.run_local:
-          if evidence.copyable and not config.SHARED_FILESYSTEM:
-            task.output_manager.save_evidence(evidence, self)
+        if not task.run_local and evidence.copyable:
+          task.output_manager.save_evidence(evidence, self)
       else:
         self.log(
             'Evidence {0:s} has empty or missing file at local_path {1:s} so '
@@ -440,7 +439,7 @@ class TurbiniaTask(object):
             'Log file {0:s} is empty. Not saving'.format(file_),
             level=logging.DEBUG)
         continue
-      result.log('Output file at {0:s}'.format(file_))
+      result.log('Output log file found at {0:s}'.format(file_))
       if not self.run_local:
         self.output_manager.save_local_file(file_, result)
 


### PR DESCRIPTION
We still want to run the file copying when using a shared filesystem because we use it to copy from tmp files to the main shared filesystem.    We also want to save the result even if the file doesn't get copied.   This also updates some comments to be more clear.