### PR TITLE
Added functionality to filter jobs and run a system dependency check on the worker. 

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -832,9 +832,9 @@ class TurbiniaCeleryWorker(TurbiniaClient):
     """
     super(TurbiniaCeleryWorker, self).__init__()
     # Deregister jobs from blacklist/whitelist.
-    disabled_jobs = list(config.DISABLED_JOBS)
+    disabled_jobs = list(config.DISABLED_JOBS) if config.DISABLED_JOBS else []
     job_manager.JobsManager.DeregisterJobs(jobs_blacklist, jobs_whitelist)
-    if disabled_jobs != []:
+    if disabled_jobs:
       log.info(
           'Disabling jobs that were configured to be disabled in the '
           'config file: {0:s}'.format(', '.join(disabled_jobs)))
@@ -887,9 +887,9 @@ class TurbiniaPsqWorker(object):
       raise TurbiniaException(msg)
 
     # Deregister jobs from blacklist/whitelist.
-    disabled_jobs = list(config.DISABLED_JOBS)
+    disabled_jobs = list(config.DISABLED_JOBS) if config.DISABLED_JOBS else []
     job_manager.JobsManager.DeregisterJobs(jobs_blacklist, jobs_whitelist)
-    if disabled_jobs != []:
+    if disabled_jobs:
       log.info(
           'Disabling jobs that were configured to be disabled in the '
           'config file: {0:s}'.format(', '.join(disabled_jobs)))

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -150,7 +150,7 @@ def check_dependencies(dependencies):
             'will not be performed for it.'.format(dep['job']))
   except (KeyError, TypeError) as exception:
     raise TurbiniaException('An issue has occured while parsing the '\
-                            'dependency config:{0:s} '.format(exception))
+                            'dependency config:{0!s} '.format(exception))
 
 
 def check_directory(directory):

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -499,4 +499,4 @@ class TestTurbiniaPsqWorker(unittest.TestCase):
         'will not be performed for it.')
 
     # Bad dependency config.
-    self.assertRaises(TypeError, check_dependencies, [{'test: test'}])
+    self.assertRaises(TurbiniaException, check_dependencies, [{'test': 'test'}])

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -475,7 +475,7 @@ class TestTurbiniaPsqWorker(unittest.TestCase):
 
   @mock.patch('turbinia.client.shutil')
   @mock.patch('logging.Logger.warning')
-  def testDependencyCheck(self, logger, mock_shutil):
+  def testDependencyCheck(self, mock_logger, mock_shutil):
     """Test system dependency check."""
     dependencies = [{
         'job': 'PlasoJob',
@@ -494,9 +494,9 @@ class TestTurbiniaPsqWorker(unittest.TestCase):
     # Job not found.
     dependencies[0]['job'] = 'non_exist'
     check_dependencies(dependencies)
-    logger.assert_called_with(
-        'Job: non_exist not found and a dependency check '
-        'will not be performed for it.')
+    mock_logger.assert_called_with(
+        'The job: non_exist was not found or has been disabled. '
+        'Skipping dependency check...')
 
     # Bad dependency config.
     self.assertRaises(TurbiniaException, check_dependencies, [{'test': 'test'}])

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -441,6 +441,7 @@ class TestTurbiniaPsqWorker(unittest.TestCase):
     config.LoadConfig()
     config.OUTPUT_DIR = self.tmp_dir
     config.MOUNT_DIR_PREFIX = self.tmp_dir
+    config.DEPENDENCIES = []
 
   def tearDown(self):
     if 'turbinia-test' in self.tmp_dir:

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -55,6 +55,9 @@ REQUIRED_VARS = [
     'SHARED_FILESYSTEM',
     # TODO(aarontp): Move this to the recipe config when it's available.
     'DEBUG_TASKS',
+    'DEPENDENCIES',
+    'DOCKER_ENABLED',
+    'DISABLED_JOBS',
 ]
 
 # Optional config vars.  Some may be mandatory depending on the configuration

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -81,11 +81,12 @@ DEBUG_TASKS = False
 
 # This will allow for the configuration of system dependencies and docker
 # containers. The following configuration will need to be set per job config.
-# Please use the example below as a guidance to adding additional job checks.
+# Please use the example below as a guide to add additional job checks.
 # {
-#   'job': 'The name of the job.'
-#   'programs': 'List of programs to check for.
-#   'docker_image': name of docker image (if any).
+#   'job': 'MyJob'
+#   'programs': ['list', 'of', 'required', 'programs']
+#   'docker_image': 'ImageID' # Can also be set to None if there is
+#                                     not an image for this Job.
 # }
 
 # This will enable the usage of docker containers for the worker.
@@ -96,8 +97,40 @@ DISABLED_JOBS = []
 
 # Configure additional job dependency checks below.
 DEPENDENCIES = [{
+    'job': 'BinaryExtractorJob',
+    'programs': ['image_export.py'],
+    'docker_image': None
+}, {
     'job': 'BulkExtractorJob',
     'programs': ['bulk_extractor'],
+    'docker_image': None
+}, {
+    'job': 'GrepJob',
+    'programs': ['grep'],
+    'docker_image': None
+}, {
+    'job': 'HadoopAnalysisJob',
+    'programs': ['strings'],
+    'docker_image': None
+}, {
+    'job': 'HindsightJob',
+    'programs': ['hindsight.py'],
+    'docker_image': None
+}, {
+    'job': 'PlasoJob',
+    'programs': ['log2timeline.py'],
+    'docker_image': None
+}, {
+    'job': 'PsortJob',
+    'programs': ['psort.py'],
+    'docker_image': None
+}, {
+    'job': 'StringsJob',
+    'programs': ['strings'],
+    'docker_image': None
+}, {
+    'job': 'VolatilityJob',
+    'programs': ['vol.py'],
     'docker_image': None
 }]
 

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -74,6 +74,34 @@ SHARED_FILESYSTEM = False
 DEBUG_TASKS = False
 
 ################################################################################
+#                         External Dependency Configurations
+#
+# Options in this section are used to configure system and docker dependencies.
+################################################################################
+
+# This will allow for the configuration of system dependencies and docker
+# containers. The following configuration will need to be set per job config.
+# Please use the example below as a guidance to adding additional job checks.
+# {
+#   'job': 'The name of the job.'
+#   'programs': 'List of programs to check for.
+#   'docker_image': name of docker image (if any).
+# }
+
+# This will enable the usage of docker containers for the worker.
+DOCKER_ENABLED = False
+
+# Any jobs added to this list will disable it from being used.
+DISABLED_JOBS = []
+
+# Configure additional job dependency checks below.
+DEPENDENCIES = [{
+    'job': 'BulkExtractorJob',
+    'programs': ['bulk_extractor'],
+    'docker_image': None
+}]
+
+################################################################################
 #                        Google Cloud Platform (GCP)
 #
 # Options in this section are required if the TASK_MANAGER is set to 'PSQ'.

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -117,6 +117,10 @@ DEPENDENCIES = [{
     'programs': ['hindsight.py'],
     'docker_image': None
 }, {
+    'job': 'JenkinsAnalysisJob',
+    'programs': ['john'],
+    'docker_image': None
+}, {
     'job': 'PlasoJob',
     'programs': ['log2timeline.py'],
     'docker_image': None

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -85,8 +85,7 @@ DEBUG_TASKS = False
 # {
 #   'job': 'MyJob'
 #   'programs': ['list', 'of', 'required', 'programs']
-#   'docker_image': 'ImageID' # Can also be set to None if there is
-#                                     not an image for this Job.
+#   'docker_image': 'ImageID' # Or None if no image configured for this job.
 # }
 
 # This will enable the usage of docker containers for the worker.

--- a/turbinia/jobs/manager.py
+++ b/turbinia/jobs/manager.py
@@ -122,6 +122,7 @@ class JobsManager(object):
       jobs_remove = [j for j in jobs_blacklist if j in registered_jobs]
 
     # Deregister the jobs.
+    jobs_remove = [j.lower() for j in jobs_remove]
     for job_name in jobs_remove:
       del cls._job_classes[job_name]
 

--- a/turbinia/jobs/manager.py
+++ b/turbinia/jobs/manager.py
@@ -94,6 +94,38 @@ class JobsManager(object):
     del cls._job_classes[job_name]
 
   @classmethod
+  def DeregisterJobs(cls, jobs_blacklist=None, jobs_whitelist=None):
+    """Deregisters a list of job names against white/black lists.
+
+    jobs_whitelist and jobs_blacklist must not be specified at the same time.
+
+    Args:
+      jobs_blacklist (Optional[list[str]]): Job names to deregister.
+      jobs_whitelist (Optional[list[str]]): Job names to register.
+
+    Raises:
+      TurbiniaException if both jobs_blacklist and jobs_whitelist are specified.
+    """
+    registered_jobs = list(cls.GetJobNames())
+    jobs_remove = []
+
+    # Create a list of jobs to deregister.
+    if jobs_whitelist and jobs_blacklist:
+      raise TurbiniaException(
+          'jobs_whitelist and jobs_blacklist cannot be specified at the same '
+          'time.')
+    elif jobs_whitelist:
+      jobs_whitelist = [j.lower() for j in jobs_whitelist]
+      jobs_remove = [j for j in registered_jobs if j not in jobs_whitelist]
+    elif jobs_blacklist:
+      jobs_blacklist = [j.lower() for j in jobs_blacklist]
+      jobs_remove = [j for j in jobs_blacklist if j in registered_jobs]
+
+    # Deregister the jobs.
+    for job_name in jobs_remove:
+      del cls._job_classes[job_name]
+
+  @classmethod
   def GetJobInstance(cls, job_name):
     """Retrieves an instance of a specific job.
 

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -315,6 +315,7 @@ class BaseTaskManager(object):
     task.requester = evidence_.config.get('requester')
     if job:
       task.job_id = job.id
+      task.job_name = job.name
       job.tasks.append(task)
     self.state_manager.write_new_task(task)
     self.enqueue_task(task, evidence_)

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -565,11 +565,13 @@ def main():
     # Set up root logger level which is normally set by the psqworker command
     # which we are bypassing.
     logger.setup()
-    worker = TurbiniaPsqWorker()
+    worker = TurbiniaPsqWorker(
+        jobs_blacklist=args.jobs_blacklist, jobs_whitelist=args.jobs_whitelist)
     worker.start()
   elif args.command == 'celeryworker':
     logger.setup()
-    worker = TurbiniaCeleryWorker()
+    worker = TurbiniaCeleryWorker(
+        jobs_blacklist=args.jobs_blacklist, jobs_whitelist=args.jobs_whitelist)
     worker.start()
   elif args.command == 'server':
     server = TurbiniaServer(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -306,6 +306,7 @@ class TurbiniaTask(object):
       id (str): Unique Id of task (string of hex)
       is_finalize_task (bool): Whether this is a finalize Task or not.
       job_id (str): Job ID the Task was created by.
+      job_name (str): The name of the Job.
       last_update (datetime): A datetime object with the last time the task was
           updated.
       name (str): Name of task
@@ -342,6 +343,7 @@ class TurbiniaTask(object):
     self.id = uuid.uuid4().hex
     self.is_finalize_task = False
     self.job_id = None
+    self.job_name = None
     self.last_update = datetime.now()
     self.name = name if name else self.__class__.__name__
     self.output_dir = None
@@ -597,6 +599,8 @@ class TurbiniaTask(object):
     Returns:
       A TurbiniaTaskResult object
     """
+    from turbinia.jobs import manager as job_manager  # calls workers job manager
+
     log.debug('Task {0:s} {1:s} awaiting execution'.format(self.name, self.id))
     evidence = evidence_decode(evidence)
     with filelock.FileLock(config.LOCK_FILE):
@@ -606,6 +610,19 @@ class TurbiniaTask(object):
         self.result = self.setup(evidence)
         original_result_id = self.result.id
         evidence.validate()
+
+        # TODO(wyassine): refactor it so the result task does not
+        # have to go through the preprocess stage. At the moment
+        # self.results.setup is required to be called to set it's status.
+        # Check if Task's job is available for the worker.
+        psq_job_manager = list(job_manager.JobsManager.GetJobNames())
+        if self.job_name.lower() not in psq_job_manager:
+          message = (
+              'Task will not run due to the job: {0:s} being disabled '
+              'on the worker.'.format(self.job_name))
+          self.result.log(message, level=logging.ERROR)
+          self.result.status = message
+          return self.result.serialize()
 
         if self.turbinia_version != turbinia.__version__:
           message = (

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -599,7 +599,8 @@ class TurbiniaTask(object):
     Returns:
       A TurbiniaTaskResult object
     """
-    from turbinia.jobs import manager as job_manager  # calls workers job manager
+    # Avoid circular dependency.
+    from turbinia.jobs import manager as job_manager
 
     log.debug('Task {0:s} {1:s} awaiting execution'.format(self.name, self.id))
     evidence = evidence_decode(evidence)
@@ -613,10 +614,10 @@ class TurbiniaTask(object):
 
         # TODO(wyassine): refactor it so the result task does not
         # have to go through the preprocess stage. At the moment
-        # self.results.setup is required to be called to set it's status.
+        # self.results.setup is required to be called to set its status.
         # Check if Task's job is available for the worker.
-        psq_job_manager = list(job_manager.JobsManager.GetJobNames())
-        if self.job_name.lower() not in psq_job_manager:
+        active_jobs = list(job_manager.JobsManager.GetJobNames())
+        if self.job_name.lower() not in active_jobs:
           message = (
               'Task will not run due to the job: {0:s} being disabled '
               'on the worker.'.format(self.job_name))

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -155,8 +155,9 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     """Test that the run wrapper can fail if the job doesn't exist."""
     self.setResults()
     self.task.job_name = 'non_exist'
-    canary_status = 'Task will not run due to the job: '\
-                    'non_exist being disabled on the worker.'
+    canary_status = (
+        'Task will not run due to the job: '
+        'non_exist being disabled on the worker.')
     new_result = self.task.run_wrapper(self.evidence.__dict__)
     new_result = TurbiniaTaskResult.deserialize(new_result)
     self.assertEqual(new_result.status, canary_status)

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -55,6 +55,7 @@ class TestTurbiniaTaskBase(unittest.TestCase):
     self.plaso_task.output_manager.get_local_output_dirs.return_value = (
         None, None)
     self.task = self.task_class(base_output_dir=self.base_output_dir)
+    self.task.job_name = 'PlasoJob'
     self.task.output_manager = mock.MagicMock()
     self.task.output_manager.get_local_output_dirs.return_value = (None, None)
 
@@ -149,6 +150,16 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.task.validate_result.assert_any_call(bad_result)
     self.assertEqual(type(new_result), TurbiniaTaskResult)
     self.assertIn('CheckedResult', new_result.status)
+
+  def testTurbiniaTaskJobUnavailable(self):
+    """Test that the run wrapper can fail if the job doesn't exist."""
+    self.setResults()
+    self.task.job_name = 'non_exist'
+    canary_status = 'Task will not run due to the job: '\
+                    'non_exist being disabled on the worker.'
+    new_result = self.task.run_wrapper(self.evidence.__dict__)
+    new_result = TurbiniaTaskResult.deserialize(new_result)
+    self.assertEqual(new_result.status, canary_status)
 
   def testTurbiniaTaskRunWrapperExceptionThrown(self):
     """Test that the run wrapper recovers from run throwing an exception."""


### PR DESCRIPTION
Added functionality to filter jobs by worker via --jobs_whitelist or --jobs_blacklist flags or in the config file inside the DISABLE_JOBS variable. Updated the config to do a system dependency check prior to starting the worker (it will check if the job name in the dependency check matches the list of available jobs and then run a check for all the programs to see if they exist or not.). The task.run_wrapper will check if a given job is enabled in the worker before running and if it does not, will set the result.status warning the user that the job has been disabled on the worker. 