### PR TITLE
Fixed exception thrown during evidence creation of PsortJob

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -540,7 +540,7 @@ class PlasoFile(Evidence):
     self.save_metadata = True
 
 
-class PlasoCsvFile(PlasoFile):
+class PlasoCsvFile(Evidence):
   """Psort output file evidence.  """
 
   def __init__(self, plaso_version=None, *args, **kwargs):


### PR DESCRIPTION
The exception would be thrown each time the PsortJob is run and it has to do with the PlasoCsvFile method being inherited from PlasoFile evidence type and the super() method get's called twice. I haven't noticed a need for the PlasoCsvFile to be inherited so I changed it to inherit from the base Evidence class. Exception that was being thrown:
```
[ERROR] PsortTask Task failed with exception: [__init__() got multiple values for keyword argument 'copyable']
[INFO] Traceback (most recent call last):
  File "turbinia/turbinia/workers/__init__.py", line 619, in run_wrapper
    self.result = self.run(evidence, self.result)
  File "turbinia/turbinia/workers/psort.py", line 42, in run
    psort_evidence = PlasoCsvFile(source_path=psort_file)
  File "turbinia/turbinia/evidence.py", line 549, in __init__
    super(PlasoCsvFile, self).__init__(copyable=True, *args, **kwargs)
  File "turbinia/turbinia/evidence.py", line 539, in __init__
    super(PlasoFile, self).__init__(copyable=True, *args, **kwargs)
TypeError: __init__() got multiple values for keyword argument 'copyable'
```