### PR TITLE
Use random disk names when creating a disk from snapshot

### DIFF
--- a/turbinia/lib/libcloudforensics.py
+++ b/turbinia/lib/libcloudforensics.py
@@ -304,7 +304,7 @@ class GoogleCloudProject(object):
 
     if not disk_name:
       disk_name = binascii.hexlify(os.urandom(5))
-    disk_name = '{0:s}{1:s}'.format(disk_name_prefix, disk_name)
+    disk_name = '{0:s}{1:s}'.format(disk_name_prefix, disk_name)[:63]
     body = dict(name=disk_name, sourceSnapshot=snapshot.get_source_string())
 
     try:


### PR DESCRIPTION
Doing fancy things with CRC32 lead to long names and unfortunate collisions. Since https://github.com/google/turbinia/pull/459 has been merged, callers can use labels to specify more verbose data (such as incident ID, or original disk name)