### PR TITLE
Allow optional preprocessing

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -77,8 +77,8 @@ def evidence_decode(evidence_dict):
         evidence_decode(e) for e in evidence_dict['collection']
     ]
 
-  # We can just reinitialize insted of deserializing because the state should be
-  # empty when just starting to process on a new machine.
+  # We can just reinitialize instead of deserializing because the state should
+  # be empty when just starting to process on a new machine.
   evidence.state = {}
   for state in EvidenceState:
     evidence.state[state] = False
@@ -141,9 +141,9 @@ class Evidence(object):
         metadata file will contain all of the key=value pairs sent along with
         the processing request in the recipe.  The output is in JSON format
     state (dict): A map of each EvidenceState type to a boolean to indicate
-        if that state state is true.  This is used by the preprocessors to set
-        the current state and Tasks can use this to determine if the Evidence is
-        in the correct state for processing.
+        if that state is true.  This is used by the preprocessors to set the
+        current state and Tasks can use this to determine if the Evidence is in
+        the correct state for processing.
   """
 
   # The list of attributes a given piece of Evidence requires to be set

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -82,7 +82,8 @@ def evidence_decode(evidence_dict):
 class EvidenceStatus(IntEnum):
   """Runtime status of Evidence.
 
-  Each Evidence object will have
+  Evidence objects will map each of these to a boolean indicating the current
+  status for the given object.
   """
   MOUNTED = 1
   ATTACHED = 2

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -205,6 +205,10 @@ class Evidence(object):
 
   def serialize(self):
     """Return JSON serializable object."""
+    # Set all statuses to False because if we are serializing the Evidence it is
+    # because this is about to be returned, and the status has no meaning
+    # outside of the context on the Worker.
+    self.status = {status: False for status in self.status}
     serialized_evidence = self.__dict__.copy()
     if self.parent_evidence:
       serialized_evidence['parent_evidence'] = self.parent_evidence.serialize()

--- a/turbinia/evidence_test.py
+++ b/turbinia/evidence_test.py
@@ -17,10 +17,15 @@
 from __future__ import unicode_literals
 
 import json
+import mock
 import unittest
 
 from turbinia import evidence
 from turbinia import TurbiniaException
+
+
+class TestEvidence(evidence.Evidence):
+  POSSIBLE_STATES = [evidence.EvidenceState.MOUNTED]
 
 
 class TestTurbiniaEvidence(unittest.TestCase):
@@ -92,3 +97,10 @@ class TestTurbiniaEvidence(unittest.TestCase):
     rawdisk = evidence.RawDisk(name='My Evidence', source_path='/tmp/foo')
     rawdisk.REQUIRED_ATTRIBUTES = ['doesnotexist']
     self.assertRaises(TurbiniaException, rawdisk.validate)
+
+  @mock.patch('turbinia.evidence.Evidence._preprocess')
+  def testEvidencePreprocess(self, mock_preprocess):
+    """Basic test for Evidence.preprocess()."""
+    test_evidence = TestEvidence()
+    test_evidence.preprocess(required_states=[evidence.EvidenceState.ATTACHED])
+    mock_preprocess.assert_called_with(None, [evidence.EvidenceState.ATTACHED])

--- a/turbinia/jobs/photorec.py
+++ b/turbinia/jobs/photorec.py
@@ -1,5 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Job to run photorec Task."""
 from __future__ import unicode_literals
 from turbinia.evidence import RawDisk
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.jobs import interface
 from turbinia.jobs import manager
 from turbinia.evidence import PhotorecOutput
@@ -8,7 +25,7 @@ from turbinia.workers.photorec import PhotorecTask
 
 class PhotorecJob(interface.TurbiniaJob):
 
-  evidence_input = [RawDisk]
+  evidence_input = [RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded]
   evidence_output = [PhotorecOutput]
 
   NAME = 'PhotorecJob'

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -149,7 +149,7 @@ class OutputManager(object):
         json_str = json.dumps(metadata)
       except TypeError as exception:
         raise TurbiniaException(
-            'Could not serialize Evidence config for {0:s}: {1:s}'.format(
+            'Could not serialize Evidence config for {0:s}: {1!s}'.format(
                 evidence_.name, exception))
 
       try:
@@ -158,7 +158,7 @@ class OutputManager(object):
           file_handle.write(json_str.encode('utf-8'))
       except IOError as exception:
         raise TurbiniaException(
-            'Could not write metadata file {0:s}: {1:s}'.format(
+            'Could not write metadata file {0:s}: {1!s}'.format(
                 metadata_path, exception))
 
       self.save_local_file(metadata_path, result)

--- a/turbinia/processors/archive.py
+++ b/turbinia/processors/archive.py
@@ -82,10 +82,10 @@ def CompressDirectory(uncompressed_directory, output_path=None):
           'The tar file has been created and '
           'can be found at: {0:s}'.format(compressed_directory))
   except IOError as exception:
-    raise TurbiniaException('An error has occurred: {0:s}'.format(exception))
+    raise TurbiniaException('An error has occurred: {0!s}'.format(exception))
   except tarfile.TarError as exception:
     raise TurbiniaException(
-        'An error has while compressing the directory: {0:s}'.format(exception))
+        'An error has while compressing the directory: {0!s}'.format(exception))
   return compressed_directory
 
 
@@ -116,9 +116,9 @@ def UncompressTarFile(compressed_directory, output_tmp):
         'The tar file has been uncompressed to the following directory: {0:s}'
         .format(uncompressed_directory))
   except IOError as exception:
-    raise TurbiniaException('An error has occurred: {0:s}'.format(exception))
+    raise TurbiniaException('An error has occurred: {0!s}'.format(exception))
   except tarfile.TarError as exception:
     raise TurbiniaException(
         'An error has occurred while uncompressing the tar '
-        'file: {0:s}'.format(exception))
+        'file: {0!s}'.format(exception))
   return uncompressed_directory

--- a/turbinia/task_manager_test.py
+++ b/turbinia/task_manager_test.py
@@ -46,6 +46,7 @@ class TestTaskManager(TestTurbiniaTaskBase):
   def testTaskManagerTasksProperty(self):
     """Basic test for task_manager Tasks property."""
     self.setResults()
+    jobs_manager.JobsManager.RegisterJob(plaso.PlasoJob)
     job = jobs_manager.JobsManager.GetJobInstance('PlasoJob')
     job.tasks.extend([self.task, self.task])
     self.manager.running_jobs.extend([job, job])

--- a/turbinia/task_manager_test.py
+++ b/turbinia/task_manager_test.py
@@ -37,10 +37,13 @@ class TestTaskManager(TestTurbiniaTaskBase):
     self.manager = task_manager.BaseTaskManager()
     self.job1 = plaso.PlasoJob()
     self.job2 = strings.StringsJob()
+    # pylint: disable=protected-access
     self.saved_jobs = jobs_manager.JobsManager._job_classes
+    jobs_manager.JobsManager._job_classes = {}
 
   def tearDown(self):
     """Tears down the test class."""
+    # pylint: disable=protected-access
     jobs_manager.JobsManager._job_classes = self.saved_jobs
 
   def testTaskManagerTasksProperty(self):

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -449,7 +449,7 @@ class TurbiniaTask(object):
           status does not meet the required status.
     """
     evidence.validate()
-    evidence.preprocess(self.tmp_dir)
+    evidence.preprocess(self.tmp_dir, requirements=self.REQUIRED_STATUS)
     for status in self.REQUIRED_STATUS:
       if not evidence.status[status]:
         raise TurbiniaException(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -371,6 +371,8 @@ class TurbiniaTask(object):
       'id', 'job_id', 'last_update', 'name', 'request_id', 'requester'
   ]
 
+  REQUIRED_STATUS = []
+
   def __init__(
       self, name=None, base_output_dir=None, request_id=None, requester=None):
     """Initialization for TurbiniaTask."""
@@ -435,6 +437,28 @@ class TurbiniaTask(object):
     task.last_update = datetime.strptime(
         input_dict['last_update'], DATETIME_FORMAT)
     return task
+
+  def evidence_setup(self, evidence):
+    """Validates and processes the evidence.
+
+    Args:
+      evidence(Evidence): The Evidence to setup.
+
+    Raises:
+      TurbiniaException: If the Evidence can't be validated or the current
+          status does not meet the required status.
+    """
+    evidence.validate()
+    evidence.preprocess(self.tmp_dir)
+    for status in self.REQUIRED_STATUS:
+      if not evidence.status[status]:
+        raise TurbiniaException(
+            'Evidence {0!s} being processed by Task {1:s} requires Evidence '
+            'to be in state {2:s}, but earlier pre-processors may have '
+            'failed.  Current status is {3:s}. See previous logs for more '
+            'information.'.format(
+                evidence, self.name, status.name,
+                pprint.pformat(evidence.status)))
 
   def execute(
       self, cmd, result, save_files=None, log_files=None, new_evidence=None,
@@ -699,7 +723,6 @@ class TurbiniaTask(object):
       original_result_id = None
       try:
         original_result_id = self.result.id
-        evidence.validate()
 
         # Preprocessor must be called after evidence validation.
         evidence.preprocess(self.tmp_dir)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -457,8 +457,8 @@ class TurbiniaTask(object):
             'to be in state {2:s}, but earlier pre-processors may have '
             'failed.  Current status is {3:s}. See previous logs for more '
             'information.'.format(
-                evidence, self.name, status.name,
-                pprint.pformat(evidence.status)))
+                evidence, self.name, status.name, pprint.pformat(
+                    evidence.status)))
 
   def execute(
       self, cmd, result, save_files=None, log_files=None, new_evidence=None,

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -371,7 +371,7 @@ class TurbiniaTask(object):
       'id', 'job_id', 'last_update', 'name', 'request_id', 'requester'
   ]
 
-  REQUIRED_STATUS = []
+  REQUIRED_STATE = []
 
   def __init__(
       self, name=None, base_output_dir=None, request_id=None, requester=None):
@@ -446,22 +446,22 @@ class TurbiniaTask(object):
 
     Raises:
       TurbiniaException: If the Evidence can't be validated or the current
-          status does not meet the required status.
+          state does not meet the required state.
     """
     evidence.validate()
-    evidence.preprocess(self.tmp_dir, requirements=self.REQUIRED_STATUS)
+    evidence.preprocess(self.tmp_dir, requirements=self.REQUIRED_STATE)
 
-    # Final check to make sure that the required evidence status has been met
+    # Final check to make sure that the required evidence state has been met
     # for Evidence types that have those capabilities.
-    for status in self.REQUIRED_STATUS:
-      if status in evidence.CAPABILITIES and not evidence.status[status]:
+    for state in self.REQUIRED_STATE:
+      if state in evidence.CAPABILITIES and not evidence.state[state]:
         raise TurbiniaException(
             'Evidence {0!s} being processed by Task {1:s} requires Evidence '
             'to be in state {2:s}, but earlier pre-processors may have '
-            'failed.  Current status is {3:s}. See previous logs for more '
+            'failed.  Current state is {3:s}. See previous logs for more '
             'information.'.format(
-                evidence, self.name, status.name, pprint.pformat(
-                    evidence.status)))
+                evidence, self.name, state.name, pprint.pformat(
+                    evidence.state)))
 
   def execute(
       self, cmd, result, save_files=None, log_files=None, new_evidence=None,

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -450,8 +450,11 @@ class TurbiniaTask(object):
     """
     evidence.validate()
     evidence.preprocess(self.tmp_dir, requirements=self.REQUIRED_STATUS)
+
+    # Final check to make sure that the required evidence status has been met
+    # for Evidence types that have those capabilities.
     for status in self.REQUIRED_STATUS:
-      if not evidence.status[status]:
+      if status in evidence.CAPABILITIES and not evidence.status[status]:
         raise TurbiniaException(
             'Evidence {0!s} being processed by Task {1:s} requires Evidence '
             'to be in state {2:s}, but earlier pre-processors may have '

--- a/turbinia/workers/analysis/jenkins.py
+++ b/turbinia/workers/analysis/jenkins.py
@@ -20,6 +20,7 @@ import os
 import re
 
 from turbinia import TurbiniaException
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import ReportText
 from turbinia.lib import text_formatter as fmt
 from turbinia.workers import TurbiniaTask
@@ -30,6 +31,11 @@ from turbinia.lib.utils import bruteforce_password_hashes
 
 class JenkinsAnalysisTask(TurbiniaTask):
   """Task to analyze a Jenkins install."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.DOCKER_MOUNTED, state.PARENT_ATTACHED,
+      state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Run the Jenkins worker.

--- a/turbinia/workers/analysis/jupyter.py
+++ b/turbinia/workers/analysis/jupyter.py
@@ -20,6 +20,7 @@ import os
 import re
 
 from turbinia import TurbiniaException
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import ReportText
 from turbinia.lib import text_formatter as fmt
 from turbinia.workers import TurbiniaTask
@@ -28,6 +29,11 @@ from turbinia.workers import Priority
 
 class JupyterAnalysisTask(TurbiniaTask):
   """Task to analyze a Jupyter Notebook config."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.DOCKER_MOUNTED, state.PARENT_ATTACHED,
+      state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Run the Jupyter worker.

--- a/turbinia/workers/analysis/wordpress.py
+++ b/turbinia/workers/analysis/wordpress.py
@@ -20,6 +20,7 @@ import gzip
 import os
 import re
 
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import ReportText
 from turbinia.lib import text_formatter as fmt
 from turbinia.workers import TurbiniaTask

--- a/turbinia/workers/artifact.py
+++ b/turbinia/workers/artifact.py
@@ -20,11 +20,16 @@ import os
 
 from turbinia import config
 from turbinia.evidence import ExportedFileArtifact
+from turbinia.evidence import EvidenceState as state
 from turbinia.workers import TurbiniaTask
 
 
 class FileArtifactExtractionTask(TurbiniaTask):
   """Task to run image_export (log2timeline)."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.PARENT_ATTACHED, state.PARENT_MOUNTED
+  ]
 
   def __init__(self, artifact_name='FileArtifact'):
     super(FileArtifactExtractionTask, self).__init__()

--- a/turbinia/workers/bulk_extractor.py
+++ b/turbinia/workers/bulk_extractor.py
@@ -21,6 +21,7 @@ import xml.etree.ElementTree as xml_tree
 from turbinia import TurbiniaException
 
 from turbinia.evidence import BulkExtractorOutput
+from turbinia.evidence import EvidenceState as state
 from turbinia.workers import TurbiniaTask
 from turbinia.lib import text_formatter as fmt
 
@@ -29,6 +30,10 @@ log = logging.getLogger('turbinia')
 
 class BulkExtractorTask(TurbiniaTask):
   """Task to generate Bulk Extractor output."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.PARENT_ATTACHED, state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Run Bulk Extractor binary.

--- a/turbinia/workers/docker.py
+++ b/turbinia/workers/docker.py
@@ -17,11 +17,11 @@ from __future__ import unicode_literals
 
 import json
 import logging
-import os
 import subprocess
 
 from turbinia import TurbiniaException
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import EvidenceState as state
 from turbinia.workers import Priority
 from turbinia.workers import TurbiniaTask
 from turbinia.lib.docker_manager import GetDockerPath
@@ -31,6 +31,10 @@ log = logging.getLogger('turbinia')
 
 class DockerContainersEnumerationTask(TurbiniaTask):
   """Enumerates Docker containers on Linux"""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.MOUNTED, state.PARENT_ATTACHED, state.PARENT_MOUNTED
+  ]
 
   def GetContainers(self, evidence):
     """Lists the containers from an input Evidence.

--- a/turbinia/workers/hadoop.py
+++ b/turbinia/workers/hadoop.py
@@ -24,6 +24,7 @@ import subprocess
 from turbinia import TurbiniaException
 
 from turbinia.lib import text_formatter as fmt
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import ReportText
 from turbinia.lib.utils import extract_artifacts
 from turbinia.workers import TurbiniaTask
@@ -34,6 +35,11 @@ log = logging.getLogger('turbinia')
 
 class HadoopAnalysisTask(TurbiniaTask):
   """Task to analyse Hadoop AppRoot files."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.DOCKER_MOUNTED, state.PARENT_ATTACHED,
+      state.PARENT_MOUNTED
+  ]
 
   def _AnalyzeHadoopAppRoot(self, collected_artifacts, output_dir):
     """Runs a naive AppRoot files parsing method.

--- a/turbinia/workers/photorec.py
+++ b/turbinia/workers/photorec.py
@@ -21,10 +21,15 @@ import os
 
 from turbinia import TurbiniaException
 from turbinia.workers import TurbiniaTask
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import PhotorecOutput
 
 
 class PhotorecTask(TurbiniaTask):
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.PARENT_ATTACHED, state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Task to execute photorec.

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -22,12 +22,16 @@ from tempfile import NamedTemporaryFile
 from turbinia import config
 from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
+from turbinia.evidence import EvidenceStatus
 from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
 
 
 class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
+
+  # Plaso requires the Disk to be attached, but doesn't require it be mounted.
+  REQUIRED_STATUS = [EvidenceStatus.ATTACHED]
 
   def run(self, evidence, result):
     """Task that process data with Plaso.

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -22,7 +22,7 @@ from tempfile import NamedTemporaryFile
 from turbinia import config
 from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
-from turbinia.evidence import EvidenceStatus
+from turbinia.evidence import EvidenceState
 from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
 
@@ -31,7 +31,7 @@ class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 
   # Plaso requires the Disk to be attached, but doesn't require it be mounted.
-  REQUIRED_STATUS = [EvidenceStatus.ATTACHED, EvidenceStatus.DECOMPRESSED]
+  REQUIRED_STATUS = [EvidenceState.ATTACHED, EvidenceState.DECOMPRESSED]
 
   def run(self, evidence, result):
     """Task that process data with Plaso.

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -31,7 +31,7 @@ class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 
   # Plaso requires the Disk to be attached, but doesn't require it be mounted.
-  REQUIRED_STATUS = [EvidenceStatus.ATTACHED]
+  REQUIRED_STATUS = [EvidenceStatus.ATTACHED, EvidenceStatus.DECOMPRESSED]
 
   def run(self, evidence, result):
     """Task that process data with Plaso.

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -22,7 +22,7 @@ from tempfile import NamedTemporaryFile
 from turbinia import config
 from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
-from turbinia.evidence import EvidenceState
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
 
@@ -31,7 +31,10 @@ class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 
   # Plaso requires the Disk to be attached, but doesn't require it be mounted.
-  REQUIRED_STATUS = [EvidenceState.ATTACHED, EvidenceState.DECOMPRESSED]
+  REQUIRED_STATUS = [
+      state.ATTACHED, state.PARENT_ATTACHED, state.PARENT_MOUNTED,
+      state.DECOMPRESSED
+  ]
 
   def run(self, evidence, result):
     """Task that process data with Plaso.

--- a/turbinia/workers/redis.py
+++ b/turbinia/workers/redis.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 import os
 import re
 
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import ReportText
 from turbinia.lib import text_formatter as fmt
 from turbinia.workers import TurbiniaTask
@@ -27,6 +28,11 @@ from turbinia.workers import Priority
 
 class RedisAnalysisTask(TurbiniaTask):
   """Task to analyze a Redis configuration file."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.DOCKER_MOUNTED, state.PARENT_ATTACHED,
+      state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Run the Redis configuration analysis worker.

--- a/turbinia/workers/strings.py
+++ b/turbinia/workers/strings.py
@@ -18,12 +18,17 @@ from __future__ import unicode_literals
 
 import os
 
+from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import TextFile
 from turbinia.workers import TurbiniaTask
 
 
 class StringsAsciiTask(TurbiniaTask):
   """Task to generate ascii strings."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.PARENT_ATTACHED, state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Run strings binary.
@@ -56,6 +61,10 @@ class StringsAsciiTask(TurbiniaTask):
 
 class StringsUnicodeTask(TurbiniaTask):
   """Task to generate Unicode (16 bit little endian) strings."""
+
+  REQUIRED_STATES = [
+      state.ATTACHED, state.PARENT_ATTACHED, state.PARENT_MOUNTED
+  ]
 
   def run(self, evidence, result):
     """Run strings binary.

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -321,7 +321,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.evidence.preprocess = mock.MagicMock()
     self.task.evidence_setup(self.evidence)
     self.evidence.preprocess.assert_called_with(
-        self.task.tmp_dir, required_state=self.task.REQUIRED_STATES)
+        self.task.tmp_dir, required_states=self.task.REQUIRED_STATES)
 
   def testEvidenceSetupStateNotFulfilled(self):
     """Test that evidence setup throws exception when states don't match."""

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -315,3 +315,25 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.task.execute(
         cmd, self.result, new_evidence=[self.evidence], close=True)
     self.assertNotIn(self.evidence, self.result.evidence)
+
+  def testEvidenceSetup(self):
+    """Tests basic run of evidence_setup."""
+    self.evidence.preprocess = mock.MagicMock()
+    self.task.evidence_setup(self.evidence)
+    self.evidence.preprocess.assert_called_with(
+        self.task.tmp_dir, required_state=self.task.REQUIRED_STATES)
+
+  def testEvidenceSetupStateNotFulfilled(self):
+    """Test that evidence setup throws exception when states don't match."""
+    self.evidence.preprocess = mock.MagicMock()
+    self.evidence.POSSIBLE_STATES = [evidence.EvidenceState.ATTACHED]
+    self.task.REQUIRED_STATES = [evidence.EvidenceState.ATTACHED]
+
+    # The current state of the evience as shown in evidence.state[ATTACHED] is
+    # not True, so this should throw an exception
+    self.assertRaises(
+        TurbiniaException, self.task.evidence_setup, self.evidence)
+
+    # Runs fine after setting the state
+    self.evidence.state[evidence.EvidenceState.ATTACHED] = True
+    self.task.evidence_setup(self.evidence)


### PR DESCRIPTION
This allows pre-processing to only be run when it is needed.  This eliminates a lot of extra work done by the workers, but also makes setup a lot more graceful, and errors cause fewer resources to be left around.

Copying some relevant bits from the docstrings for `Evidence.preprocess()`, see there for more info:

    Tasks export a list of the required_states they have for the state of the
    Evidence it can process in `TurbiniaTask.REQUIRED_STATES`[1].  Evidence also
    exports a list of the possible states it can have after pre/post-processing
    in `Evidence.POSSIBLE_STATES`.  The pre-processors should run selectively
    based on the these requirements that come from the Task, and the
    post-processors should run selectively based on the current state of the
    Evidence.

    If a Task requires a given state supported by the given Evidence class, but
    it is not met after the preprocessing of the Evidence is run, then the Task
    will abort early.  Note that for compound evidence types that have parent
    Evidence objects (e.g. where `context_dependent` is True), we only inspect
    the child Evidence type for its state as it is assumed that it would only be
    able to run the appropriate pre/post-processors when the parent Evidence
    processors have been successful.

    [1] Note that the evidence states required by the Task are only required if
    the Evidence also supports that state in `POSSSIBLE_STATES`.  This is so
    that the Tasks are flexible enough to support multiple types of Evidence.
    For example, `PlasoTask` allows both `CompressedDirectory` and
    `GoogleCloudDisk` as Evidence input, and has states `ATTACHED` and
    `DECOMPRESSED` listed in `PlasoTask.REQUIRED_STATES`.  Since `ATTACHED`
    state is supported by `GoogleCloudDisk`, and `DECOMPRESSED` is supported by
    `CompressedDirectory`, only those respective pre-processors will be run and
    the state is confirmed after the preprocessing is complete.


Some other small fixes:
- Fixed some format strings
- Fixed input_evidence being attached to TurbiniaTaskResult

Note: Based on some feedback from the original PR, I've renamed 'status' to 'state', and 'capabilities' to 'possible_states'.
