### PR TITLE
Remove Directory Evidence type

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -296,11 +296,6 @@ class EvidenceCollection(Evidence):
     self.collection.append(evidence)
 
 
-class Directory(Evidence):
-  """Filesystem directory evidence."""
-  pass
-
-
 class CompressedDirectory(Evidence):
   """CompressedDirectory based evidence.
 

--- a/turbinia/jobs/binary_extractor.py
+++ b/turbinia/jobs/binary_extractor.py
@@ -16,7 +16,6 @@
 
 from __future__ import unicode_literals
 
-from turbinia.evidence import Directory
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.evidence import RawDisk
@@ -30,9 +29,7 @@ class BinaryExtractorJob(interface.TurbiniaJob):
   """Run image_export.py on evidence to extract binaries."""
 
   # The types of evidence that this Job will process.
-  evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
-  ]
+  evidence_input = [RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded]
   evidence_output = [BinaryExtraction]
 
   NAME = 'BinaryExtractorJob'

--- a/turbinia/jobs/http_access_logs.py
+++ b/turbinia/jobs/http_access_logs.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 
 from turbinia.workers import artifact
 
-from turbinia.evidence import Directory
 from turbinia.evidence import DockerContainer
 from turbinia.evidence import RawDisk
 from turbinia.evidence import GoogleCloudDisk
@@ -37,8 +36,7 @@ class HTTPAccessLogExtractionJob(interface.TurbiniaJob):
   """HTTP Access log extraction job."""
 
   evidence_input = [
-      Directory, DockerContainer, RawDisk, GoogleCloudDisk,
-      GoogleCloudDiskRawEmbedded
+      DockerContainer, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/jenkins.py
+++ b/turbinia/jobs/jenkins.py
@@ -16,7 +16,6 @@
 
 from __future__ import unicode_literals
 
-from turbinia.evidence import Directory
 from turbinia.evidence import DockerContainer
 from turbinia.evidence import RawDisk
 from turbinia.evidence import GoogleCloudDisk
@@ -31,8 +30,7 @@ class JenkinsAnalysisJob(interface.TurbiniaJob):
   """Jenkins analysis job."""
 
   evidence_input = [
-      Directory, DockerContainer, RawDisk, GoogleCloudDisk,
-      GoogleCloudDiskRawEmbedded
+      DockerContainer, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
   ]
   evidence_output = [ReportText]
 

--- a/turbinia/jobs/plaso.py
+++ b/turbinia/jobs/plaso.py
@@ -19,7 +19,6 @@ from __future__ import unicode_literals
 from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import CompressedDirectory
-from turbinia.evidence import Directory
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.evidence import PlasoFile
@@ -33,8 +32,8 @@ class PlasoJob(interface.TurbiniaJob):
   """Runs Plaso on some evidence to generate a Plaso file."""
   # The types of evidence that this Job will process
   evidence_input = [
-      Directory, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
-      BitlockerDisk, APFSEncryptedDisk, CompressedDirectory
+      RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, BitlockerDisk,
+      APFSEncryptedDisk, CompressedDirectory
   ]
   evidence_output = [PlasoFile]
 

--- a/turbinia/jobs/sshd.py
+++ b/turbinia/jobs/sshd.py
@@ -18,7 +18,6 @@ from __future__ import unicode_literals
 
 from turbinia.workers import artifact
 from turbinia.workers import sshd
-from turbinia.evidence import Directory
 from turbinia.evidence import DockerContainer
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
@@ -34,8 +33,7 @@ class SSHDExtractionJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-      Directory, DockerContainer, RawDisk, GoogleCloudDisk,
-      GoogleCloudDiskRawEmbedded
+      DockerContainer, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/tomcat.py
+++ b/turbinia/jobs/tomcat.py
@@ -16,7 +16,6 @@
 from __future__ import unicode_literals
 from turbinia.workers import artifact
 from turbinia.workers import tomcat
-from turbinia.evidence import Directory
 from turbinia.evidence import DockerContainer
 from turbinia.evidence import GoogleCloudDisk
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
@@ -32,8 +31,7 @@ class TomcatExtractionJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-      Directory, DockerContainer, RawDisk, GoogleCloudDisk,
-      GoogleCloudDiskRawEmbedded
+      DockerContainer, RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded
   ]
 
   evidence_output = [ExportedFileArtifact]

--- a/turbinia/jobs/worker_stat.py
+++ b/turbinia/jobs/worker_stat.py
@@ -16,7 +16,6 @@
 
 from __future__ import unicode_literals
 
-from turbinia.evidence import Directory
 from turbinia.evidence import RawDisk
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
@@ -28,7 +27,7 @@ class StatJob(interface.TurbiniaJob):
   """Job to run Stat."""
 
   # The types of evidence that this Job will process
-  evidence_input = [RawDisk, Directory]
+  evidence_input = [RawDisk]
   evidence_output = [ReportText]
 
   NAME = 'StatJob'

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -275,17 +275,6 @@ def main():
       '-m', '--module_list', type=csv_list,
       help='Volatility module(s) to execute', required=True)
 
-  # Parser options for Directory evidence type
-  parser_directory = subparsers.add_parser(
-      'directory', help='Process a directory as Evidence')
-  parser_directory.add_argument(
-      '-l', '--source_path', help='Local path to the evidence', required=True)
-  parser_directory.add_argument(
-      '-s', '--source', help='Description of the source of the evidence',
-      required=False)
-  parser_directory.add_argument(
-      '-n', '--name', help='Descriptive name of the evidence', required=False)
-
   # Parser options for CompressedDirectory evidence type
   parser_directory = subparsers.add_parser(
       'compressedirectory', help='Process a compressed tar file as Evidence')
@@ -521,11 +510,6 @@ def main():
     evidence_ = evidence.BitlockerDisk(
         name=args.name, source_path=source_path, recovery_key=args.recovery_key,
         password=args.password, source=args.source)
-  elif args.command == 'directory':
-    args.name = args.name if args.name else args.source_path
-    source_path = os.path.abspath(args.source_path)
-    evidence_ = evidence.Directory(
-        name=args.name, source_path=source_path, source=args.source)
   elif args.command == 'compressedirectory':
     archive.ValidateTarFile(args.source_path)
     args.name = args.name if args.name else args.source_path


### PR DESCRIPTION
CompressedDirectory should be used instead since it can be easily managed by the storage manager.