### PR TITLE
Remove pip session from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,8 @@ from setuptools import find_packages
 from setuptools import setup
 
 try:  # for pip >= 10
-  from pip._internal.download import PipSession
   from pip._internal.req import parse_requirements
 except ImportError:  # for pip <= 9.0.3
-  from pip.download import PipSession
   from pip.req import parse_requirements
 
 
@@ -66,7 +64,7 @@ setup(
     zip_safe=False,
     entry_points={'console_scripts': ['turbiniactl=turbinia.turbiniactl:main']},
     install_requires=[str(req.req) for req in parse_requirements(
-        'requirements.txt', session=PipSession())
+        'requirements.txt', session=False)
     ],
     extras_require={
         'dev': ['mock', 'nose', 'yapf', 'celery~=4.1', 'coverage'],


### PR DESCRIPTION
The internal API of pip changed and this is a workaround for #492 .  This seems to work just fine for `pip install -e .`, but I'm not actually sure what the session is for, and I saw other people setting it to other values as a workaround.   Longer term we'll have to come up with a different fix to not use parse_requirements at all.