### PR TITLE
Get artifacts/parsers/file_filter from --recipe_config

### DIFF
--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -65,15 +65,14 @@ class PlasoTask(TurbiniaTask):
           for filter_ in file_filters.split(':'):
             file_filter_fh.write(filter_.encode('utf-8') + b'\n')
       except IOError as exception:
-        message = ('Cannot write to filter file {0:s}: {1!s}'.format(
-            file_filter_file, exception))
+        message = 'Cannot write to filter file {0:s}: {1!s}'.format(
+            file_filter_file, exception)
         result.close(self, success=False, status=message)
         return result
 
     else:
       file_filters = None
       file_filter_file = None
-
 
     # Write plaso file into tmp_dir because sqlite has issues with some shared
     # filesystems (e.g NFS).

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -19,7 +19,6 @@ from __future__ import unicode_literals
 import os
 
 from turbinia import config
-from turbinia import TurbiniaException
 from turbinia.evidence import APFSEncryptedDisk
 from turbinia.evidence import BitlockerDisk
 from turbinia.evidence import PlasoFile
@@ -46,7 +45,6 @@ class PlasoTask(TurbiniaTask):
     # using the --recipe_config flag, and this can be used with colon separated
     # values like:
     # --recipe_config='artifact_filters=BrowserFoo:BrowserBar,parsers=foo:bar'
-    result.log('DEBUG: Evidence config is:\n{0!s}'.format(evidence.config))
     if evidence.config and evidence.config.get('artifact_filters'):
       artifact_filters = evidence.config.get('artifact_filters')
       artifact_filters = artifact_filters.replace(':', ',')
@@ -67,9 +65,11 @@ class PlasoTask(TurbiniaTask):
           for filter_ in file_filters.split(':'):
             file_filter_fh.write(filter_.encode('utf-8') + b'\n')
       except IOError as exception:
-        TurbiniaException(
-            'Cannot write to filter file {0:s}: {1!s}'.format(
-                file_filter_file, exception))
+        message = ('Cannot write to filter file {0:s}: {1!s}'.format(
+            file_filter_file, exception))
+        result.close(self, success=False, status=message)
+        return result
+
     else:
       file_filters = None
       file_filter_file = None

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -63,9 +63,9 @@ class PlasoTask(TurbiniaTask):
       file_filters = evidence.config.get('file_filters')
       file_filter_file = os.path.join(self.tmp_dir, 'file_filter.txt')
       try:
-        with open(file_filter_file, 'w') as file_filter_fh:
+        with open(file_filter_file, 'wb') as file_filter_fh:
           for filter_ in file_filters.split(':'):
-            file_filter_fh.write(filter_.encode('utf-8'))
+            file_filter_fh.write(filter_.encode('utf-8') + b'\n')
       except IOError as exception:
         TurbiniaException(
             'Cannot write to filter file {0:s}: {1!s}'.format(
@@ -92,7 +92,7 @@ class PlasoTask(TurbiniaTask):
     if parsers:
       cmd.extend(['--parsers', parsers])
     if file_filters:
-      cmd.extend(['--file_filters', file_filter_file])
+      cmd.extend(['--file_filter', file_filter_file])
 
     if isinstance(evidence, (APFSEncryptedDisk, BitlockerDisk)):
       if evidence.recovery_key:

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -46,21 +46,21 @@ class PlasoTask(TurbiniaTask):
     # using the --recipe_config flag, and this can be used with colon separated
     # values like:
     # --recipe_config='artifact_filters=BrowserFoo:BrowserBar,parsers=foo:bar'
-    self.log('DEBUG: Evidence config is:\n{0!s}'.format(self.evidence.config))
-    if self.evidence.config and self.evidence.config.get('artifact_filters'):
-      artifact_filters = self.evidence.config.get('artifact_filters')
+    result.log('DEBUG: Evidence config is:\n{0!s}'.format(evidence.config))
+    if evidence.config and evidence.config.get('artifact_filters'):
+      artifact_filters = evidence.config.get('artifact_filters')
       artifact_filters = artifact_filters.replace(':', ',')
     else:
       artifact_filters = None
 
-    if self.evidence.config and self.evidence.config.get('parsers'):
-      parsers = self.evidence.config.get('parsers')
+    if evidence.config and evidence.config.get('parsers'):
+      parsers = evidence.config.get('parsers')
       parsers = parsers.replace(':', ',')
     else:
       parsers = None
 
-    if self.evidence.config and self.evidence.config.get('file_filters'):
-      file_filters = self.evidence.config.get('file_filters')
+    if evidence.config and evidence.config.get('file_filters'):
+      file_filters = evidence.config.get('file_filters')
       file_filter_file = os.path.join(self.tmp_dir, 'file_filter.txt')
       try:
         with open(file_filter_file, 'w') as file_filter_fh:


### PR DESCRIPTION
This is a temporary mechanism to import Plaso artifacts/parsers/file_filters from the --recipe_config flag while #486 is being finalized, and once that's in place it will replace this. 

Tested with the following (since the Plaso flags are mutually exclusive):
`turbiniactl --jobs_whitelist PlasoJob -f --recipe_config='file_filters=/foo/bar:/bar/foo' rawdisk -l /tmp/test-small.img`

`turbiniactl --jobs_whitelist PlasoJob -f --recipe_config='artifact_filters=BrowserCache:BrowserHistory,parsers=webhist:linux' rawdisk -l /tmp/test-small.img`