### PR TITLE
Remove --vss_stores all from default Plaso Task

### DIFF
--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -671,7 +671,7 @@ def main():
         except ValueError as exception:
           log.error(
               'Could not parse key=value pair [{0:s}] from recipe config '
-              '{1:s}: {2!s}'.format(pair, args.recipe_config, exception))
+              '{1!s}: {2!s}'.format(pair, args.recipe_config, exception))
           sys.exit(1)
         request.recipe[key] = value
     if args.dump_json:

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -69,10 +69,14 @@ class PlasoTask(TurbiniaTask):
             file_filter_file, exception)
         result.close(self, success=False, status=message)
         return result
-
     else:
       file_filters = None
       file_filter_file = None
+
+    if evidence.config and evidence.config.get('vss'):
+      vss = evidence.config.get('vss')
+    else:
+      vss = None
 
     # Write plaso file into tmp_dir because sqlite has issues with some shared
     # filesystems (e.g NFS).
@@ -83,7 +87,7 @@ class PlasoTask(TurbiniaTask):
     # TODO(aarontp): Move these flags into a recipe
     cmd = (
         'log2timeline.py --status_view none --hashers all '
-        '--partition all --vss_stores all').split()
+        '--partition all').split()
     if config.DEBUG_TASKS:
       cmd.append('-d')
     if artifact_filters:
@@ -92,6 +96,8 @@ class PlasoTask(TurbiniaTask):
       cmd.extend(['--parsers', parsers])
     if file_filters:
       cmd.extend(['--file_filter', file_filter_file])
+    if vss:
+      cmd.extend(['--vss_stores', vss])
 
     if isinstance(evidence, (APFSEncryptedDisk, BitlockerDisk)):
       if evidence.recovery_key:


### PR DESCRIPTION
Removes the  `--vss_stores all` flag from the default run of the Plaso Task, but this can now be passed in with `--recipe_config='vss=all'` if needed.  Also fixes format string in turbiniactl --recipe_config parsing.