### PR TITLE
Updated documentation for Docker usage instructions and fixed docker dependency check to check image id length

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ optional arguments:
 *   [Developing new Tasks](docs/developing-new-tasks.md)
 *   [FAQ](docs/faq.md)
 *   [Debugging and Common Errors](docs/debugging.md)
+*   [Using Docker to execute jobs](docs/using-docker.md)
 
 ##### Obligatory Fine Print
 

--- a/docs/using-docker.md
+++ b/docs/using-docker.md
@@ -1,19 +1,19 @@
-# Using Docker for job execution
+# Using Docker for Job execution
 
 ## Overview 
-Turbinia can support Docker by allowing users to configure jobs to execute through a Docker container. This eliminates the need to install all the necessary dependencies and/or external programs on the host machine and instead execute the job through a container that has all the necessary dependencies installed. Please note that Turbinia does not provide the Docker images necessary for each job and they will need to either be created or pulled from a container registry. 
+Turbinia supports the use of Docker by allowing a Task to execute its command through a Docker Container instead. For example, when a Task for a PlasoJob is passed to a Worker, the Task will execute the command `log2timeline.py <ARGS>` through the Container and pass back the associated data to the Worker for further processing. The benefit being that it eliminates having to install the required dependencies and/or external programs for a Job on the Worker's host machine. Please note that Turbinia does not provide the Docker Images necessary for each Job and they will need to either be created or pulled from a container registry.
 
 ## Enabling Docker usage
 In order to enable this feature, please take the following steps. 
-1. Install the Docker daemon on the host machine. Please visit the Docker website for the [Installation Guide](https://docs.docker.com/install/).
+1. Install the Docker daemon on the Worker's host machine. Please visit the Docker website for the [Installation Guide](https://docs.docker.com/install/).
 2. In the `.turbiniarc` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
-3. Review the `DEPENDENCIES` flag in the `.turbiniarc` configuration file and identify which job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the `image_id` of the Docker image. 
-4. Save the `.turbiniarc` configuration file then start a new worker.
-5. If the dependency check succeeds, the worker should now execute the configured job through a Docker container. 
+3. Review the `DEPENDENCIES` flag in the `.turbiniarc` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the `image_id` of the Docker image. 
+4. Save the `.turbiniarc` configuration file then restart all Workers for the changes to take into effect. 
+5. When the Workers start, they will perform dependency checks to ensure that the binaries required by the Job are installed in the Container, and if that check passes, it will execute those in the configured Docker Container. 
 6. If you no longer would like to use the Docker image, set the `docker_image` value back to `None`.
 
 ## Example using Plaso
-The following section provides an example of the steps mentioned above for the Plaso job by using the Docker CLI to retrieve the required information.
+The following section provides an example of the steps mentioned above for the Plaso Job by using the Docker CLI to retrieve the required information.
 1. Retrieve the latest Plaso Docker image either locally or through a preconfigured registry containing the image.
     * ` docker pull log2timeline/plaso`
 2. Identify the  `image_id` for the retrieved image. 
@@ -25,7 +25,7 @@ The following section provides an example of the steps mentioned above for the P
     log2timeline/plaso                              latest              9c22665bff50        4 days ago          314MB
     ```
 3. Open up the `.turbiniarc` configuration file then set the attribute `DOCKER_ENABLED` to `True`. 
-4. Identify the `DEPENDENICES` attribute and look for the job `PlasoJob`, then replace the `docker_image` value with the identified `IMAGE ID`. 
+4. Identify the `DEPENDENICES` attribute and look for the Job `PlasoJob`, then replace the `docker_image` value with the identified `IMAGE ID`. 
     ```python
     {
         'job': 'PlasoJob'
@@ -33,6 +33,6 @@ The following section provides an example of the steps mentioned above for the P
         'docker_image': '9c22665bff50' 
     }
     ```
-5. Save the configuration file, then restart the turbinia worker.
-    * `turbiniactl psqworker`
-6. If the dependency check succeeds, the worker should now execute the `PlasoJob` through the specified docker container.
+5. Save the configuration file, then restart the turbinia Worker.
+    * `sudo systemctl restart turbinia@psqworker.service`
+6. If the dependency check succeeds, once a Worker receives a Docker configured Task, the Task will execute its external command through the Docker Container instead and pass the associated data back to the Worker for further processing. 

--- a/docs/using-docker.md
+++ b/docs/using-docker.md
@@ -1,0 +1,38 @@
+# Using Docker for job execution
+
+## Overview 
+Turbinia can support Docker by allowing users to configure jobs to execute through a Docker container. This eliminates the need to install all the necessary dependencies and/or external programs on the host machine and instead execute the job through a container that has all the necessary dependencies installed. Please note that Turbinia does not provide the Docker images necessary for each job and they will need to either be created or pulled from a container registry. 
+
+## Enabling Docker usage
+In order to enable this feature, please take the following steps. 
+1. Install the Docker daemon on the host machine. Please visit the Docker website for the [Installation Guide](https://docs.docker.com/install/).
+2. In the `.turbiniarc` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
+3. Review the `DEPENDENCIES` flag in the `.turbiniarc` configuration file and identify which job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the `image_id` of the Docker image. 
+4. Save the `.turbiniarc` configuration file then start a new worker.
+5. If the dependency check succeeds, the worker should now execute the configured job through a Docker container. 
+6. If you no longer would like to use the Docker image, set the `docker_image` value back to `None`.
+
+## Example using Plaso
+The following section provides an example of the steps mentioned above for the Plaso job by using the Docker CLI to retrieve the required information.
+1. Retrieve the latest Plaso Docker image either locally or through a preconfigured registry containing the image.
+    * ` docker pull log2timeline/plaso`
+2. Identify the  `image_id` for the retrieved image. 
+    * `docker image ls`  
+
+    Then copy the value listed under the column `IMAGE ID`.
+    ```
+    REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
+    log2timeline/plaso                              latest              9c22665bff50        4 days ago          314MB
+    ```
+3. Open up the `.turbiniarc` configuration file then set the attribute `DOCKER_ENABLED` to `True`. 
+4. Identify the `DEPENDENICES` attribute and look for the job `PlasoJob`, then replace the `docker_image` value with the identified `IMAGE ID`. 
+    ```python
+    {
+        'job': 'PlasoJob'
+        'programs': ['log2timeline.py'],
+        'docker_image': '9c22665bff50' 
+    }
+    ```
+5. Save the configuration file, then restart the turbinia worker.
+    * `turbiniactl psqworker`
+6. If the dependency check succeeds, the worker should now execute the `PlasoJob` through the specified docker container.

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -137,7 +137,12 @@ def check_docker_dependencies(dependencies):
           'The job {0:s} was not found or has been disabled. Skipping '
           'dependency check...'.format(job))
       continue
-    elif values.get('docker_image') in images:
+    docker_image = values.get('docker_image')
+    # short id only pulls the first 10 characters of image id.
+    if docker_image and len(docker_image) > 10:
+      docker_image = docker_image[0:10]
+
+    if docker_image in images:
       for program in values['programs']:
         cmd = 'type {0:s}'.format(program)
         stdout, stderr, ret = docker_manager.ContainerManager(
@@ -148,7 +153,7 @@ def check_docker_dependencies(dependencies):
               'the dependency for the container or disable the job.'.format(
                   program, job))
       job_manager.JobsManager.RegisterDockerImage(job, values['docker_image'])
-    elif values.get('docker_image'):
+    elif docker_image:
       raise TurbiniaException(
           'Docker image {0:s} was not found for the job {1:s}. Please '
           'update the config with the correct image id'.format(


### PR DESCRIPTION
Updated documentation for Docker usage instructions and fixed a part of the Docker dependency check where the python Docker library pulls only the first 10 characters of the Image id and running a command such as docker image ls, will pull the image id containing the first 12 characters. 