### PR TITLE
Fixed yapf style update from 'chromium' to 'yapf'

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -3,7 +3,7 @@
 #     yapf -i -r --style .style.yapf ./turbinia/
 #
 [style]
-based_on_style = chromium
+based_on_style = yapf
 COALESCE_BRACKETS = True
 SPLIT_BEFORE_FIRST_ARGUMENT = True
 SPLIT_PENALTY_AFTER_OPENING_BRACKET = 0


### PR DESCRIPTION
Per: https://github.com/google/yapf/commit/22ef70f3c497436adf59934b2ffa84ce6f962b88 variable for 'chromium' style guide was updated to 'yapf'