### PR TITLE
Fixed write/encoding issue with SSHD task writing to output file

### DIFF
--- a/turbinia/workers/sshd.py
+++ b/turbinia/workers/sshd.py
@@ -54,7 +54,7 @@ class SSHDAnalysisTask(TurbiniaTask):
     result.report_data = report
 
     # Write the report to the output file.
-    with open(output_file_path, 'w') as fh:
+    with open(output_file_path, 'wb') as fh:
       fh.write(output_evidence.text_data.encode('utf-8'))
 
     # Add the resulting evidence to the result object.


### PR DESCRIPTION
Since we are encoding the data into utf-8, the data type is bytes so we have to open the file with 'wb' instead of 'w'