### PR TITLE
Fixed yapf encoding issue

### DIFF
--- a/turbinia/yapf_test.py
+++ b/turbinia/yapf_test.py
@@ -21,7 +21,7 @@ class StyleTest(unittest.TestCase):
             'From the root directory of the repository, run '
             '"yapf --style {0:s} -i -r {1:s}" to correct '
             'these problems: {2:s}'.format(
-                config_path, turbinia_path, e.output.encode('utf-8')))
+                config_path, turbinia_path, e.output.decode('utf-8')))
       raise
 
 


### PR DESCRIPTION
Fixed yapf encoding issue when running tests. Issue was due to Python3 automatic encoding so had to decode the value instead. 