### PR TITLE
Auto conversion of Directory evidence to CompressedDirectory

### DIFF
--- a/turbinia/processors/archive.py
+++ b/turbinia/processors/archive.py
@@ -53,11 +53,12 @@ def ValidateTarFile(compressed_directory):
         'acceptable exensions are: .tgz or .tar.gz')
 
 
-def CompressDirectory(uncompressed_directory):
+def CompressDirectory(uncompressed_directory, output_path=None):
   """Compress a given directory into a tar file.
 
   Args:
     uncompressed_directory(str): The path to the uncompressed directory.
+    output_path(str): The path to compress the directory into.
 
   Returns:
     str: The path to the tar file.
@@ -70,6 +71,9 @@ def CompressDirectory(uncompressed_directory):
 
   # Iterate through a given list of files and compress them.
   compressed_directory = uncompressed_directory + '.tar.gz'
+  if output_path:
+    output_file = compressed_directory.split('/')[-1]
+    compressed_directory = os.path.join(output_path, output_file)
   try:
     with tarfile.TarFile.open(compressed_directory, 'w:gz') as tar:
       tar.add(uncompressed_directory, arcname='')

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -531,8 +531,18 @@ def main():
   elif args.command == 'directory':
     args.name = args.name if args.name else args.source_path
     source_path = os.path.abspath(args.source_path)
-    evidence_ = evidence.Directory(
-        name=args.name, source_path=source_path, source=args.source)
+
+    if not config.SHARED_FILESYSTEM:
+      log.info(
+          'A Cloud Only Architecture has been detected. '
+          'Compressing the directory for GCS upload.')
+      source_path = archive.CompressDirectory(source_path, output_path='/tmp')
+      args.name = args.name if args.name else source_path
+      evidence_ = evidence.CompressedDirectory(
+          name=args.name, source_path=source_path, source=args.source)
+    else:
+      evidence_ = evidence.Directory(
+          name=args.name, source_path=source_path, source=args.source)
   elif args.command == 'compressedirectory':
     archive.ValidateTarFile(args.source_path)
     args.name = args.name if args.name else args.source_path


### PR DESCRIPTION
* If a directory is passed by the `turbinia client`, adds logic to check within the config if it is a `SHARED_FILESYSTEM` and if NOT, convert the `Directory` evidence type into a `CompressedDirectory` evidence type. 