### PR TITLE
Copy disks when only zone is different

### DIFF
--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -493,7 +493,8 @@ def main():
       log.error('Turbinia project must be set by --project or in config')
       sys.exit(1)
 
-    if args.project and args.project != config.TURBINIA_PROJECT:
+    if ((args.project and args.project != config.TURBINIA_PROJECT) or
+        (args.zone and args.zone != config.TURBINIA_ZONE)):
       new_disk = gcp_forensics.CreateDiskCopy(
           args.project, config.TURBINIA_PROJECT, None, config.TURBINIA_ZONE,
           disk_name=args.disk_name)


### PR DESCRIPTION
Currently the Turbinia client will copy the disk from the source zone/project when the project is different, but this will make it so that it will copy the disk even when the project is the same but the zone is different.