### PR TITLE
small fix on dependency checker for local turbinia

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -952,7 +952,7 @@ class TurbiniaCeleryWorker(BaseTurbiniaClient):
     dependencies = config.ParseDependencies()
     if config.DOCKER_ENABLED:
       check_docker_dependencies(dependencies)
-    check_system_dependencies(config.DEPENDENCIES)
+    check_system_dependencies(dependencies)
     check_directory(config.MOUNT_DIR_PREFIX)
     check_directory(config.OUTPUT_DIR)
     check_directory(config.TMP_DIR)


### PR DESCRIPTION
function check_system_dependencies expects to be given a dict. The constructor on TurbiniaCeleryWorker feeds the unprocessed list from the config module, prompting an AttributeError triggered by Items() being called on a list.

Fixed by feeding the dictionary resulting from ParseDependencies, as happens in the TurbiniaPsqWorker constructor.