### PR TITLE
minor fix on redis state manager

### DIFF
--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -284,8 +284,6 @@ class RedisStateManager(BaseStateManager):
     task_data = self.get_task_dict(task)
     task_data['last_update'] = task_data['last_update'].strftime(
         DATETIME_FORMAT)
-    if task_data['run_time']:
-      task_data['run_time'] = task_data['run_time'].total_seconds()
     # Need to use json.dumps, else redis returns single quoted string which
     # is invalid json
     if not self.client.set(key, json.dumps(task_data)):

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -261,7 +261,7 @@ class RedisStateManager(BaseStateManager):
         task['last_update'] = datetime.strptime(
             task.get('last_update'), DATETIME_FORMAT)
       if task.get('run_time'):
-        task['run_time'] = datetime.timedelta(seconds=task['run_time'])
+        task['run_time'] = timedelta(seconds=task['run_time'])
 
     # pylint: disable=no-else-return
     if days:


### PR DESCRIPTION
potential minor bug in RedisStateManager. The UpdateTask function gets a dictionary of task attributes from the get_task_dict function, it then attempts to replace the value associated to the 'run_time' key to a second count. This is something that the get_task_dict already does. Therefore the total_seconds method is called on a float object causing a AttributeError.