### PR TITLE
Use config settings for log and output dirs

### DIFF
--- a/docker/server/start.sh
+++ b/docker/server/start.sh
@@ -6,4 +6,4 @@ then
     echo "${TURBINIA_CONF}" | base64 -d > /etc/turbinia/turbinia.conf
 fi
 
-/usr/local/bin/turbiniactl -L /var/log/turbinia/turbinia.log -S -o /var/lib/turbinia server
+/usr/local/bin/turbiniactl -S server

--- a/docker/worker/start.sh
+++ b/docker/worker/start.sh
@@ -6,4 +6,4 @@ then
     echo "${TURBINIA_CONF}" | base64 -d > /etc/turbinia/turbinia.conf
 fi
 
-/usr/local/bin/turbiniactl -L /var/log/turbinia/turbinia.log -S -o /var/lib/turbinia psqworker
+/usr/local/bin/turbiniactl -S psqworker


### PR DESCRIPTION
The current docker image for both server and worker uses hard coded paths for log files and output. This PR changes that and will let Turbinia pick those from the config file instead.