### PR TITLE
Some googleclouddisk e2e test improvements

### DIFF
--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -39,8 +39,8 @@ $TURBINIA_CLI -d -r $REQ_ID -L $MAIN_LOG -a -w googleclouddisk -d $DISK -z $ZONE
 $TURBINIA_CLI -d status -r $REQ_ID -s > $STATS_LOG 2>&1
 
 # Parse out the number of succesfull and failed tasks.
-FAILED=`cat $STATS_LOG | grep Failed stats.log  | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
-SUCCESS=`cat $STATS_LOG | grep Success stats.log  | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
+FAILED=`cat $STATS_LOG | grep Failed | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
+SUCCESS=`cat $STATS_LOG | grep Success | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
 
 echo "Results for request ID: $REQ_ID" | tee -a $MAIN_LOG
 echo "Failed tasks: $FAILED" | tee -a $MAIN_LOG
@@ -50,6 +50,7 @@ echo "Successful tasks: $SUCCESS"  | tee -a $MAIN_LOG
 $TURBINIA_CLI -d -a status -r $REQ_ID -R > $DETAIL_LOG 2>&1
 
 # Retrieve all test output from GCS and store LOGS folder
+echo "Copy all task result files from GCS"
 cat $DETAIL_LOG|grep "gs://"|tr -d "*\`"|while read line
 do
   OUTFILE=`echo "$line"|awk -F/ '{print $(NF-1)"_"$NF}'`
@@ -63,7 +64,7 @@ tar -vzcf $OUT_TGZ $LOGS/*
 echo -n "Ended at "
 date -Iseconds
 
-if [ $FAILED -ne "0" ]
+if [ "$FAILED" != "0" ]
 then
   exit 1
 fi

--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -33,7 +33,7 @@ echo "Executing googlecloudisk e2e test....this takes ~60 minutes!"
 $TURBINIA_CLI -d -r $REQ_ID -L $MAIN_LOG -a -w googleclouddisk -d $DISK -z $ZONE
 
 # When the Turbinia request is finished request the final request statistics.
-$TURBINIA_CLI -d status -D -r $REQ_ID -s > $STATS_LOG 2>&1
+$TURBINIA_CLI -d status -r $REQ_ID -s > $STATS_LOG 2>&1
 
 # Parse out the number of succesfull and failed tasks.
 FAILED=`cat $STATS_LOG | grep Failed stats.log  | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
@@ -44,7 +44,7 @@ echo "Failed tasks: $FAILED" | tee -a $MAIN_LOG
 echo "Successful tasks: $SUCCESS"  | tee -a $MAIN_LOG
 
 # Output the details, including GCS worker output for the request.
-$TURBINIA_CLI -d -a status -D -r $REQ_ID -R > $DETAIL_LOG 2>&1
+$TURBINIA_CLI -d -a status -r $REQ_ID -R > $DETAIL_LOG 2>&1
 
 # tgz the log files for debugging purposes
 tar -vzcf $OUT_TGZ $MAIN_LOG $STATS_LOG $DETAIL_LOG

--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -33,7 +33,7 @@ echo "Executing googlecloudisk e2e test....this takes ~60 minutes!"
 $TURBINIA_CLI -r $REQ_ID -L $MAIN_LOG -a -w googleclouddisk -d $DISK -z $ZONE
 
 # When the Turbinia request is finished request the final request statistics.
-$TURBINIA_CLI status -r $REQ_ID -s > $STATS_LOG 2>&1
+$TURBINIA_CLI status -D -r $REQ_ID -s > $STATS_LOG 2>&1
 
 # Parse out the number of succesfull and failed tasks.
 FAILED=`cat $STATS_LOG | grep Failed stats.log  | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
@@ -44,7 +44,7 @@ echo "Failed tasks: $FAILED" | tee -a $MAIN_LOG
 echo "Successful tasks: $SUCCESS"  | tee -a $MAIN_LOG
 
 # Output the details, including GCS worker output for the request.
-$TURBINIA_CLI -a status -r $REQ_ID -R > $DETAIL_LOG 2>&1
+$TURBINIA_CLI -a status -D -r $REQ_ID -R > $DETAIL_LOG 2>&1
 
 # tgz the log files for debugging purposes
 tar -vzcf $OUT_TGZ $MAIN_LOG $STATS_LOG $DETAIL_LOG

--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -51,7 +51,8 @@ $TURBINIA_CLI -d -a status -r $REQ_ID -R > $DETAIL_LOG 2>&1
 
 # Retrieve all test output from GCS and store LOGS folder
 echo "Copy all task result files from GCS"
-cat $DETAIL_LOG|grep "gs://"|tr -d "*\`"|while read line
+echo "Note: excluding result from StringAsciiTask due to large result file"
+cat $DETAIL_LOG|grep "gs://"|tr -d "*\`"|grep -v "\.ascii"|while read line
 do
   OUTFILE=`echo "$line"|awk -F/ '{print $(NF-1)"_"$NF}'`
   echo "Copying $line to $OUTFILE"

--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -8,7 +8,7 @@ LOGS="logs"
 MAIN_LOG="$LOGS/main.log"
 STATS_LOG="$LOGS/stats.log"
 DETAIL_LOG="$LOGS/reqdetails.log"
-OUT_TGZ="$LOGS/reqresults.tgz"
+OUT_TGZ="e2e-test-logs.tgz"
 DISK="test-disk2"
 
 if [ $# -ne  2 ]

--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -30,10 +30,10 @@ echo "Creating GCE test disk to use in e2e test"
 gcloud --project=$PROJECT compute disks create $DISK --image=$DISK --zone=$ZONE
 
 echo "Executing googlecloudisk e2e test....this takes ~60 minutes!"
-$TURBINIA_CLI -r $REQ_ID -L $MAIN_LOG -a -w googleclouddisk -d $DISK -z $ZONE
+$TURBINIA_CLI -d -r $REQ_ID -L $MAIN_LOG -a -w googleclouddisk -d $DISK -z $ZONE
 
 # When the Turbinia request is finished request the final request statistics.
-$TURBINIA_CLI status -D -r $REQ_ID -s > $STATS_LOG 2>&1
+$TURBINIA_CLI -d status -D -r $REQ_ID -s > $STATS_LOG 2>&1
 
 # Parse out the number of succesfull and failed tasks.
 FAILED=`cat $STATS_LOG | grep Failed stats.log  | cut -d ":" -f 3 | cut -d ',' -f 1 |  tr -d '[:space:]'`
@@ -44,7 +44,7 @@ echo "Failed tasks: $FAILED" | tee -a $MAIN_LOG
 echo "Successful tasks: $SUCCESS"  | tee -a $MAIN_LOG
 
 # Output the details, including GCS worker output for the request.
-$TURBINIA_CLI -a status -D -r $REQ_ID -R > $DETAIL_LOG 2>&1
+$TURBINIA_CLI -d -a status -D -r $REQ_ID -R > $DETAIL_LOG 2>&1
 
 # tgz the log files for debugging purposes
 tar -vzcf $OUT_TGZ $MAIN_LOG $STATS_LOG $DETAIL_LOG

--- a/turbinia/e2e/teardown-gce.sh
+++ b/turbinia/e2e/teardown-gce.sh
@@ -34,15 +34,14 @@ do
   fi
 done
 
-# TODO(rbdebeer) Debug and fix remove-iam-policy-binding calls.
 # Remove IAM bindings and terraform service account
 echo "Removing IAM bidings and service account..."
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/editor' --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/compute.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/cloudfunctions.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/servicemanagement.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/pubsub.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/storage.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/redis.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts remove-iam-policy-binding $SA_MEMBER --member=serviceAccount:$SA_MEMBER --role='roles/cloudsql.admin'  --all
-# gcloud -q --project=$PROJECT iam service-accounts delete $SA_MEMBER
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/editor'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/compute.admin'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/cloudfunctions.admin'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/servicemanagement.admin'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/pubsub.admin'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/storage.admin'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/redis.admin'
+gcloud -q --project=$PROJECT projects remove-iam-policy-binding $PROJECT --member=serviceAccount:$SA_MEMBER --role='roles/cloudsql.admin'
+gcloud -q --project=$PROJECT iam service-accounts delete $SA_MEMBER


### PR DESCRIPTION
* IAM roles and service account are cleaned up when test is done
* debug flag is set for each turbiniactl command
* e2e return value parsing improvements
* include GCS stored output of each task in local archive (excluding StringAsciiTask on whole disk due to size)