### PR TITLE
Support logfile path from env variable

### DIFF
--- a/docker/server/start.sh
+++ b/docker/server/start.sh
@@ -6,4 +6,10 @@ then
     echo "${TURBINIA_CONF}" | base64 -d > /etc/turbinia/turbinia.conf
 fi
 
-/usr/local/bin/turbiniactl -S server
+# Use log file path from environment variable is it exists, else get the path from the config.
+if [ ! -z ${TURBINIA_LOG_FILE+x} ]
+then
+    /usr/local/bin/turbiniactl -L $TURBINIA_LOG_FILE -S server
+else
+    /usr/local/bin/turbiniactl -S server
+fi

--- a/docker/server/start.sh
+++ b/docker/server/start.sh
@@ -6,4 +6,4 @@ then
     echo "${TURBINIA_CONF}" | base64 -d > /etc/turbinia/turbinia.conf
 fi
 
-/usr/local/bin/turbiniactl -L /var/log/turbinia/turbinia.log -S -o /var/lib/turbinia server
+/usr/local/bin/turbiniactl -S server

--- a/docker/worker/start.sh
+++ b/docker/worker/start.sh
@@ -6,4 +6,10 @@ then
     echo "${TURBINIA_CONF}" | base64 -d > /etc/turbinia/turbinia.conf
 fi
 
-/usr/local/bin/turbiniactl -S psqworker
+# Use log file path from environment variable is it exists, else get the path from the config.
+if [ ! -z ${TURBINIA_LOG_FILE+x} ]
+then
+    /usr/local/bin/turbiniactl -L $TURBINIA_LOG_FILE -S psqworker
+else
+    /usr/local/bin/turbiniactl -S psqworker
+fi

--- a/docker/worker/start.sh
+++ b/docker/worker/start.sh
@@ -6,4 +6,4 @@ then
     echo "${TURBINIA_CONF}" | base64 -d > /etc/turbinia/turbinia.conf
 fi
 
-/usr/local/bin/turbiniactl -L /var/log/turbinia/turbinia.log -S -o /var/lib/turbinia psqworker
+/usr/local/bin/turbiniactl -S psqworker


### PR DESCRIPTION
To support custom location of the logfile, e.g. when having  a multinode setup using docker compose there need to be a separate logfile for each node. This PR adds support for that via a env variable.

This variable can be set per node using the docker compose file with the --env TURBINIA_LOG_FILE=/foo/bar.log