### PR TITLE
PR to migrate Travis to Github actions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,8 +27,3 @@ jobs:
         pip install .
         pip install .[local]
         pip install -r dfvfs_requirements.txt
-    - name: Run Tests
-      run: |
-        ./run_tests.py
-        tox --sitepackages ${TOXENV}
-        

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,23 @@
+
+name: Turbinia Run
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install mock nose coverage yapf
+        pip install tox
+        pip install .
+        pip install .[local]
+        pip install -r dfvfs_requirements.txt
+        

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,6 +12,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
+    - name: Use cached dependencies
     - uses: actions/cache@v2
       with:
         path: ~/.cache/pip
@@ -26,4 +27,8 @@ jobs:
         pip install .
         pip install .[local]
         pip install -r dfvfs_requirements.txt
+    - name: Run Tests
+      run: |
+        ./run_tests.py
+        tox --sitepackages ${TOXENV}
         

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,6 +12,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,10 +1,11 @@
 
-name: Turbinia Run
-#t
+name: Turbinia Test Run
+
 on: push
 
 jobs:
-  build:
+  install-n-test:
+    name: Install Turbinia dependencies and run tests.
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
     - name: Setup Python 3.6
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,6 +1,6 @@
 
 name: Turbinia Run
-
+#t
 on: push
 
 jobs:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,3 +27,7 @@ jobs:
         pip install .
         pip install .[local]
         pip install -r dfvfs_requirements.txt
+    - name: Run Tests
+      run: |
+        ./run_tests.py
+        tox --sitepackages ${TOXENV}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
     - name: Setup Python 3.6
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         python-version: 3.6
     - name: Use cached dependencies
-    - uses: actions/cache@v2
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}


### PR DESCRIPTION
The following PR creates an `actions.yml` file that will replicate the test run of Travis by installing Turbinia dependencies then running ./run_tests.py. Fixes #611 