### PR TITLE
Removing useless Object inheritance

### DIFF
--- a/turbinia/celery.py
+++ b/turbinia/celery.py
@@ -36,7 +36,7 @@ from turbinia.message import TurbiniaMessageBase
 log = logging.getLogger('turbinia')
 
 
-class TurbiniaCelery(object):
+class TurbiniaCelery:
   """Celery app object.
 
   Attributes:

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -235,7 +235,7 @@ def check_directory(directory):
           'Can not add write permissions to {0:s}'.format(directory))
 
 
-class TurbiniaStats(object):
+class TurbiniaStats:
   """Statistics for Turbinia task execution.
 
   Attributes:
@@ -307,7 +307,7 @@ class TurbiniaStats(object):
         self.description, self.count, self.min, self.mean, self.max)
 
 
-class BaseTurbiniaClient(object):
+class BaseTurbiniaClient:
   """Client class for Turbinia.
 
   Attributes:
@@ -1100,7 +1100,7 @@ class TurbiniaCeleryClient(BaseTurbiniaClient):
     return self.redis.get_task_data(instance, days, task_id, request_id)
 
 
-class TurbiniaServer(object):
+class TurbiniaServer:
   """Turbinia Server class.
 
   Attributes:
@@ -1181,7 +1181,7 @@ class TurbiniaCeleryWorker(BaseTurbiniaClient):
     self.worker.start(argv)
 
 
-class TurbiniaPsqWorker(object):
+class TurbiniaPsqWorker:
   """Turbinia PSQ Worker class.
 
   Attributes:

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -103,7 +103,7 @@ class EvidenceState(IntEnum):
   DOCKER_MOUNTED = 6
 
 
-class Evidence(object):
+class Evidence:
   """Evidence object for processing.
 
   In most cases, these objects will just contain metadata about the actual

--- a/turbinia/jobs/interface.py
+++ b/turbinia/jobs/interface.py
@@ -22,7 +22,7 @@ from turbinia.evidence import EvidenceCollection
 log = logging.getLogger('turbinia')
 
 
-class TurbiniaJob(object):
+class TurbiniaJob:
   """Base class for Turbinia Jobs.
 
   Attributes:

--- a/turbinia/jobs/manager.py
+++ b/turbinia/jobs/manager.py
@@ -19,7 +19,7 @@ from __future__ import unicode_literals
 from turbinia import TurbiniaException
 
 
-class JobsManager(object):
+class JobsManager:
   """The jobs manager."""
 
   _job_classes = {}

--- a/turbinia/lib/docker_manager.py
+++ b/turbinia/lib/docker_manager.py
@@ -76,7 +76,7 @@ def GetDockerPath(mount_path):
   return docker_path
 
 
-class DockerManager(object):
+class DockerManager:
   """Class handling Docker management."""
 
   def __init__(self):

--- a/turbinia/lib/dockermanager_test.py
+++ b/turbinia/lib/dockermanager_test.py
@@ -27,7 +27,7 @@ from turbinia.lib import docker_manager
 from turbinia import TurbiniaException
 
 
-class MockImage(object):
+class MockImage:
   """Mock class for a Docker image.
 
   Attributes:
@@ -41,7 +41,7 @@ class MockImage(object):
     self.short_id = 'sha256:{0:s}'.format(short_id)
 
 
-class MockContainer(object):
+class MockContainer:
   """Mock class for a Docker container.
 
   Attributes:

--- a/turbinia/message.py
+++ b/turbinia/message.py
@@ -31,7 +31,7 @@ from turbinia import TurbiniaException
 log = logging.getLogger('turbinia')
 
 
-class TurbiniaRequest(object):
+class TurbiniaRequest:
   """An object to request evidence to be processed.
 
   Attributes:
@@ -99,7 +99,7 @@ class TurbiniaRequest(object):
     self.__dict__ = obj
 
 
-class TurbiniaMessageBase(object):
+class TurbiniaMessageBase:
   """Base class to define common functions and interfaces around client/server
     communication.
   """

--- a/turbinia/output_manager.py
+++ b/turbinia/output_manager.py
@@ -35,7 +35,7 @@ if config.GCS_OUTPUT_PATH and config.GCS_OUTPUT_PATH.lower() is not 'none':
 log = logging.getLogger('turbinia')
 
 
-class OutputManager(object):
+class OutputManager:
   """Manages output data.
 
   Manages the configured output writers.  Also saves and retrieves evidence data
@@ -221,7 +221,7 @@ class OutputManager(object):
     self.is_setup = True
 
 
-class OutputWriter(object):
+class OutputWriter:
   """Base class.
 
   By default this will write the files the Evidence objects point to along with

--- a/turbinia/pubsub_test.py
+++ b/turbinia/pubsub_test.py
@@ -42,7 +42,7 @@ def getTurbiniaRequest():
   return request
 
 
-class MockPubSubMessage(object):
+class MockPubSubMessage:
   """This is a mock of a PubSub message."""
 
   def __init__(self, data='fake data', message_id='12345'):

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -68,7 +68,7 @@ def get_state_manager():
     raise TurbiniaException(msg)
 
 
-class BaseStateManager(object):
+class BaseStateManager:
   """Class to manage Turbinia state persistence."""
 
   def get_task_dict(self, task):

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -88,7 +88,7 @@ def task_runner(obj, *args, **kwargs):
   return obj.run_wrapper(*args, **kwargs)
 
 
-class BaseTaskManager(object):
+class BaseTaskManager:
   """Class to manage Turbinia Tasks.
 
   Handles incoming new Evidence messages, adds new Tasks to the queue and

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -57,7 +57,7 @@ class Priority(IntEnum):
   CRITICAL = 10
 
 
-class TurbiniaTaskResult(object):
+class TurbiniaTaskResult:
   """Object to store task results to be returned by a TurbiniaTask.
 
   Attributes:
@@ -336,7 +336,7 @@ class TurbiniaTaskResult(object):
     return result
 
 
-class TurbiniaTask(object):
+class TurbiniaTask:
   """Base class for Turbinia tasks.
 
   Attributes:


### PR DESCRIPTION
## Description 

This Pull Request removes the implicit `object` inheritance from the Base Class. 

The Issue seems to be very minor but it improves the readability of the Code and since Python 3 inserts it for us behind the scenes, I suggested that its best remove them up. 