### PR TITLE
Add option to provide arbitrary arguments to deploy.sh

### DIFF
--- a/turbinia/e2e/setup-gce.sh
+++ b/turbinia/e2e/setup-gce.sh
@@ -15,11 +15,13 @@ echo "Initiate gcloud configuration"
 if [ $# -ne  1 ]
 then
   echo "Not enough arguments supplied, please provide project."
+  echo "Any extra arguments will be passed to deploy.sh"
   echo "$0 [PROJECT]"
   exit 1
 fi
 
 PROJECT="$1"
+EXTRA_ARGS="$@"
 
 gcloud --project=$PROJECT info
 
@@ -49,6 +51,6 @@ sleep 60
 
 echo "Setup Terraform Turbinia infrastructure."
 export DEVSHELL_PROJECT_ID=$PROJECT
-./osdfir-infrastructure/deploy.sh --no-timesketch
+./osdfir-infrastructure/deploy.sh --no-timesketch $EXTRA_ARGS
 
 

--- a/turbinia/e2e/setup-gce.sh
+++ b/turbinia/e2e/setup-gce.sh
@@ -21,6 +21,7 @@ then
 fi
 
 PROJECT="$1"
+shift
 EXTRA_ARGS="$@"
 
 gcloud --project=$PROJECT info


### PR DESCRIPTION
To setup different version of the e2e tests (eg against dev docker images) we should be able to provide arbitrary switches to the terraform deploy.sh script.