### PR TITLE
Allow >1 argument to setup-gce.sh

### DIFF
--- a/turbinia/e2e/setup-gce.sh
+++ b/turbinia/e2e/setup-gce.sh
@@ -12,7 +12,7 @@ install_packages() {
 
 echo "Initiate gcloud configuration"
 
-if [ $# -ne  1 ]
+if [ $# -lt  1 ]
 then
   echo "Not enough arguments supplied, please provide project."
   echo "Any extra arguments will be passed to deploy.sh"


### PR DESCRIPTION
As we now pass extra arguments to Terraform deploy.sh we should allow >1 argument instead of checking for exactly 1 argument.