### PR TITLE
Custom artifact extraction recipe flag

### DIFF
--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -119,8 +119,8 @@ class BinaryExtractorTask(TurbiniaTask):
 
       with open(artifact_file, 'wb') as artifact:
         artifact.write(artifact_text.encode('utf-8'))
-      cmd.extend(
-          ['--custom_artifact_definitions', artifact_file, '--artifact_filters',
+      cmd.extend([
+          '--custom_artifact_definitions', artifact_file, '--artifact_filters',
           'TurbiniaCustomArtifact'
       ])
     else:

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -120,7 +120,7 @@ class BinaryExtractorTask(TurbiniaTask):
       with open(artifact_file, 'wb') as artifact:
         artifact.write(artifact_text.encode('utf-8'))
       cmd.extend(
-          ['--custom_artifact_definitions', artifact_dir, '--artifact_filters',
+          ['--custom_artifact_definitions', artifact_file, '--artifact_filters',
           'TurbiniaCustomArtifact'])
     else:
       cmd.extend(['--signatures', 'elf,exe_mz'])

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -142,7 +142,7 @@ class BinaryExtractorTask(TurbiniaTask):
       return result
 
     status = (
-        'Extracted {0:d} hashes and {1:d} binaries from the '
+        'Extracted {0:d} hashes and {1:d} files from the '
         'evidence.'.format(hash_cnt, binary_cnt))
 
     if hash_cnt != binary_cnt:

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -119,8 +119,8 @@ class BinaryExtractorTask(TurbiniaTask):
       with open(artifact_file, 'wb') as artifact:
         artifact.write(artifact_text.encode('utf-8'))
       cmd.extend(
-          '--custom_artifact_definitions', artifact_dir, '--artifact_filters'
-          'TurbiniaCustomArtifact')
+          ['--custom_artifact_definitions', artifact_dir, '--artifact_filters'
+          'TurbiniaCustomArtifact'])
     else:
       cmd.extend(['--signatures', 'elf,exe_mz'])
 

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -110,6 +110,7 @@ class BinaryExtractorTask(TurbiniaTask):
           """
           name: TurbiniaCustomArtifact
           doc: Ad hoc artifact created for file extraction.
+          sources:
           - type: FILE
             attributes:
                 paths: ['{0:s}']

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -121,7 +121,8 @@ class BinaryExtractorTask(TurbiniaTask):
         artifact.write(artifact_text.encode('utf-8'))
       cmd.extend(
           ['--custom_artifact_definitions', artifact_file, '--artifact_filters',
-          'TurbiniaCustomArtifact'])
+          'TurbiniaCustomArtifact'
+      ])
     else:
       cmd.extend(['--signatures', 'elf,exe_mz'])
 

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -132,11 +132,16 @@ class BinaryExtractorTask(TurbiniaTask):
     result.log('Running image_export as [{0:s}]'.format(' '.join(cmd)))
     self.execute(
         cmd, result, log_files=[image_export_log, self.json_path],
-        new_evidence=[binary_extraction_evidence], close=True)
+        new_evidence=[binary_extraction_evidence])
 
-    binary_cnt, hash_cnt = self.check_extraction()
+    try:
+      binary_cnt, hash_cnt = self.check_extraction()
+    except TurbiniaException as exception:
+      message = 'File extraction failed: {0!s}'.format(exception)
+      result.close(self, success=False, status=message)
+      return result
 
-    result.status = (
+    status = (
         'Extracted {0:d} hashes and {1:d} binaries from the '
         'evidence.'.format(hash_cnt, binary_cnt))
 
@@ -148,5 +153,6 @@ class BinaryExtractorTask(TurbiniaTask):
           'details.', logging.WARNING)
 
     binary_extraction_evidence.compress()
+    result.close(self, success=True, status=status)
 
     return result

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -116,8 +116,8 @@ class BinaryExtractorTask(TurbiniaTask):
           """)
       artifact_text = artifact_text.format(binary_extraction_path)
 
-      with open(artifact_file) as artifact:
-        artifact.write(artifact_text)
+      with open(artifact_file, 'wb') as artifact:
+        artifact.write(artifact_text.encode('utf-8'))
       cmd.extend(
           '--custom_artifact_definitions', artifact_dir, '--artifact_filters'
           'TurbiniaCustomArtifact')

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 import logging
 import json
 import os
+import textwrap
 
 from turbinia import TurbiniaException
 from turbinia import config
@@ -93,9 +94,36 @@ class BinaryExtractorTask(TurbiniaTask):
     self.json_path = os.path.join(self.binary_extraction_dir, 'hashes.json')
 
     cmd = [
-        'image_export.py', '--partitions', 'all', '--no_vss', '--signatures',
-        'elf,exe_mz', '--logfile', image_export_log
+        'image_export.py', '--partitions', 'all', '--no_vss', '--logfile',
+        image_export_log
     ]
+
+    if evidence.config and evidence.config.get('binary_extraction_path'):
+      artifact_dir = os.path.join(self.tmp_dir, 'artifacts')
+      artifact_file = os.path.join(artifact_dir, 'artifacts.yaml')
+      os.mkdir(artifact_dir)
+      binary_extraction_path = evidence.config.get('binary_extraction_path')
+      result.log(
+          'Using custom artifact path {0:s}'.format(binary_extraction_path))
+
+      artifact_text = textwrap.dedent(
+          """
+          name: TurbiniaCustomArtifact
+          doc: Ad hoc artifact created for file extraction.
+          - type: FILE
+            attributes:
+                paths: ['{0:s}']
+          """)
+      artifact_text = artifact_text.format(binary_extraction_path)
+
+      with open(artifact_file) as artifact:
+        artifact.write(artifact_text)
+      cmd.extend(
+          '--custom_artifact_definitions', artifact_dir, '--artifact_filters'
+          'TurbiniaCustomArtifact')
+    else:
+      cmd.extend(['--signatures', 'elf,exe_mz'])
+
     if config.DEBUG_TASKS or evidence.config.get('debug_tasks'):
       cmd.append('-d')
     cmd.extend(['-w', self.binary_extraction_dir, evidence.local_path])

--- a/turbinia/workers/binary_extractor.py
+++ b/turbinia/workers/binary_extractor.py
@@ -119,7 +119,7 @@ class BinaryExtractorTask(TurbiniaTask):
       with open(artifact_file, 'wb') as artifact:
         artifact.write(artifact_text.encode('utf-8'))
       cmd.extend(
-          ['--custom_artifact_definitions', artifact_dir, '--artifact_filters'
+          ['--custom_artifact_definitions', artifact_dir, '--artifact_filters',
           'TurbiniaCustomArtifact'])
     else:
       cmd.extend(['--signatures', 'elf,exe_mz'])


### PR DESCRIPTION
Allows you to specify something like `turbiniactl -C 'binary_extraction_path=%%users.homedir%%/Downloads/**'` (in ForensicsArtifacts format) to collect arbitrary files in an image with the binary extractor job. 