### PR TITLE
Fix Turbinia local stack

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ psq
 redis
 six>=1.15.0
 urllib3[secure]
-vine=1.3.0
+vine==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ psq
 redis
 six>=1.15.0
 urllib3[secure]
+vine=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+celery
 docker
 filelock
 google-api-core
@@ -12,5 +13,6 @@ google-cloud-storage
 prometheus_client
 libcloudforensics
 psq
+redis
 six>=1.15.0
 urllib3[secure]

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -1204,7 +1204,7 @@ class TurbiniaCeleryWorker(BaseTurbiniaClient):
     """Start Turbinia Celery Worker."""
     log.info('Running Turbinia Celery Worker.')
     self.worker.task(task_manager.task_runner, name='task_runner')
-    argv = ['celery', 'worker', '--loglevel=info', '--pool=solo']
+    argv = ['worker', '--loglevel=info', '--pool=solo']
     self.worker.start(argv)
 
 


### PR DESCRIPTION
2 small fixes so we can get the local stack to work again.
* add celery and redis to the requirements.txt (these are small and adding them there will make sure docker builds are consistent and work on both cloud and local)
* fix startup of celery worker ('celery' parameter is not needed anymore)
