### PR TITLE
Pin celery to <5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery==4.3.0
+celery<5.0
 docker
 filelock
 google-api-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery
+celery==4.3.0
 docker
 filelock
 google-api-core


### PR DESCRIPTION
The newest celery (5.x) is not compatible with our use of vines and kombu. Pinning to <5.0.