### PR TITLE
Add dynamic release versioning.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ with open('requirements.txt','r') as f:
   requirements = f.read().splitlines()
 setup(
     name='turbinia',
-    version=turbinia.__version__,
     description='Automation and Scaling of Digital Forensics Tools',
     long_description=turbinia_description,
     license='Apache License, Version 2.0',
@@ -66,5 +65,7 @@ setup(
         'dev': ['mock', 'nose', 'yapf', 'celery~=4.1', 'coverage'],
         'local': ['celery~=4.1', 'kombu~=4.1', 'redis~=3.0'],
         'worker': ['docker-explorer>=20191104', 'plaso>=20200430', 'pyhindsight>=20200607']
-    }
+    },
+    use_scm_version=True,
+    setup_requires=['setuptools_scm']
 )

--- a/turbinia/__init__.py
+++ b/turbinia/__init__.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 """Main Turbinia application."""
 
-
 import logging
 log = logging.getLogger('turbinia')
 
@@ -23,6 +22,7 @@ try:
   __version__ = get_distribution(__name__).version
 except DistributionNotFound:
   __version__ = "unknown"
+
 
 def log_and_report(message, trace):
   """Log an error and if enabled, send to GCP Error Reporting API.

--- a/turbinia/__init__.py
+++ b/turbinia/__init__.py
@@ -14,11 +14,15 @@
 # limitations under the License.
 """Main Turbinia application."""
 
-__version__ = '20190819'
 
 import logging
 log = logging.getLogger('turbinia')
 
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+  __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+  __version__ = "unknown"
 
 def log_and_report(message, trace):
   """Log an error and if enabled, send to GCP Error Reporting API.


### PR DESCRIPTION
Add automatic release versioning using setuptools_scm.

Fixes #694 

```
$ turbiniactl -V
20190819.4.dev118+g9ca7def.d20210128
```
Using setuptools_scm where:
20190819 = tag (of master in this case)
.4 = version number of tag
.dev118 = the distance to this tag (e.g. number of revisions since latest tag)
+short commit hash
+build date
```