### PR TITLE
Pin PyJWT.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ redis
 six>=1.15.0
 urllib3[secure]
 vine==1.3.0
+PyJWT[crypto]<2


### PR DESCRIPTION
Dependency failure while building, solve by pinning PyJWT[crypto]<2