### PR TITLE
Fix worker runtime in status output

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -797,7 +797,7 @@ class BaseTurbiniaClient:
         task_dict['status'] = status
         # Check status for anything that is running.
         if 'running' in status:
-          run_time = (datetime.now() -
+          run_time = (datetime.utcnow() -
                       result.get('last_update')).total_seconds()
           run_time = timedelta(seconds=run_time)
           task_dict['run_time'] = run_time


### PR DESCRIPTION
When showing the 'running' tasks, the task runtime was showing as a negative value because the worker updated the time based on UTC and the client was using local time, and it looked like the task had finished in the future :).