### PR TITLE
Use absolute path for dockerexplorer

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -14,6 +14,7 @@ python3-pip \
 software-properties-common \
 sudo \
 testdisk \
+sleuthkit \
 && rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt /tmp/
@@ -23,8 +24,9 @@ RUN cd /tmp/ && pip3 install -r dfvfs_requirements.txt
 
 RUN pip3 install pip --upgrade
 
-# Install Hindsight
+# Install third-party worker dependencies
 RUN pip3 install pyhindsight
+RUN pip3 install docker-explorer
 
 # Install Plaso
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \

--- a/turbinia/lib/utils.py
+++ b/turbinia/lib/utils.py
@@ -103,6 +103,25 @@ def extract_files(file_name, disk_path, output_dir):
   return _image_export(image_export_cmd, output_dir)
 
 
+def get_exe_path(filename):
+  """Gets the full path for a given executable.
+
+  Args:
+    filename (str): Executable name.
+
+  Returns:
+    (str|None): Full file path if it exists, else None
+  """
+  binary = None
+  for path in os.environ['PATH'].split(os.pathsep):
+    tentative_path = os.path.join(path, filename)
+    if os.path.exists(tentative_path):
+      binary = tentative_path
+      break
+
+  return binary
+
+
 def bruteforce_password_hashes(password_hashes, timeout=300):
   """Bruteforce password hashes using John the Ripper.
 

--- a/turbinia/processors/docker.py
+++ b/turbinia/processors/docker.py
@@ -23,6 +23,7 @@ import tempfile
 
 from turbinia import config
 from turbinia import TurbiniaException
+from turbinia import utils
 
 log = logging.getLogger('turbinia')
 
@@ -66,12 +67,7 @@ def PreprocessMountDockerFS(docker_dir, container_id):
   log.info(
       'Using docker_explorer to mount container {0:s} on {1:s}'.format(
           container_id, container_mount_path))
-  de_binary = None
-  for path in os.environ['PATH'].split(os.pathsep):
-    tentative_path = os.path.join(path, 'de.py')
-    if os.path.exists(tentative_path):
-      de_binary = tentative_path
-      break
+  de_binary = utils.get_exe_path('de.py')
 
   if not de_binary:
     raise TurbiniaException('Could not find docker-explorer script: de.py')

--- a/turbinia/processors/docker.py
+++ b/turbinia/processors/docker.py
@@ -23,7 +23,7 @@ import tempfile
 
 from turbinia import config
 from turbinia import TurbiniaException
-from turbinia import utils
+from turbinia.lib import utils
 
 log = logging.getLogger('turbinia')
 

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -208,7 +208,7 @@ def GetFilesystem(path):
   Returns:
     str: the filesystem detected (for example: 'ext4')
   """
-  cmd = ['lsblk', path, '-f', '-o', 'FSTYPE', '-n']
+  cmd = ['fsstat', '-t', path]
   log.info('Running {0!s}'.format(cmd))
   for retry in range(RETRY_MAX):
     fstype = subprocess.check_output(cmd).split()

--- a/turbinia/processors/mount_local_test.py
+++ b/turbinia/processors/mount_local_test.py
@@ -190,7 +190,7 @@ class MountLocalProcessorTest(unittest.TestCase):
     """Test GetFilesystem method."""
     mock_subprocess.return_value = b'ext4'
     fstype = mount_local.GetFilesystem('/dev/loop0')
-    expected_args = ['lsblk', '/dev/loop0', '-f', '-o', 'FSTYPE', '-n']
+    expected_args = ['fsstat', '-t', '/dev/loop0']
     mock_subprocess.assert_called_once_with(expected_args)
     self.assertEqual(fstype, 'ext4')
 

--- a/turbinia/workers/docker.py
+++ b/turbinia/workers/docker.py
@@ -26,6 +26,7 @@ from turbinia.workers import Priority
 from turbinia.workers import TurbiniaTask
 from turbinia.lib.docker_manager import GetDockerPath
 from turbinia import config
+from turbinia import utils
 
 log = logging.getLogger('turbinia')
 
@@ -51,7 +52,8 @@ class DockerContainersEnumerationTask(TurbiniaTask):
       a list(dict) containing information about the containers found.
 
     Raises:
-      TurbiniaException: when the docker-explorer tool failed to run.
+      TurbiniaException: when the docker-explorer tool cannot be found or failed
+          to run.
     """
     config.LoadConfig()
     docker_dir = GetDockerPath(evidence.mount_path)
@@ -60,8 +62,12 @@ class DockerContainersEnumerationTask(TurbiniaTask):
 
     # TODO(rgayon): use docker-explorer exposed constant when
     # https://github.com/google/docker-explorer/issues/80 is in.
+    de_binary = utils.get_exe_path('de.py')
+    if not de_binary:
+       raise TurbiniaException('Cannot find de.py in path')
+
     docker_explorer_command = [
-        'sudo', 'de.py', '-r', docker_dir, 'list', 'all_containers'
+        'sudo', de_binary, '-r', docker_dir, 'list', 'all_containers'
     ]
     if config.DEBUG_TASKS or evidence.config.get('debug_tasks'):
       docker_explorer_command.append('-d')

--- a/turbinia/workers/docker.py
+++ b/turbinia/workers/docker.py
@@ -22,11 +22,11 @@ import subprocess
 from turbinia import TurbiniaException
 from turbinia.evidence import DockerContainer
 from turbinia.evidence import EvidenceState as state
+from turbinia.lib import utils
 from turbinia.workers import Priority
 from turbinia.workers import TurbiniaTask
 from turbinia.lib.docker_manager import GetDockerPath
 from turbinia import config
-from turbinia import utils
 
 log = logging.getLogger('turbinia')
 
@@ -64,7 +64,7 @@ class DockerContainersEnumerationTask(TurbiniaTask):
     # https://github.com/google/docker-explorer/issues/80 is in.
     de_binary = utils.get_exe_path('de.py')
     if not de_binary:
-       raise TurbiniaException('Cannot find de.py in path')
+      raise TurbiniaException('Cannot find de.py in path')
 
     docker_explorer_command = [
         'sudo', de_binary, '-r', docker_dir, 'list', 'all_containers'


### PR DESCRIPTION
Because we install de.py with pip, when we run it with `sudo` it can't find the path so we grab it before execution.   Also switch to using fsstat instead of lsblk because sometimes lsblk doesn't give output for common filesystems (even ext4).