### PR TITLE
Set path_spec by default

### DIFF
--- a/turbinia/workers/partitions.py
+++ b/turbinia/workers/partitions.py
@@ -123,6 +123,7 @@ class PartitionEnumerationTask(TurbiniaTask):
     success = False
 
     mediator = dfvfs_classes.UnattendedVolumeScannerMediator()
+    path_specs = []
     try:
       scanner = volume_scanner.VolumeScanner(mediator=mediator)
       path_specs = scanner.GetBasePathSpecs(evidence.local_path)


### PR DESCRIPTION
Prevents `UnboundLocalError: local variable 'path_specs' referenced before assignment` error in case of an exception during processing.