### PR TITLE
Pin cloud logging to <2.1,>=2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-auth<2.0.0.dev0
 google-cloud-core
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
- google-cloud-logging<2.1,>=1.14.0
+google-cloud-logging<2.1,>=2.0.0
 google-cloud-pubsub==1.7.0
 google-cloud-storage
 prometheus_client


### PR DESCRIPTION
The imports for v2 have changed, so we either need to pin this >=2.0 or adjust the imports (and choosing to do the former here).