### PR TITLE
Start devcontainer in privileged mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"build": {
 		"dockerfile": "../docker/vscode/Dockerfile"
 	},
+	"runArgs": [ "--privileged" ],
 	// start redis-server and copy launch profiles to .vscode
 	"postCreateCommand": "/etc/init.d/redis-server start && mkdir -p .vscode && cp docker/vscode/vscode-launch.json .vscode/launch.json",
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
To support loop devices we need to start the vscode devcontainer in privileged mode.