### PR TITLE
Always save stdout/stderr from Task execution

### DIFF
--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -40,6 +40,7 @@ class TestTurbiniaTaskBase(unittest.TestCase):
     remove_dirs(list(str)): Dirs that will be removed after the test run
     base_output_dir(str): The base output directory used by the Task
     task(TurbiniaTask): The instantiated Task under test
+    test_stdout_path(str): A path we can use to send temporary stdout too
     evidence(Evidence): The test evidence object used by the Task
     result(TurbiniaResult): The result object used by the Task
   """
@@ -64,6 +65,8 @@ class TestTurbiniaTaskBase(unittest.TestCase):
     # Set up RawDisk Evidence
     test_disk_path = tempfile.mkstemp(dir=self.base_output_dir)[1]
     self.remove_files.append(test_disk_path)
+    self.test_stdout_path = tempfile.mkstemp(dir=self.base_output_dir)[1]
+    self.remove_files.append(self.test_stdout_path)
     self.evidence = evidence.RawDisk(source_path=test_disk_path)
     self.evidence.preprocess = mock.MagicMock()
     # Set up TurbiniaTaskResult
@@ -236,7 +239,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecute(self, popen_mock):
     """Test execution with success case."""
     cmd = 'test cmd'
-    output = ('test stdout', 'test stderr')
+    output = (b'test stdout', b'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -244,20 +247,25 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     proc_mock.returncode = 0
     popen_mock.return_value = proc_mock
 
-    self.task.execute(cmd, self.result, close=True)
+    self.task.execute(
+        cmd, self.result, stdout_file=self.test_stdout_path, close=True)
+
+    with open(self.test_stdout_path, 'rb') as stdout_path:
+      stdout_data = stdout_path.read()
 
     # Command was executed, has the correct output saved and
     # TurbiniaTaskResult.close() was called with successful status.
-    popen_mock.assert_called_with(cmd)
-    self.assertEqual(self.result.error['stdout'], output[0])
-    self.assertEqual(self.result.error['stderr'], output[1])
+    popen_mock.assert_called_with(cmd, stdout=-1, stderr=-1)
+    self.assertEqual(self.result.error['stdout'], str(output[0]))
+    self.assertEqual(self.result.error['stderr'], str(output[1]))
+    self.assertEqual(stdout_data, output[0])
     self.result.close.assert_called_with(self.task, success=True)
 
   @mock.patch('turbinia.workers.subprocess.Popen')
   def testTurbiniaTaskExecuteFailure(self, popen_mock):
     """Test execution with failure case."""
     cmd = 'test cmd'
-    output = ('test stdout', 'test stderr')
+    output = (b'test stdout', b'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -269,7 +277,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
     # Command was executed and TurbiniaTaskResult.close() was called with
     # unsuccessful status.
-    popen_mock.assert_called_with(cmd)
+    popen_mock.assert_called_with(cmd, stdout=-1, stderr=-1)
     self.result.close.assert_called_with(
         self.task, success=False, status=mock.ANY)
 
@@ -277,7 +285,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteEvidenceExists(self, popen_mock):
     """Test execution with new evidence that has valid a source_path."""
     cmd = 'test cmd'
-    output = ('test stdout', 'test stderr')
+    output = (b'test stdout', b'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -297,7 +305,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteEvidenceDoesNotExist(self, popen_mock):
     """Test execution with new evidence that does not have a source_path."""
     cmd = 'test cmd'
-    output = ('test stdout', 'test stderr')
+    output = (b'test stdout', b'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -313,7 +321,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteEvidenceExistsButEmpty(self, popen_mock):
     """Test execution with new evidence source_path that exists but is empty."""
     cmd = 'test cmd'
-    output = ('test stdout', 'test stderr')
+    output = (b'test stdout', b'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()


### PR DESCRIPTION
This way we can always get access to the stdout/stderr easily from saved output, and it's not dependent on how logs are saved from the Worker.  This also makes it easier for saving stdout as directly as Evidence output.

Also unset input evidence when serializing `TurbiniaTaskResults` which fixes: #779.

This should be submitted before #770 