### PR TITLE
Heartbeat check for long running tasks

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -138,6 +138,7 @@ def register_job_timeouts(dependencies):
     dependencies(dict): dependencies to grab timeout value from.
   """
   log.info('Registering job timeouts.')
+  timeout_default = 3600
 
   job_names = list(job_manager.JobsManager.GetJobNames())
   # Iterate through list of jobs
@@ -145,6 +146,10 @@ def register_job_timeouts(dependencies):
     if job not in job_names:
       continue
     timeout = values.get('timeout')
+    if type(timeout) != int:
+      log.warning(
+          'No timeout found for job: {0:s}. Setting default timeout of {1:d} seconds.'
+          .format(job, timeout_default))
     job_manager.JobsManager.RegisterTimeout(job, values['timeout'])
 
 

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -131,6 +131,23 @@ def get_turbinia_client(run_local=False):
     raise TurbiniaException(msg)
 
 
+def register_job_timeouts(dependencies):
+  """Registers a timeout for each job.
+
+  Args:
+    dependencies(dict): dependencies to grab timeout value from.
+  """
+  log.info('Registering job timeouts.')
+
+  job_names = list(job_manager.JobsManager.GetJobNames())
+  # Iterate through list of jobs
+  for job, values in dependencies.items():
+    if job not in job_names:
+      continue
+    timeout = values.get('timeout')
+    job_manager.JobsManager.RegisterTimeout(job, values['timeout'])
+
+
 def check_docker_dependencies(dependencies):
   """Checks docker dependencies.
 
@@ -1266,6 +1283,7 @@ class TurbiniaPsqWorker:
     check_directory(config.MOUNT_DIR_PREFIX)
     check_directory(config.OUTPUT_DIR)
     check_directory(config.TMP_DIR)
+    register_job_timeouts(dependencies)
 
     jobs = job_manager.JobsManager.GetJobNames()
     log.info(

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -146,7 +146,7 @@ def register_job_timeouts(dependencies):
     if job not in job_names:
       continue
     timeout = values.get('timeout')
-    if type(timeout) != int:
+    if not isinstance(timeout, int):
       log.warning(
           'No timeout found for job: {0:s}. Setting default timeout of {1:d} seconds.'
           .format(job, timeout_default))

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -150,7 +150,8 @@ def register_job_timeouts(dependencies):
       log.warning(
           'No timeout found for job: {0:s}. Setting default timeout of {1:d} seconds.'
           .format(job, timeout_default))
-    job_manager.JobsManager.RegisterTimeout(job, values['timeout'])
+      timeout = timeout_default
+    job_manager.JobsManager.RegisterTimeout(job, timeout)
 
 
 def check_docker_dependencies(dependencies):

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -212,6 +212,7 @@ def ParseDependencies():
       dependencies[job] = {}
       dependencies[job]['programs'] = values['programs']
       dependencies[job]['docker_image'] = values.get('docker_image')
+      dependencies[job]['timeout'] = values.get('timeout')
   except (KeyError, TypeError) as exception:
     raise TurbiniaException(
         'An issue has occurred while parsing the '

--- a/turbinia/config/turbinia_config_test.py
+++ b/turbinia/config/turbinia_config_test.py
@@ -157,10 +157,18 @@ class TestTurbiniaConfig(unittest.TestCase):
 
   def testParseDependencies(self):
     """Tests a valid config for the ParseDependencies() method."""
-    smpl_depends = 'DEPENDENCIES = [{"job": "PlasoJob","programs": ["test"], "docker_image": "test"}]'
+    smpl_depends = 'DEPENDENCIES = [{"job": "PlasoJob","programs": ["test"], \
+                   "docker_image": "test", "timeout":30}]'
+
     self.WriteConfig(smpl_depends)
     config.LoadConfig()
-    smpl_out = {'plasojob': {'programs': ['test'], 'docker_image': 'test'}}
+    smpl_out = {
+        'plasojob': {
+            'programs': ['test'],
+            'docker_image': 'test',
+            'timeout': 30
+        }
+    }
     smpl_test = config.ParseDependencies()
     self.assertEqual(smpl_out, smpl_test)
 

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -103,59 +103,73 @@ DISABLED_JOBS = ['BinaryExtractorJob', 'BulkExtractorJob', 'PhotorecJob']
 DEPENDENCIES = [{
     'job': 'BinaryExtractorJob',
     'programs': ['image_export.py'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'BulkExtractorJob',
     'programs': ['bulk_extractor'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'FsstatJob',
     'programs': ['fsstat'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'GrepJob',
     'programs': ['grep'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'HadoopAnalysisJob',
     'programs': ['strings'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'HindsightJob',
     'programs': ['hindsight.py'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'JenkinsAnalysisJob',
     'programs': ['john'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'PartitionEnumerationJob',
     'programs': ['bdemount'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'PlasoJob',
     'programs': ['log2timeline.py'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': '3600'
 }, {
     'job': 'PhotorecJob',
     'programs': ['photorec'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'PsortJob',
     'programs': ['psort.py'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'StringsJob',
     'programs': ['strings'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'VolatilityJob',
     'programs': ['vol.py'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }, {
     'job': 'DockerContainersEnumerationJob',
     'programs': ['de.py'],
-    'docker_image': None
+    'docker_image': None,
+    'timeout': 300
 }]
 
 ################################################################################

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -104,72 +104,72 @@ DEPENDENCIES = [{
     'job': 'BinaryExtractorJob',
     'programs': ['image_export.py'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 7200
 }, {
     'job': 'BulkExtractorJob',
     'programs': ['bulk_extractor'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 14400
 }, {
     'job': 'FsstatJob',
     'programs': ['fsstat'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1800
 }, {
     'job': 'GrepJob',
     'programs': ['grep'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1800
 }, {
     'job': 'HadoopAnalysisJob',
     'programs': ['strings'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1200
 }, {
     'job': 'HindsightJob',
     'programs': ['hindsight.py'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1200
 }, {
     'job': 'JenkinsAnalysisJob',
     'programs': ['john'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1200
 }, {
     'job': 'PartitionEnumerationJob',
     'programs': ['bdemount'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1200
 }, {
     'job': 'PlasoJob',
     'programs': ['log2timeline.py'],
     'docker_image': None,
-    'timeout': '3600'
+    'timeout': 86400
 }, {
     'job': 'PhotorecJob',
     'programs': ['photorec'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 14400
 }, {
     'job': 'PsortJob',
     'programs': ['psort.py'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 3600
 }, {
     'job': 'StringsJob',
     'programs': ['strings'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 3600
 }, {
     'job': 'VolatilityJob',
     'programs': ['vol.py'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 3600
 }, {
     'job': 'DockerContainersEnumerationJob',
     'programs': ['de.py'],
     'docker_image': None,
-    'timeout': 300
+    'timeout': 1200
 }]
 
 ################################################################################

--- a/turbinia/jobs/interface.py
+++ b/turbinia/jobs/interface.py
@@ -36,6 +36,7 @@ class TurbiniaJob:
     docker_image (str): Docker image to run for this job or None if unavailable.
     completed_task_count (int): The number of Tasks that have been removed.
     evidence (EvidenceCollection): The Evidence returned by Tasks from this Job.
+    timeout (int): The amount of seconds to wait before timing out.
   """
 
   NAME = 'name'
@@ -53,6 +54,7 @@ class TurbiniaJob:
     self.evidence = EvidenceCollection()
     self.evidence.request_id = request_id
     self.evidence.config = evidence_config if evidence_config else {}
+    self.timeout = 300
 
   def check_done(self):
     """Check to see if all Tasks for this Job have completed.

--- a/turbinia/jobs/interface.py
+++ b/turbinia/jobs/interface.py
@@ -54,7 +54,7 @@ class TurbiniaJob:
     self.evidence = EvidenceCollection()
     self.evidence.request_id = request_id
     self.evidence.config = evidence_config if evidence_config else {}
-    self.timeout = 300
+    self.timeout = None
 
   def check_done(self):
     """Check to see if all Tasks for this Job have completed.

--- a/turbinia/jobs/manager.py
+++ b/turbinia/jobs/manager.py
@@ -256,3 +256,30 @@ class JobsManager:
     if hasattr(job_class, 'docker_image') and job_class:
       docker_image = job_class.docker_image
     return docker_image
+
+  @classmethod
+  def RegisterTimeout(cls, job_name, timeout):
+    """Registers a timeout for the job.
+
+    Args:
+      job_name(str): name of the job.
+      timeout(int): The amount of seconds to wait before timing out.
+    """
+    job_name = job_name.lower()
+    cls._job_classes[job_name].timeout = timeout
+
+  @classmethod
+  def GetTimeoutValue(cls, job_name):
+    """Retrieves the timeout value associated with the job.
+
+    Args:
+      job_name(str): name of the job.
+
+    Returns:
+      timeout(int): The timeout value.
+    """
+    timeout = None
+    job_class = cls._job_classes.get(job_name.lower())
+    if hasattr(job_class, 'timeout') and job_class:
+      timeout = job_class.timeout
+    return timeout

--- a/turbinia/lib/docker_manager.py
+++ b/turbinia/lib/docker_manager.py
@@ -207,7 +207,8 @@ class ContainerManager(DockerManager):
     return device_paths, file_paths
 
   def execute_container(
-      self, cmd, shell=False, ro_paths=None, rw_paths=None, **kwargs):
+      self, cmd, shell=False, ro_paths=None, rw_paths=None, timeout_limit=3600,
+      **kwargs):
     """Executes a Docker container.
 
     A new Docker container will be created from the image id,
@@ -217,6 +218,7 @@ class ContainerManager(DockerManager):
       cmd(str|list): command to be executed.
       shell (bool): Whether the cmd is in the form of a string or a list.
       mount_paths(list): A list of paths to mount to the container.
+      timeout_limit(int): The number of seconds before killing a container.
       **kwargs: Any additional keywords to pass to the container.
 
     Returns:
@@ -267,7 +269,7 @@ class ContainerManager(DockerManager):
         stdo = codecs.decode(stdo, 'utf-8').strip()
         log.debug(stdo)
         stdout += stdo
-      results = container.wait()
+      results = container.wait(timeout=timeout_limit)
     except docker.errors.APIError as exception:
       if container:
         container.remove(v=True)

--- a/turbinia/lib/dockermanager_test.py
+++ b/turbinia/lib/dockermanager_test.py
@@ -66,7 +66,7 @@ class MockContainer:
     """Mock method of container.logs()"""
     return self.s_logs
 
-  def wait(self):
+  def wait(self, timeout):
     """Mock method of container.wait()"""
     return self.s_wait
 

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -588,8 +588,7 @@ class TurbiniaTask:
         message = 'Execution of [{0!s}] failed due to job timeout of seconds has been reached.'.format(
             cmd)
         result.log(message)
-        if close:
-          result.close(self, success=False, status=message)
+        result.close(self, success=False, status=message)
         # Increase timeout metric and raise exception
         turbinia_worker_tasks_timeout_total.inc()
         raise TurbiniaException(message)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -585,8 +585,8 @@ class TurbiniaTask:
           proc.wait(timeout_limit)
       except subprocess.TimeoutExpired as exception:
         # Log error and close result.
-        message = 'Execution of [{0!s}] failed due to job timeout of seconds has been reached.'.format(
-            cmd)
+        message = 'Execution of [{0!s}] failed due to job timeout of \
+                  {1:d} seconds has been reached.'.format(cmd, timeout_limit)
         result.log(message)
         result.close(self, success=False, status=message)
         # Increase timeout metric and raise exception

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -553,6 +553,9 @@ class TurbiniaTask:
     stdout = None
     stderr = None
 
+    # Get timeout value.
+    timeout_limit = job_manager.JobsManager.GetTimeoutValue(self.job_name)
+
     # Execute the job via docker.
     docker_image = job_manager.JobsManager.GetDockerImage(self.job_name)
     if docker_image:
@@ -570,9 +573,11 @@ class TurbiniaTask:
       if shell:
         proc = subprocess.Popen(
             cmd, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        proc.wait(timeout_limit)
       else:
         proc = subprocess.Popen(
             cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        proc.wait(timeout_limit)
       stdout, stderr = proc.communicate()
       ret = proc.returncode
 

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -585,8 +585,9 @@ class TurbiniaTask:
           proc.wait(timeout_limit)
       except subprocess.TimeoutExpired as exception:
         # Log error and close result.
-        message = 'Execution of [{0!s}] failed due to job timeout of \
-                  {1:d} seconds has been reached.'.format(cmd, timeout_limit)
+        message = (
+            'Execution of [{0!s}] failed due to job timeout of '
+            '{1:d} seconds has been reached.'.format(cmd, timeout_limit))
         result.log(message)
         result.close(self, success=False, status=message)
         # Increase timeout metric and raise exception

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -566,7 +566,8 @@ class TurbiniaTask:
       rw_paths = [self.output_dir, self.tmp_dir]
       container_manager = docker_manager.ContainerManager(docker_image)
       stdout, stderr, ret = container_manager.execute_container(
-          cmd, shell, ro_paths=ro_paths, rw_paths=rw_paths)
+          cmd, shell, ro_paths=ro_paths, rw_paths=rw_paths,
+          timeout_limit=timeout_limit)
 
     # Execute the job on the host system.
     else:

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -17,7 +17,6 @@
 from __future__ import unicode_literals
 
 import os
-import timeout_decorator
 from tempfile import NamedTemporaryFile
 
 from turbinia import config
@@ -27,7 +26,6 @@ from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
 
 
-@timeout_decorator.timeout(5)
 class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 import os
+import timeout_decorator
 from tempfile import NamedTemporaryFile
 
 from turbinia import config
@@ -25,7 +26,7 @@ from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
 
-
+@timeout_decorator.timeout(5)
 class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -26,6 +26,7 @@ from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import PlasoFile
 from turbinia.workers import TurbiniaTask
 
+
 @timeout_decorator.timeout(5)
 class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""


### PR DESCRIPTION
Adds a timeout for each of the jobs that is configurable via turbiniarc. For any Job the worker runs that exceeds X amount of specified time, it'll raise a timeout exception and the job will report as failed.