### PR TITLE
Exclude big files from test result output tgz.

### DIFF
--- a/turbinia/e2e/googleclouddisk.sh
+++ b/turbinia/e2e/googleclouddisk.sh
@@ -9,6 +9,7 @@ MAIN_LOG="$LOGS/main.log"
 STATS_LOG="$LOGS/stats.log"
 DETAIL_LOG="$LOGS/reqdetails.log"
 OUT_TGZ="e2e-test-logs.tgz"
+OUT_EXCLUDE="\.ascii|\.tar\.gz|\.plaso|\.csv"
 DISK="test-disk2"
 
 if [ $# -ne  2 ]
@@ -52,7 +53,7 @@ $TURBINIA_CLI -d -a status -r $REQ_ID -R > $DETAIL_LOG 2>&1
 # Retrieve all test output from GCS and store LOGS folder
 echo "Copy all task result files from GCS"
 echo "Note: excluding result from StringAsciiTask due to large result file"
-cat $DETAIL_LOG|grep "gs://"|tr -d "*\`"|grep -v "\.ascii"|while read line
+cat $DETAIL_LOG|grep "gs://"|tr -d "*\`"|grep -Ev $OUT_EXCLUDE|while read line
 do
   OUTFILE=`echo "$line"|awk -F/ '{print $(NF-1)"_"$NF}'`
   echo "Copying $line to $OUTFILE"


### PR DESCRIPTION
Current e2e output size is 300MB for each run where most of the files included (eg BulkExtractor) are not needed. To limit size of the output file we exclude different result types.