### PR TITLE
Add prometheus endpoint to celery worker

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -1244,6 +1244,13 @@ class TurbiniaCeleryWorker(BaseTurbiniaClient):
 
   def start(self):
     """Start Turbinia Celery Worker."""
+    if config.PROMETHEUS_ENABLED:
+      if config.PROMETHEUS_PORT and config.PROMETHEUS_ADDR:
+        log.info('Starting Prometheus endpoint.')
+        start_http_server(
+            port=config.PROMETHEUS_PORT, addr=config.PROMETHEUS_ADDR)
+      else:
+        log.info('Prometheus enabled but port or address not set!')
     log.info('Running Turbinia Celery Worker.')
     self.worker.task(task_manager.task_runner, name='task_runner')
     argv = ['celery', 'worker', '--loglevel=info', '--pool=solo']


### PR DESCRIPTION
The prometheus endpoint was only enabled in the server and psq-worker, let's add this to the celery-worker as well.