### PR TITLE
Fix PlasoTask attributes and version mismatch error

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -973,6 +973,7 @@ class TurbiniaTask:
                 .format(self.turbinia_version, turbinia.__version__))
             self.result.log(message, level=logging.ERROR)
             self.result.status = message
+            self.result.successful = False
             return self.result.serialize()
 
           self.result.update_task_status(self, 'running')

--- a/turbinia/workers/plaso.py
+++ b/turbinia/workers/plaso.py
@@ -31,7 +31,7 @@ class PlasoTask(TurbiniaTask):
   """Task to run Plaso (log2timeline)."""
 
   # Plaso requires the Disk to be attached, but doesn't require it be mounted.
-  REQUIRED_STATUS = [state.ATTACHED, state.DECOMPRESSED]
+  REQUIRED_STATES = [state.ATTACHED, state.DECOMPRESSED]
 
   TASK_CONFIG = {
       # 'none' as indicated in the options for status_view within


### PR DESCRIPTION
The attribute misnaming caused the pre-processors not to attach the disk.  For the version mismatch, the error wasn't showing up as a failed task without explicitly setting the successful attribute.