### PR TITLE
Update linux accounting Task required states

### DIFF
--- a/turbinia/workers/analysis/linux_acct.py
+++ b/turbinia/workers/analysis/linux_acct.py
@@ -30,7 +30,7 @@ from turbinia.workers import TurbiniaTask
 class LinuxAccountAnalysisTask(TurbiniaTask):
   """Task to analyze a Linux password file."""
 
-  REQUIRED_STATES = [state.ATTACHED, state.MOUNTED]
+  REQUIRED_STATES = [state.ATTACHED, state.DECOMPRESSED]
 
   def run(self, evidence, result):
     """Run the Linux Account worker.


### PR DESCRIPTION
Since this uses `image_export.py` we don't actually need the `MOUNTED` state after evidence pre-processing.   We do want the `DECOMPRESSED` state though for the `CompressedDirectory` evidence type.