### PR TITLE
fixed permission issues for start.sh

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia
     && chown -R turbinia:turbinia /var/log/turbinia/
 
 COPY docker/server/start.sh /home/turbinia/start.sh
-RUN chmod +x /home/turbinia/start.sh
+RUN chmod +rwx /home/turbinia/start.sh
 USER turbinia
 CMD ["/home/turbinia/start.sh"]
 # Expose Prometheus endpoint.

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -62,7 +62,7 @@ RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia
     && mkdir -p /home/turbinia/.john && chown -R turbinia:turbinia /home/turbinia/
 
 COPY docker/worker/start.sh /home/turbinia/start.sh
-RUN chmod +x /home/turbinia/start.sh
+RUN chmod +rwx /home/turbinia/start.sh
 USER turbinia
 CMD ["/home/turbinia/start.sh"]
 # Expose Prometheus endpoint.


### PR DESCRIPTION
Fixed permissions issues for start.sh when building docker image then when attempting to run, getting a permission denied. The root cause likely due to the `start.sh` file that was cloned before building having a different set of permissions when copied over to docker image.