### PR TITLE
Switch analysis tasks to full disk evidence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@ celery<5.0
 cryptography>=2.0.2,<3.4
 docker
 filelock
-google-api-core
+google-api-core<2.0.0dev
 google-api-python-client
 google-auth<2.0.0.dev0
-google-cloud-core
+google-cloud-core<2.0.0dev
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
 google-cloud-logging>=2.0.0

--- a/turbinia/jobs/binary_extractor.py
+++ b/turbinia/jobs/binary_extractor.py
@@ -17,7 +17,9 @@
 from __future__ import unicode_literals
 
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import BinaryExtraction
 from turbinia.jobs import interface
 from turbinia.jobs import manager
@@ -28,7 +30,9 @@ class BinaryExtractorJob(interface.TurbiniaJob):
   """Run image_export.py on evidence to extract binaries."""
 
   # The types of evidence that this Job will process.
-  evidence_input = [Directory, DiskPartition]
+  evidence_input = [
+      Directory, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, RawDisk
+  ]
   evidence_output = [BinaryExtraction]
 
   NAME = 'BinaryExtractorJob'

--- a/turbinia/jobs/hadoop.py
+++ b/turbinia/jobs/hadoop.py
@@ -16,8 +16,10 @@
 
 from __future__ import unicode_literals
 
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
 from turbinia.jobs import manager
@@ -27,7 +29,9 @@ from turbinia.workers.hadoop import HadoopAnalysisTask
 class HadoopAnalysisJob(interface.TurbiniaJob):
   """Analyzes Hadoop AppRoot files."""
 
-  evidence_input = [DiskPartition, DockerContainer]
+  evidence_input = [
+      DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, RawDisk
+  ]
   evidence_output = [ReportText]
 
   NAME = 'HadoopAnalysisJob'

--- a/turbinia/jobs/http_access_logs.py
+++ b/turbinia/jobs/http_access_logs.py
@@ -18,8 +18,10 @@ from __future__ import unicode_literals
 from turbinia.workers import artifact
 
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ExportedFileArtifact
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
@@ -34,7 +36,10 @@ ACCESS_LOG_ARTIFACTS = [
 class HTTPAccessLogExtractionJob(interface.TurbiniaJob):
   """HTTP Access log extraction job."""
 
-  evidence_input = [Directory, DiskPartition, DockerContainer]
+  evidence_input = [
+      Directory, DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      RawDisk
+  ]
   evidence_output = [ExportedFileArtifact]
 
   NAME = 'HTTPAccessLogExtractionJob'

--- a/turbinia/jobs/jenkins.py
+++ b/turbinia/jobs/jenkins.py
@@ -17,8 +17,10 @@
 from __future__ import unicode_literals
 
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
 from turbinia.jobs import manager
@@ -28,7 +30,10 @@ from turbinia.workers.analysis.jenkins import JenkinsAnalysisTask
 class JenkinsAnalysisJob(interface.TurbiniaJob):
   """Jenkins analysis job."""
 
-  evidence_input = [Directory, DiskPartition, DockerContainer]
+  evidence_input = [
+      Directory, DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      RawDisk
+  ]
   evidence_output = [ReportText]
 
   NAME = 'JenkinsAnalysisJob'

--- a/turbinia/jobs/jupyter.py
+++ b/turbinia/jobs/jupyter.py
@@ -18,8 +18,10 @@ from __future__ import unicode_literals
 
 from turbinia.workers import artifact
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ExportedFileArtifact
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
@@ -31,7 +33,10 @@ class JupyterExtractionJob(interface.TurbiniaJob):
   """Extract Jupyter configuration files for analysis."""
 
   # The types of evidence that this Job will process
-  evidence_input = [Directory, DiskPartition, DockerContainer]
+  evidence_input = [
+      Directory, DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      RawDisk
+  ]
   evidence_output = [ExportedFileArtifact]
 
   NAME = 'JupyterExtractionJob'

--- a/turbinia/jobs/redis.py
+++ b/turbinia/jobs/redis.py
@@ -19,8 +19,10 @@ from __future__ import unicode_literals
 from turbinia.workers import artifact
 from turbinia.workers import redis
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ExportedFileArtifact
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
@@ -31,7 +33,10 @@ class RedisExtractionJob(interface.TurbiniaJob):
   """Extract Redis configuration files for analysis."""
 
   # The types of evidence that this Job will process
-  evidence_input = [Directory, DiskPartition, DockerContainer]
+  evidence_input = [
+      Directory, DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      RawDisk
+  ]
   evidence_output = [ExportedFileArtifact]
 
   NAME = 'RedisExtractionJob'

--- a/turbinia/jobs/sshd.py
+++ b/turbinia/jobs/sshd.py
@@ -19,8 +19,10 @@ from __future__ import unicode_literals
 from turbinia.workers import artifact
 from turbinia.workers import sshd
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ExportedFileArtifact
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
@@ -31,7 +33,10 @@ class SSHDExtractionJob(interface.TurbiniaJob):
   """Filter input based on regular expression patterns."""
 
   # The types of evidence that this Job will process
-  evidence_input = [Directory, DiskPartition, DockerContainer]
+  evidence_input = [
+      Directory, DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      RawDisk
+  ]
   evidence_output = [ExportedFileArtifact]
 
   NAME = 'SSHDExtractionJob'

--- a/turbinia/jobs/tomcat.py
+++ b/turbinia/jobs/tomcat.py
@@ -17,8 +17,10 @@ from __future__ import unicode_literals
 from turbinia.workers import artifact
 from turbinia.workers import tomcat
 from turbinia.evidence import Directory
-from turbinia.evidence import DiskPartition
 from turbinia.evidence import DockerContainer
+from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import GoogleCloudDiskRawEmbedded
+from turbinia.evidence import RawDisk
 from turbinia.evidence import ExportedFileArtifact
 from turbinia.evidence import ReportText
 from turbinia.jobs import interface
@@ -29,7 +31,10 @@ class TomcatExtractionJob(interface.TurbiniaJob):
   """Extract Apache Tomcat files for analysis."""
 
   # The types of evidence that this Job will process
-  evidence_input = [Directory, DiskPartition, DockerContainer]
+  evidence_input = [
+      Directory, DockerContainer, GoogleCloudDisk, GoogleCloudDiskRawEmbedded,
+      RawDisk
+  ]
   evidence_output = [ExportedFileArtifact]
 
   NAME = 'TomcatExtractionJob'


### PR DESCRIPTION
Switch analysis tasks to full disk evidence now that image_export runs unattended