### PR TITLE
Add timeouts to image_export calls

### DIFF
--- a/turbinia/jobs/manager.py
+++ b/turbinia/jobs/manager.py
@@ -18,6 +18,8 @@ from __future__ import unicode_literals
 
 from turbinia import TurbiniaException
 
+DEFAULT_TIMEOUT = 7200
+
 
 class JobsManager:
   """The jobs manager."""
@@ -278,7 +280,7 @@ class JobsManager:
     Returns:
       timeout(int): The timeout value.
     """
-    timeout = 7200
+    timeout = DEFAULT_TIMEOUT
     job_class = cls._job_classes.get(job_name.lower())
     if hasattr(job_class, 'timeout') and job_class:
       timeout = job_class.timeout

--- a/turbinia/jobs/manager.py
+++ b/turbinia/jobs/manager.py
@@ -278,7 +278,7 @@ class JobsManager:
     Returns:
       timeout(int): The timeout value.
     """
-    timeout = None
+    timeout = 7200
     job_class = cls._job_classes.get(job_name.lower())
     if hasattr(job_class, 'timeout') and job_class:
       timeout = job_class.timeout

--- a/turbinia/lib/utils.py
+++ b/turbinia/lib/utils.py
@@ -26,8 +26,10 @@ from turbinia import TurbiniaException
 
 log = logging.getLogger('turbinia')
 
+DEFAULT_TIMEOUT = 7200
 
-def _image_export(command, output_dir):
+
+def _image_export(command, output_dir, timeout=DEFAULT_TIMEOUT):
   """Runs image_export command.
 
   Args:
@@ -43,9 +45,12 @@ def _image_export(command, output_dir):
   # TODO: Consider using the exec helper to gather stdin/err.
   log.debug('Running image_export as [{0:s}]'.format(' '.join(command)))
   try:
-    subprocess.check_call(command)
-  except subprocess.CalledProcessError:
-    raise TurbiniaException('image_export.py failed.')
+    subprocess.check_call(command, timeout=timeout)
+  except subprocess.CalledProcessError as e:
+    raise TurbiniaException('image_export.py failed: {0!s}'.format(e))
+  except subprocess.TimeoutExpired as e:
+    raise TurbiniaException(
+        'image_export.py timed out after {0:d}s: {1!s}'.format(timeout, e))
 
   collected_file_paths = []
   file_count = 0


### PR DESCRIPTION
This also sets a default timeout value of 2hr for all tasks that don't have one set in the config.