### PR TITLE
Fixes for postprocess resource tracking

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -386,7 +386,7 @@ class Evidence:
           log.info(
               'Resource ID {0:s} still in use. Skipping detaching Evidence...'
               .format(self.resource_id))
-          return
+              
     if is_detachable:
       self._postprocess()
     if self.parent_evidence:

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -386,7 +386,7 @@ class Evidence:
           log.info(
               'Resource ID {0:s} still in use. Skipping detaching Evidence...'
               .format(self.resource_id))
-              
+
     if is_detachable:
       self._postprocess()
     if self.parent_evidence:

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -387,7 +387,7 @@ class Evidence:
               'Resource ID {0:s} still in use. Skipping detaching Evidence...'
               .format(self.resource_id))
           return
-    if not is_detachable:
+    if is_detachable:
       self._postprocess()
     if self.parent_evidence:
       self.parent_evidence.postprocess(task_id)

--- a/turbinia/evidence_test.py
+++ b/turbinia/evidence_test.py
@@ -102,5 +102,6 @@ class TestTurbiniaEvidence(unittest.TestCase):
   def testEvidencePreprocess(self, mock_preprocess):
     """Basic test for Evidence.preprocess()."""
     test_evidence = TestEvidence()
-    test_evidence.preprocess(required_states=[evidence.EvidenceState.ATTACHED])
+    test_evidence.preprocess(
+        'task123', required_states=[evidence.EvidenceState.ATTACHED])
     mock_preprocess.assert_called_with(None, [evidence.EvidenceState.ATTACHED])

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -519,7 +519,7 @@ class TurbiniaTask:
     """
     evidence.validate()
     evidence.preprocess(
-        self.tmp_dir, required_states=self.REQUIRED_STATES, task_id=self.id)
+        self.id, tmp_dir=self.tmp_dir, required_states=self.REQUIRED_STATES)
 
     # Final check to make sure that the required evidence state has been met
     # for Evidence types that have those capabilities.

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -355,8 +355,8 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.evidence.preprocess = mock.MagicMock()
     self.task.evidence_setup(self.evidence)
     self.evidence.preprocess.assert_called_with(
-        self.task.tmp_dir, required_states=self.task.REQUIRED_STATES,
-        task_id=self.task.id)
+        self.task.id, tmp_dir=self.task.tmp_dir,
+        required_states=self.task.REQUIRED_STATES)
 
   def testEvidenceSetupStateNotFulfilled(self):
     """Test that evidence setup throws exception when states don't match."""


### PR DESCRIPTION
There was an issue with `postprocess` not removing the appropiate `task_id` when the Task is complete for the `parent_evidence`, this PR resolves that by not returning after doing the `PostProcessResourceState ` check and instead adds a `is_detachable` variable that equals True but evaluates to False if the `resource_id` is still in use and to not run the rest of the `postprocess` code. This PR also requires `task_id` be a required attribute of `postprocess` and `preprocess`