### PR TITLE
Add sketch_id to globals

### DIFF
--- a/turbinia/lib/recipe_helpers.py
+++ b/turbinia/lib/recipe_helpers.py
@@ -30,7 +30,8 @@ DEFAULT_GLOBALS_RECIPE = {
     'jobs_allowlist': [],
     'jobs_denylist': [],
     'yara_rules': '',
-    'filter_patterns': []
+    'filter_patterns': [],
+    'sketch_id': None
 }
 
 #Default recipes dict


### PR DESCRIPTION
This is used so that we can write the sketch_id to the metadata.json files so Timesketch knows what sketch to use.