### PR TITLE
Add evidence size to evidence object

### DIFF
--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -180,7 +180,7 @@ DEPENDENCIES = [{
     'timeout': 1200
 }, {
     'job': 'PartitionEnumerationJob',
-    'programs': ['bdemount'],
+    'programs': ['bdemount', 'blockdev'],
     'docker_image': None,
     'timeout': 1200
 }, {

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -548,12 +548,10 @@ class RawDisk(Evidence):
     """Initialization for raw disk evidence object."""
     self.device_path = None
     super(RawDisk, self).__init__(*args, **kwargs)
-    if hasattr(config, 'TURBINIA_COMMAND') and config.TURBINIA_COMMAND:
-      if 'worker' in config.TURBINIA_COMMAND:
-        if self.source_path and self.size is None:
-          self.size = mount_local.GetDiskSize(self.source_path)
 
   def _preprocess(self, _, required_states):
+    if self.size is None:
+      self.size = mount_local.GetDiskSize(self.source_path)
     if EvidenceState.ATTACHED in required_states or self.has_child_evidence:
       self.device_path = mount_local.PreprocessLosetup(self.source_path)
       self.state[EvidenceState.ATTACHED] = True
@@ -591,10 +589,7 @@ class DiskPartition(RawDisk):
     self.partition_size = partition_size
     self.lv_uuid = lv_uuid
     self.path_spec = path_spec
-    if 'size' not in kwargs:
-      super(DiskPartition, self).__init__(size=partition_size, *args, **kwargs)
-    else:
-      super(DiskPartition, self).__init__(*args, **kwargs)
+    super(DiskPartition, self).__init__(*args, **kwargs)
 
     # This Evidence needs to have a parent
     self.context_dependent = True

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -45,16 +45,17 @@ def GetDiskSize(source_path):
   size = None
 
   if not os.path.exists(source_path):
-    raise TurbiniaException(
-        ('Cannot check disk size for non-existing source_path '
-         '{0!s}').format(source_path))
+    log.error(
+        'Cannot check disk size for non-existing source_path {0!s}'.format(
+            source_path))
+    return None
 
   cmd = ['blockdev', '--getsize64', source_path]
   log.info('Running {0!s}'.format(cmd))
 
   # Run blockdev first, this will fail if evidence is not a block device
   try:
-    cmd_output = subprocess.check_output(cmd).split()
+    cmd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).split()
     size = int(cmd_output[0].decode('utf-8'))
   except subprocess.CalledProcessError:
     log.debug('blockdev failed, attempting to get file size')

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -59,6 +59,10 @@ def GetDiskSize(source_path):
     size = int(cmd_output[0].decode('utf-8'))
   except subprocess.CalledProcessError:
     log.debug('blockdev failed, attempting to get file size')
+  except ValueError:
+    log.debug(
+        'Unexpected output from blockdev: {0:s}'.format(
+            cmd_output[0].decode('utf-8')))
 
   if size is None:
     # evidence is not a block device, check image file size

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -30,6 +30,47 @@ log = logging.getLogger('turbinia')
 RETRY_MAX = 10
 
 
+def GetDiskSize(source_path):
+  """Gets the size of disk evidence in bytes.
+
+  Tries using blockdev to query the size of block devices, and falls back on
+  filesize for image files.
+
+  Args:
+    source_path(str): the source path of the disk.
+
+  Returns:
+    int: the size of the disk in bytes.
+  """
+  size = None
+
+  if not os.path.exists(source_path):
+    raise TurbiniaException(
+        ('Cannot check disk size for non-existing source_path '
+         '{0!s}').format(source_path))
+
+  cmd = ['blockdev', '--getsize64', source_path]
+  log.info('Running {0!s}'.format(cmd))
+
+  # Run blockdev first, this will fail if evidence is not a block device
+  try:
+    cmd_output = subprocess.check_output(cmd).split()
+    size = int(cmd_output[0].decode('utf-8'))
+  except subprocess.CalledProcessError:
+    log.debug('blockdev failed, attempting to get file size')
+
+  if size is None:
+    # evidence is not a block device, check image file size
+    cmd = ['ls', '-s', source_path]
+    try:
+      cmd_output = subprocess.check_output(cmd).split()
+      size = int(cmd_output[0].decode('utf-8'))
+    except subprocess.CalledProcessError as e:
+      log.warning('Checking disk size failed: {0!s}'.format(e))
+
+  return size
+
+
 def PreprocessBitLocker(source_path, partition_offset=None, credentials=None):
   """Uses libbde on a target block device or image file.
 

--- a/turbinia/processors/mount_local_test.py
+++ b/turbinia/processors/mount_local_test.py
@@ -32,6 +32,7 @@ def _mock_bitlocker_returns(*args, **kwargs):
     return False
   return True
 
+
 def _mock_disk_size_returns(*args, **kwargs):
   """Mock return values."""
   if args[0][0] == 'blockdev' and args[0][2] == '/dev/loop0':
@@ -43,6 +44,7 @@ def _mock_disk_size_returns(*args, **kwargs):
   if args[0][0] == 'ls' and args[0][2] == 'test2.dd':
     raise CalledProcessError(1, 'ls')
   return ''
+
 
 class MountLocalProcessorTest(unittest.TestCase):
   """Tests for mount_local processor."""

--- a/turbinia/processors/mount_local_test.py
+++ b/turbinia/processors/mount_local_test.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 
 import os
 from subprocess import CalledProcessError
+from subprocess import STDOUT
 import unittest
 
 import mock
@@ -59,7 +60,7 @@ class MountLocalProcessorTest(unittest.TestCase):
     mock_subprocess.side_effect = _mock_disk_size_returns
     size = mount_local.GetDiskSize(source_path)
     expected_args = ['blockdev', '--getsize64', source_path]
-    mock_subprocess.assert_called_once_with(expected_args)
+    mock_subprocess.assert_called_once_with(expected_args, stderr=STDOUT)
     self.assertEqual(size, 100)
 
     # Test for image file
@@ -76,8 +77,8 @@ class MountLocalProcessorTest(unittest.TestCase):
 
     # Test path doesn't exist
     mock_path_exists.return_value = False
-    with self.assertRaises(TurbiniaException):
-      mount_local.GetDiskSize(source_path)
+    size = mount_local.GetDiskSize(source_path)
+    self.assertIsNone(size)
 
   @mock.patch('turbinia.processors.mount_local.config')
   @mock.patch('tempfile.mkdtemp')


### PR DESCRIPTION
Added evidence size to evidence objects for metrics tracking
- Currently only populating for RawDisk

@aarontp @wajihyassine - as discussed