### PR TITLE
Fix protobuf dependencies and comment out hindsight.

### DIFF
--- a/docker/local/local-config.sed
+++ b/docker/local/local-config.sed
@@ -8,4 +8,4 @@ s/OUTPUT_DIR = .*/OUTPUT_DIR = '\/evidence'/g
 s/MOUNT_DIR_PREFIX = .*/MOUNT_DIR_PREFIX = '\/tmp\/turbinia-mounts'/g
 s/SHARED_FILESYSTEM = .*/SHARED_FILESYSTEM = True/g
 s/DEBUG_TASKS = .*/DEBUG_TASKS = True/g
-s/DISABLED_JOBS = .*/DISABLED_JOBS = ['DfdeweyJob', 'VolatilityJob']/g
+s/DISABLED_JOBS = .*/DISABLED_JOBS = ['DfdeweyJob', 'VolatilityJob', 'HindsightJob']/g

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -29,7 +29,8 @@ RUN pip3 install requests --upgrade
 RUN pip3 install urllib3 cryptography --upgrade
 
 # Install third-party worker dependencies
-RUN pip3 install pyhindsight
+# TODO(hacktobeer) uncomment when protobuf lib dependency if fixed upstream
+# RUN pip3 install pyhindsight
 
 # Install Plaso, bulkextractor and docker-explorer
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ google-cloud-error-reporting
 google-cloud-logging>=2.0.0
 google-cloud-pubsub==1.7.0
 google-cloud-storage
+pycryptodomex
 prometheus_client
 libcloudforensics
 protobuf<3.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,11 @@ google-cloud-pubsub==1.7.0
 google-cloud-storage
 prometheus_client
 libcloudforensics
+protobuf<3.18.0
+proto-plus<1.19.7
 psq
+pyparsing<3
+pyyaml>=5.4.1
 redis
 six>=1.15.0
 urllib3[secure]

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -120,7 +120,7 @@ DOCKER_ENABLED = False
 # still be enabled with the --jobs_allowlist flag on the server, but the client
 # will not be able to allowlist jobs that have been disabled or denylisted on
 # the server.
-DISABLED_JOBS = ['BinaryExtractorJob', 'BulkExtractorJob', 'DfdeweyJob', 'PhotorecJob']  # yapf: disable
+DISABLED_JOBS = ['BinaryExtractorJob', 'BulkExtractorJob', 'DfdeweyJob', 'HindsightJob', 'PhotorecJob']  # yapf: disable
 
 # Configure additional job dependency checks below.
 DEPENDENCIES = [{


### PR DESCRIPTION
Fix a protobuf dependency that prevented the dev and experimental docker images from being build. Once the hindsight upstream code is fixed we can uncomment the installation again.

Fix #935 