### PR TITLE
Added resource manager tests and update resource manager json load logic

### DIFF
--- a/turbinia/processors/resource_manager.py
+++ b/turbinia/processors/resource_manager.py
@@ -27,8 +27,12 @@ config.LoadConfig()
 log = logging.getLogger('turbinia')
 
 
-def ValidateStateFile():
-  """Checks if resource file exists and the json object can be properly loaded."""
+def RetrieveResourceState():
+  """Creates a resource file if it doesn't exist and load resource state into a json object.
+  
+    Returns:
+      json_load(dict): The resource state json object.
+  """
   # Check if file exists and if not create it
   if not os.path.exists(config.RESOURCE_FILE):
     log.info(
@@ -38,15 +42,18 @@ def ValidateStateFile():
       fh.write("{}")
     fh.close()
 
-  # Ensure file can be loaded as json object
+  # Load file as json object
   try:
     with open(config.RESOURCE_FILE) as fh:
       json_load = json.load(fh)
-    fh.close()
   except ValueError as e:
     message = 'Can not load json from resource state file.'
     log.error(message)
     raise TurbiniaException(message)
+  finally:
+    fh.close()
+
+  return json_load
 
 
 def PreprocessResourceState(resource_id, task_id):
@@ -56,9 +63,9 @@ def PreprocessResourceState(resource_id, task_id):
     Args:
       resource_id (str): The unique id representing the resource being tracked.
       task_id (str): The id of a given Task.
-    """
-  ValidateStateFile()
-  json_load = json.load(open(config.RESOURCE_FILE))
+  """
+  # Retrieve the resource state
+  json_load = RetrieveResourceState()
 
   # Append task_id to existing resource else add new resource id.
   if resource_id in json_load.keys():
@@ -90,9 +97,9 @@ def PostProcessResourceState(resource_id, task_id):
     
     Returns:
       is_detachable (bool): Whether the given resource can be postprocessed.
-    """
-  ValidateStateFile()
-  json_load = json.load(open(config.RESOURCE_FILE))
+  """
+  # Retrieve the resource state
+  json_load = RetrieveResourceState()
   is_detachable = False
 
   # Either remove task id or remove resource id if it is last Task remaining.

--- a/turbinia/processors/resource_manager_test.py
+++ b/turbinia/processors/resource_manager_test.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for resource_manager handler."""
+
+from __future__ import unicode_literals
+
+import unittest
+import os
+import shutil
+import tempfile
+
+import mock
+
+from turbinia import TurbiniaException, config
+from turbinia.processors import resource_manager
+
+
+class TestResourceManager(unittest.TestCase):
+  """Test ResourceManager module."""
+
+  def setUp(self):
+    """Test setup."""
+    config.LoadConfig()
+    self.tmp_dir = tempfile.mkdtemp(prefix='turbinia-test-tmp')
+    config.RESOURCE_FILE = os.path.join(self.tmp_dir, 'turbinia-state.json')
+
+  def tearDown(self):
+    """Tears Down temporary directory."""
+    if 'turbinia-test-tmp' in self.tmp_dir:
+      shutil.rmtree(self.tmp_dir)
+
+  def testRetrieveStateFile(self):
+    """Tests the RetrieveResourceState() method."""
+    # Test call was succesful
+    self.assertEqual(resource_manager.RetrieveResourceState(), {})
+
+    # Test file was created
+    self.assertTrue(os.path.exists(config.RESOURCE_FILE))
+
+    # Test bad resource file
+    with open(config.RESOURCE_FILE, 'w') as fh:
+      fh.write("blah")
+    fh.close()
+    self.assertRaises(TurbiniaException, resource_manager.RetrieveResourceState)
+    os.remove(config.RESOURCE_FILE)
+
+  def testPreProcessResourceState(self):
+    """Tests the PreProcessResourceState() method."""
+    resource_id_1 = "resource_id_1"
+    task_id_1 = "task_id_1"
+    json_out = {resource_id_1: [task_id_1]}
+
+    # Test that the resource id is properly added with associated task
+    resource_manager.PreprocessResourceState(resource_id_1, task_id_1)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out)
+
+    # Test that the additional task id is appended to resource id
+    task_id_2 = "task_id_2"
+    json_out_2 = {resource_id_1: [task_id_1, task_id_2]}
+    resource_manager.PreprocessResourceState(resource_id_1, task_id_2)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_2)
+
+    # Test that additional resource id is added into state file
+    resource_id_2 = "resource_id_2"
+    json_out_3 = {
+        resource_id_1: [task_id_1, task_id_2],
+        resource_id_2: [task_id_1]
+    }
+    resource_manager.PreprocessResourceState(resource_id_2, task_id_1)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_3)
+
+    # Test that same task id is not duplicated into state file
+    resource_manager.PreprocessResourceState(resource_id_2, task_id_1)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_3)
+
+  def testPostProcessResourceState(self):
+    """Tests the PostProcessResourceState() method."""
+    resource_id_1 = "resource_id_1"
+    resource_id_2 = "resource_id_2"
+    task_id_1 = "task_id_1"
+    task_id_2 = "task_id_2"
+
+    # Add test resource ids and task ids into state file
+    resource_manager.PreprocessResourceState(resource_id_1, task_id_1)
+    resource_manager.PreprocessResourceState(resource_id_1, task_id_2)
+    resource_manager.PreprocessResourceState(resource_id_2, task_id_1)
+
+    # Test that task id was removed from resource id
+    json_out_1 = {resource_id_1: [task_id_2], resource_id_2: [task_id_1]}
+    is_detachable = resource_manager.PostProcessResourceState(
+        resource_id_1, task_id_1)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_1)
+    self.assertEqual(is_detachable, False)
+
+    # Test that resource id was removed from resource state
+    json_out_2 = {resource_id_2: [task_id_1]}
+    is_detachable = resource_manager.PostProcessResourceState(
+        resource_id_1, task_id_2)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_2)
+    self.assertEqual(is_detachable, True)
+
+    # Test that non existent task did not throw an error
+    is_detachable = resource_manager.PostProcessResourceState(
+        resource_id_2, task_id_2)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_2)
+    self.assertEqual(is_detachable, False)
+
+    # Test removing all from resource state
+    json_out_3 = {}
+    is_detachable = resource_manager.PostProcessResourceState(
+        resource_id_2, task_id_1)
+    self.assertEqual(resource_manager.RetrieveResourceState(), json_out_3)
+    self.assertEqual(is_detachable, True)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
This PR adds in unit tests for `resource_manager.py` as well as updates the `resource_manager` to move closing out file handler close to finally statement in the event an exception is raised as well as returns `json_load` to remove the duplicate step in `PreProcessResourceState` and `PostProcessResourceState`.