### PR TITLE
Persistent storage through Filestore 

### DIFF
--- a/docs/user/install-gke.md
+++ b/docs/user/install-gke.md
@@ -45,6 +45,13 @@ Please follow these steps for configuring Turbinia for GCP use and then running 
     and take note of the bucket name as this will be referenced later by the
     `GCS_OUTPUT_PATH` variable.
 *   Deploy Cloud Functions `cd <git clone path>/tools/gcf_init && ./deploy_gcf.py`
+* Enable [Cloud Filestore](https://console.cloud.google.com/filestore)
+    * Go to Filestore in the cloud console
+    * Hit the `Create Instance` button
+    * Set the `Instance ID` and `File Share Name` to the default name `output`.
+        * Note: The name can be changed however you must update the appropiate sections in the k8s Deployment files with the newly chosen name. Please see the `GKE Setup` section for more details.
+    * Select the same region and zone selected in the previous steps.
+    * After the Filestore instance has been created, keep a note of the IP address for later use.
 
 ### **GKE Setup**
 * Enable the [Kubernetes Engine API](https://console.cloud.google.com/apis/api/container.googleapis.com/overview).
@@ -72,6 +79,9 @@ gcloud container clusters create CLUSTER_NAME \
 * Ensure that the zone and region in the Turbinia config file are equal to the zone and region you created your k8s cluster in.
 * The `image` variable can be optionally changed in the `turbinia-worker.yaml` and `turbinia-server.yaml` files to chose the docker images used during deployment.
 * In the `turbinia-worker.yaml` file, ensure that the path in the volume labeled `lockfolder` matches the Turbinia config variable `TMP_RESOURCE_DIR`.
+* If the Filestore `Instance ID` and `File share name` have a different name then the default name `output`, update `turbinia-worker.yaml`, `turbinia-server.yaml`, `turbinia-output-claim-filestore.yaml`, and `turbinia-output-filestore.yaml` by searching for the string `output` and replacing it with the custom name. Skip this step if the default name was used.
+* To have all logs go to the central Filestore location, update the `LOG_DIR` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom Filestore path.
+* In `turbinia-output-filestore.yaml`, update `<IP_ADDRESS>` to the Filestore IP address.  
 * Ensure that the `.turbiniarc` config file has been properly configured with required GCP variables.
 * Deploy the Turbinia infrastructure by executing `./setup-pubsub.sh <PATH TO CONFIG>`. 
 * The Turbinia infrastructure can be destroyed by executing `./destroy-pubsub.sh`.

--- a/docs/user/install-gke.md
+++ b/docs/user/install-gke.md
@@ -12,7 +12,7 @@ GKE is only supported for Google Cloud so a Google Cloud Project is required to 
 
 ## **Installation**
 
-Please follow these steps for configuring Turbinia for GCP use and than running it within GKE. Ensure that the `.turbiniarc` config file has been updated appropriately. 
+Please follow these steps for configuring Turbinia for GCP use and then running it within GKE. Ensure that the `.turbiniarc` config file has been updated appropriately. 
 
 ### **GCP Setup**
 

--- a/docs/user/install-gke.md
+++ b/docs/user/install-gke.md
@@ -80,8 +80,9 @@ gcloud container clusters create CLUSTER_NAME \
 * The `image` variable can be optionally changed in the `turbinia-worker.yaml` and `turbinia-server.yaml` files to chose the docker images used during deployment.
 * In the `turbinia-worker.yaml` file, ensure that the path in the volume labeled `lockfolder` matches the Turbinia config variable `TMP_RESOURCE_DIR`.
 * If the Filestore `Instance ID` and `File share name` have a different name then the default name `output`, update `turbinia-worker.yaml`, `turbinia-server.yaml`, `turbinia-output-claim-filestore.yaml`, and `turbinia-output-filestore.yaml` by searching for the string `output` and replacing it with the custom name. Skip this step if the default name was used.
-* To have all logs go to the central Filestore location, update the `LOG_DIR` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom Filestore path.
-* In `turbinia-output-filestore.yaml`, update `<IP_ADDRESS>` to the Filestore IP address.  
+* To have all logs go to the central location, update the `LOG_DIR` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom path.
+* In `turbinia-output-filestore.yaml`, update `<IP_ADDRESS>` to the Filestore IP address.
+* If the Filestore instance size is greater than 1 TB, update the `storage` sections in `turbinia-output-claim-filestore.yaml` and `turbinia-output-filestore.yaml` with the appropiate size.
 * Ensure that the `.turbiniarc` config file has been properly configured with required GCP variables.
 * Deploy the Turbinia infrastructure by executing `./setup-pubsub.sh <PATH TO CONFIG>`. 
 * The Turbinia infrastructure can be destroyed by executing `./destroy-pubsub.sh`.

--- a/docs/user/install-gke.md
+++ b/docs/user/install-gke.md
@@ -12,7 +12,7 @@ GKE is only supported for Google Cloud so a Google Cloud Project is required to 
 
 ## **Installation**
 
-Please follow these steps for configuring Turbinia for GCP use and then running it within GKE. Ensure that the `.turbiniarc` config file has been updated appropriately. 
+Please follow these steps for configuring Turbinia for GCP use and than running it within GKE. Ensure that the `.turbiniarc` config file has been updated appropriately. 
 
 ### **GCP Setup**
 
@@ -49,7 +49,7 @@ Please follow these steps for configuring Turbinia for GCP use and then running 
     * Go to Filestore in the cloud console
     * Hit the `Create Instance` button
     * Set the `Instance ID` and `File Share Name` to the default name `output`.
-        * Note: The name can be changed however you must update the appropiate sections in the k8s Deployment files with the newly chosen name. Please see the `GKE Setup` section for more details.
+        * Note: The name can be changed however you must update the appropriate sections in the k8s Deployment files with the newly chosen name. Please see the `GKE Setup` section for more details.
     * Select the same region and zone selected in the previous steps.
     * After the Filestore instance has been created, keep a note of the IP address for later use.
 
@@ -79,10 +79,10 @@ gcloud container clusters create CLUSTER_NAME \
 * Ensure that the zone and region in the Turbinia config file are equal to the zone and region you created your k8s cluster in.
 * The `image` variable can be optionally changed in the `turbinia-worker.yaml` and `turbinia-server.yaml` files to chose the docker images used during deployment.
 * In the `turbinia-worker.yaml` file, ensure that the path in the volume labeled `lockfolder` matches the Turbinia config variable `TMP_RESOURCE_DIR`.
-* If the Filestore `Instance ID` and `File share name` have a different name then the default name `output`, update `turbinia-worker.yaml`, `turbinia-server.yaml`, `turbinia-output-claim-filestore.yaml`, and `turbinia-output-filestore.yaml` by searching for the string `output` and replacing it with the custom name. Skip this step if the default name was used.
+* If the Filestore `Instance ID` and `File share name` have a different name than the default name `output`, update `turbinia-worker.yaml`, `turbinia-server.yaml`, `turbinia-output-claim-filestore.yaml`, and `turbinia-output-filestore.yaml` by searching for the string `output` and replacing it with the custom name. Skip this step if the default name was used.
 * To have all logs go to the central location, update the `LOG_DIR` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom path.
 * In `turbinia-output-filestore.yaml`, update `<IP_ADDRESS>` to the Filestore IP address.
-* If the Filestore instance size is greater than 1 TB, update the `storage` sections in `turbinia-output-claim-filestore.yaml` and `turbinia-output-filestore.yaml` with the appropiate size.
+* If the Filestore instance size is greater than 1 TB, update the `storage` sections in `turbinia-output-claim-filestore.yaml` and `turbinia-output-filestore.yaml` with the appropriate size.
 * Ensure that the `.turbiniarc` config file has been properly configured with required GCP variables.
 * Deploy the Turbinia infrastructure by executing `./setup-pubsub.sh <PATH TO CONFIG>`. 
 * The Turbinia infrastructure can be destroyed by executing `./destroy-pubsub.sh`.

--- a/k8s/gcp-pubsub/destroy-pubsub.sh
+++ b/k8s/gcp-pubsub/destroy-pubsub.sh
@@ -10,4 +10,6 @@ kubectl delete -f turbinia-autoscale-cpu.yaml
 kubectl delete -f turbinia-server-metrics-service.yaml 
 kubectl delete -f turbinia-worker-metrics-service.yaml 
 kubectl delete -f turbinia-worker.yaml 
-kubectl delete -f turbinia-server.yaml 
+kubectl delete -f turbinia-server.yaml
+kubectl delete -f turbinia-output-filestore.yaml 
+kubectl delete -f turbinia-output-claim-filestore.yaml 

--- a/k8s/gcp-pubsub/destroy-pubsub.sh
+++ b/k8s/gcp-pubsub/destroy-pubsub.sh
@@ -11,5 +11,5 @@ kubectl delete -f turbinia-server-metrics-service.yaml
 kubectl delete -f turbinia-worker-metrics-service.yaml 
 kubectl delete -f turbinia-worker.yaml 
 kubectl delete -f turbinia-server.yaml
-kubectl delete -f turbinia-output-filestore.yaml 
 kubectl delete -f turbinia-output-claim-filestore.yaml 
+kubectl delete -f turbinia-output-filestore.yaml 

--- a/k8s/gcp-pubsub/setup-pubsub.sh
+++ b/k8s/gcp-pubsub/setup-pubsub.sh
@@ -13,6 +13,8 @@ fi
 
 base64 -w0 $TURBINIA_CONF > turbinia-config.b64
 kubectl create configmap turbinia-config --from-file=TURBINIA_CONF=turbinia-config.b64
+kubectl create -f turbinia-output-filestore.yaml 
+kubectl create -f turbinia-output-claim-filestore.yaml 
 kubectl create -f turbinia-server-metrics-service.yaml 
 kubectl create -f turbinia-worker-metrics-service.yaml 
 kubectl create -f turbinia-server.yaml 

--- a/k8s/gcp-pubsub/turbinia-output-claim-filestore.yaml
+++ b/k8s/gcp-pubsub/turbinia-output-claim-filestore.yaml
@@ -3,9 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: output-claim
 spec:
-  # Specify "" as the storageClassName so it matches the PersistentVolume's StorageClass.
-  # A nil storageClassName value uses the default StorageClass. For details, see
-  # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
   accessModes:
   - ReadWriteMany
   storageClassName: ""

--- a/k8s/gcp-pubsub/turbinia-output-claim-filestore.yaml
+++ b/k8s/gcp-pubsub/turbinia-output-claim-filestore.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: output-claim
+spec:
+  # Specify "" as the storageClassName so it matches the PersistentVolume's StorageClass.
+  # A nil storageClassName value uses the default StorageClass. For details, see
+  # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+  accessModes:
+  - ReadWriteMany
+  storageClassName: ""
+  volumeName: output
+  resources:
+    requests:
+      storage: 1T

--- a/k8s/gcp-pubsub/turbinia-output-filestore.yaml
+++ b/k8s/gcp-pubsub/turbinia-output-filestore.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: output
+spec:
+  capacity:
+    storage: 1T
+  accessModes:
+  - ReadWriteMany
+  nfs:
+    path: /output
+    server: <IP_ADDRESS>

--- a/k8s/gcp-pubsub/turbinia-server.yaml
+++ b/k8s/gcp-pubsub/turbinia-server.yaml
@@ -17,6 +17,13 @@ spec:
       labels:
         app: turbinia-server
     spec:
+      initContainers:
+        - name: init-filestore
+          image: busybox:1.28
+          command: ['sh', '-c', 'chmod go+w /mnt/output']
+          volumeMounts:
+            - mountPath: "/mnt/output"
+              name: output
       containers:
         - name: server
           image: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server:latest
@@ -28,5 +35,13 @@ spec:
                   key: TURBINIA_CONF
             - name: TURBINIA_EXTRA_ARGS
               value: "-d"
+          volumeMounts:
+            - mountPath: /mnt/output
+              name: output
           ports:
             - containerPort: 9200
+      volumes:
+        - name: output
+          persistentVolumeClaim:
+            claimName: output-claim
+            readOnly: false

--- a/k8s/gcp-pubsub/turbinia-worker.yaml
+++ b/k8s/gcp-pubsub/turbinia-worker.yaml
@@ -20,6 +20,13 @@ spec:
       # The grace period needs to be set to the largest task timeout as
       # set in the turbinia configuration file.
       terminationGracePeriodSeconds: 86400
+      initContainers:
+        - name: init-filestore
+          image: busybox:1.28
+          command: ['sh', '-c', 'chmod go+w /mnt/output']
+          volumeMounts:
+            - mountPath: "/mnt/output"
+              name: output
       containers:
         - name: worker
           image: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:latest
@@ -47,6 +54,8 @@ spec:
             - mountPath: "/var/run/lock"
               name: lockfolder
               readOnly: false
+            - mountPath: /mnt/output
+              name: output
           ports:
             - containerPort: 9200
           resources: 
@@ -63,3 +72,7 @@ spec:
         - name: lockfolder
           hostPath:
             path: /var/run/lock
+        - name: output
+          persistentVolumeClaim:
+            claimName: output-claim
+            readOnly: false

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -45,6 +45,7 @@ REQUIRED_VARS = [
     'INSTANCE_ID',
     'STATE_MANAGER',
     'TASK_MANAGER',
+    'LOG_DIR',
     'LOG_FILE',
     'LOCK_FILE',
     'TMP_RESOURCE_DIR',

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -15,6 +15,7 @@
 """Turbinia Config Template"""
 
 from __future__ import unicode_literals
+from os import uname
 
 ################################################################################
 #                          Base Turbinia configuration
@@ -45,8 +46,13 @@ OUTPUT_DIR = '/var/tmp'
 # different from the OUTPUT_DIR.
 TMP_DIR = '/tmp'
 
+# Default directory to where logs will be stored. Note for a Kubernetes
+# environment, set this path to the shared path configured for Filestore
+# so that logs are can be easily retrieved from one central location.
+LOG_DIR = '/var/tmp'
+
 # File to log debugging output to.
-LOG_FILE = '%s/turbinia.log' % TMP_DIR
+LOG_FILE = '%s/%s.log' % (LOG_DIR, uname().nodename)
 
 # Path to a lock file used for the worker tasks.
 LOCK_FILE = '%s/turbinia-worker.lock' % TMP_DIR


### PR DESCRIPTION
The following PR deploys Filestore NFS share to Turbinia GKE to allow for persistent and shared storage.
* Added Deployment files `turbinia-output-claim-filestore.yaml` and `turbinia-output-filestore.yaml` which configure Filestore to the Kubernetes cluster
* Updated `setup-pubsub.sh` and `destroy-pubsub.sh` to create and destroy the Filestore Deployment files.
* Added a new config variable `LOG_DIR` to the `.turbiniarc` config template which sets the default output directory for logs.
* Updated `install-gke.md` docs with instructions for properly configuring Filestore.
