### PR TITLE
remove log_file for log_dir and change in turbiniactl to log node name instead

### DIFF
--- a/docs/user/install-gke.md
+++ b/docs/user/install-gke.md
@@ -80,7 +80,7 @@ gcloud container clusters create CLUSTER_NAME \
 * The `image` variable can be optionally changed in the `turbinia-worker.yaml` and `turbinia-server.yaml` files to chose the docker images used during deployment.
 * In the `turbinia-worker.yaml` file, ensure that the path in the volume labeled `lockfolder` matches the Turbinia config variable `TMP_RESOURCE_DIR`.
 * If the Filestore `Instance ID` and `File share name` have a different name than the default name `output`, update `turbinia-worker.yaml`, `turbinia-server.yaml`, `turbinia-output-claim-filestore.yaml`, and `turbinia-output-filestore.yaml` by searching for the string `output` and replacing it with the custom name. Skip this step if the default name was used.
-* To have all logs go to the central location, update the `LOG_FILE` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom path.
+* To have all logs go to the central location, update the `LOG_DIR` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom path.
 * In `turbinia-output-filestore.yaml`, update `<IP_ADDRESS>` to the Filestore IP address.
 * If the Filestore instance size is greater than 1 TB, update the `storage` sections in `turbinia-output-claim-filestore.yaml` and `turbinia-output-filestore.yaml` with the appropriate size.
 * Ensure that the `.turbiniarc` config file has been properly configured with required GCP variables.

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -45,7 +45,7 @@ REQUIRED_VARS = [
     'INSTANCE_ID',
     'STATE_MANAGER',
     'TASK_MANAGER',
-    'LOG_FILE',
+    'LOG_DIR',
     'LOCK_FILE',
     'TMP_RESOURCE_DIR',
     'RESOURCE_FILE',

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -62,7 +62,7 @@ def setup(need_file_handler=True, need_stream_handler=True):
               exception, config.CONFIG_MSG))
       sys.exit(1)
 
-    file_handler = logging.FileHandler(config.LOG_FILE)
+    file_handler = logging.FileHandler(config.LOG_DIR)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.DEBUG)

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -46,7 +46,7 @@ TMP_DIR = '/tmp'
 # Default path to where logs will be stored. Note for a Kubernetes
 # environment, change the path to the shared path configured for Filestore
 # so that logs are can be easily retrieved from one central location.
-LOG_DIR = '/var/tmp/'
+LOG_DIR = '/var/tmp'
 
 # Path to a lock file used for the worker tasks.
 LOCK_FILE = '%s/turbinia-worker.lock' % TMP_DIR

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 """Turbinia Config Template"""
 
-from __future__ import unicode_literals
-from os import uname
-
 ################################################################################
 #                          Base Turbinia configuration
 #
@@ -49,7 +46,7 @@ TMP_DIR = '/tmp'
 # Default path to where logs will be stored. Note for a Kubernetes
 # environment, change the path to the shared path configured for Filestore
 # so that logs are can be easily retrieved from one central location.
-LOG_FILE = '/var/tmp/%s.log' % uname().nodename
+LOG_DIR = '/var/tmp/'
 
 # Path to a lock file used for the worker tasks.
 LOCK_FILE = '%s/turbinia-worker.lock' % TMP_DIR

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -397,7 +397,12 @@ def main():
   if args.log_file:
     config.LOG_DIR = args.log_file
   else:
-    config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, uname().nodename)
+    log_name = uname().nodename
+    if log_name:
+      config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, log_name)
+    else:
+      config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, 'turbinia.log')
+      
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -395,10 +395,10 @@ def main():
     sys.exit(1)
 
   if args.log_file:
-    config.LOG_FILE = args.log_file
+    config.LOG_DIR = args.log_file
   else:
-    config.LOG_FILE = '{0:s}/{1:s}.log'.format(
-        config.LOG_FILE,
+    config.LOG_DIR = '{0:s}/{1:s}.log'.format(
+        config.LOG_DIR,
         uname().nodename)
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -27,6 +27,7 @@ import sys
 import uuid
 import copy
 
+from os import uname
 from turbinia import config
 from turbinia import TurbiniaException
 from turbinia.config import logger
@@ -395,6 +396,10 @@ def main():
 
   if args.log_file:
     config.LOG_FILE = args.log_file
+  else:
+    config.LOG_FILE = '{0:s}/{1:s}.log'.format(
+        config.LOG_FILE,
+        uname().nodename)
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -397,9 +397,7 @@ def main():
   if args.log_file:
     config.LOG_DIR = args.log_file
   else:
-    config.LOG_DIR = '{0:s}/{1:s}.log'.format(
-        config.LOG_DIR,
-        uname().nodename)
+    config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, uname().nodename)
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 


### PR DESCRIPTION
This PR replaces `LOG_FILE` with `LOG_DIR` and removes the python code in the configuration to instead be set during `turbiniactl.py`. 