### PR TITLE
Check for empty evidence

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -315,6 +315,14 @@ class TurbiniaTaskResult:
             was supplied to the task, so likely the caller will always want to
             use evidence_.config for this parameter.
     """
+    if (os.path.exists(evidence.source_path) and
+        os.path.getsize(evidence.source_path) == 0):
+      self.log(
+          'Evidence source path [{0:s}] for [{1:s}] exists but is empty. Not '
+          'adding empty Evidence.'.format(evidence.source_path, evidence.name),
+          logging.WARNING)
+      return
+
     # We want to enforce this here to make sure that any new Evidence objects
     # created also contain the config.  We could create a closure to do this
     # automatically, but the real fix is to attach this to a separate object.

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -315,7 +315,7 @@ class TurbiniaTaskResult:
             was supplied to the task, so likely the caller will always want to
             use evidence_.config for this parameter.
     """
-    if (os.path.exists(evidence.source_path) and
+    if (evidence.source_path and os.path.exists(evidence.source_path) and
         os.path.getsize(evidence.source_path) == 0):
       self.log(
           'Evidence source path [{0:s}] for [{1:s}] exists but is empty. Not '

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -388,6 +388,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
     # Test that evidence is *not* added when source_path points to file with no
     # contents.
+    self.result.evidence = []
     empty_file = tempfile.mkstemp(dir=self.base_output_dir)[1]
     self.remove_files.append(empty_file)
     self.evidence.source_path = empty_file
@@ -396,6 +397,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.assertEqual(len(self.result.evidence), 0)
 
     # Test that evidence with source_path=None gets added
+    self.result.evidence = []
     self.evidence.source_path = None
     self.result.add_evidence(self.evidence, 'EmptyConfig')
     self.assertEqual(self.result.evidence[0].name, 'AddEvidenceTest')

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -372,3 +372,30 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     # Runs fine after setting the state
     self.evidence.state[evidence.EvidenceState.ATTACHED] = True
     self.task.evidence_setup(self.evidence)
+
+  def testAddEvidence(self):
+    """Test that add_evidence adds evidence when appropriate."""
+
+    # Test that evidence gets added in the base case (source_path points to file
+    # with contents)
+    self.evidence.name = 'AddEvidenceTest'
+    with open(self.evidence.source_path, 'w') as source_path:
+      source_path.write('test')
+    self.result.add_evidence(self.evidence, 'EmptyConfig')
+    self.assertEqual(len(self.result.evidence), 1)
+    self.assertEqual(self.result.evidence[0].name, 'AddEvidenceTest')
+    self.assertEqual(self.result.evidence[0].config, 'EmptyConfig')
+
+    # Test that evidence is *not* added when source_path points to file with no
+    # contents.
+    empty_file = tempfile.mkstemp(dir=self.base_output_dir)[1]
+    self.remove_files.append(empty_file)
+    self.evidence.source_path = empty_file
+    self.result.add_evidence(self.evidence, 'EmptyConfig')
+    # Evidence with empty path was not in evidence list
+    self.assertEqual(len(self.result.evidence), 0)
+
+    # Test that evidence with source_path=None gets added
+    self.evidence.source_path = None
+    self.result.add_evidence(self.evidence, 'EmptyConfig')
+    self.assertEqual(self.result.evidence[0].name, 'AddEvidenceTest')


### PR DESCRIPTION
Changes the worker not to return generated Evidence files that point to source_paths that are empty.  Not all evidence has a source_path though, so source_path=None is still returned.