### PR TITLE
Close results on early task setup failures

### DIFF
--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -436,6 +436,17 @@ class BaseTaskManager:
     Returns:
       TurbiniaJob|None: The Job for the processed task, else None
     """
+    if task_result.successful is None:
+      log.error(
+          'Task {0:s} from {1:s} returned invalid success status "None". '
+          'Setting this to False so the client knows the Task is complete. '
+          'Usually this means that the close() method was not called on the '
+          'TurbiniaTaskResult prior to returning it'.format(
+              task_result.task_name, task_result.worker_name))
+      task_result.successful = False
+      task_result.status = (
+          task_result.status + ' (Sucess status forcefully set to False)')
+
     if not task_result.successful:
       log.error(
           'Task {0:s} from {1:s} was not successful'.format(

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -64,6 +64,9 @@ turbinia_jobs_completed_total = Gauge(
     'turbinia_jobs_completed_total', 'Total number jobs resolved')
 turbinia_server_request_total = Gauge(
     'turbinia_server_request_total', 'Total number of requests received.')
+turbinia_result_success_invalid = Gauge(
+    'turbinia_result_success_invalid',
+    'The result returned from the Task had an invalid success status of None')
 
 
 def get_task_manager():
@@ -443,6 +446,7 @@ class BaseTaskManager:
           'Usually this means that the Task returning the TurbiniaTaskResult '
           'did not call the close() method on it.'.format(
               task_result.task_name, task_result.worker_name))
+      turbinia_result_success_invalid.inc()
       task_result.successful = False
       if task_result.status:
         task_result.status = (

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -440,8 +440,8 @@ class BaseTaskManager:
       log.error(
           'Task {0:s} from {1:s} returned invalid success status "None". '
           'Setting this to False so the client knows the Task is complete. '
-          'Usually this means that the close() method was not called on the '
-          'TurbiniaTaskResult prior to returning it'.format(
+          'Usually this means that the Task returning the TurbiniaTaskResult '
+          'did not call the close() method on it.'.format(
               task_result.task_name, task_result.worker_name))
       task_result.successful = False
       if task_result.status:

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -445,7 +445,7 @@ class BaseTaskManager:
               task_result.task_name, task_result.worker_name))
       task_result.successful = False
       task_result.status = (
-          task_result.status + ' (Sucess status forcefully set to False)')
+          task_result.status + ' (Success status forcefully set to False)')
 
     if not task_result.successful:
       log.error(

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -444,8 +444,9 @@ class BaseTaskManager:
           'TurbiniaTaskResult prior to returning it'.format(
               task_result.task_name, task_result.worker_name))
       task_result.successful = False
-      task_result.status = (
-          task_result.status + ' (Success status forcefully set to False)')
+      if task_result.status:
+        task_result.status = (
+            task_result.status + ' (Success status forcefully set to False)')
 
     if not task_result.successful:
       log.error(

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -964,7 +964,7 @@ class TurbiniaTask:
       else:
         self.result = self.create_result(
             message=message, trace=traceback.format_exc())
-      # self.result.close(self, success=False)
+      self.result.close(self, success=False)
       return self.result.serialize()
 
     log.info('Starting Task {0:s} {1:s}'.format(self.name, self.id))

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -964,6 +964,7 @@ class TurbiniaTask:
       else:
         self.result = self.create_result(
             message=message, trace=traceback.format_exc())
+      # self.result.close(self, success=False)
       return self.result.serialize()
 
     log.info('Starting Task {0:s} {1:s}'.format(self.name, self.id))

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -213,7 +213,8 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     # Checking specifically for `False` value and not whether this evaluates to
     # `False` because we don't want the `None` case to pass.
     self.assertEqual(new_result.successful, False)
-    self.assertIn(canary_status, new_result.status)
+    create_results_args = mock_create_results.call_args.kwargs
+    self.assertIn(canary_status, create_results_args['message'])
 
   def testTurbiniaTaskValidateResultGoodResult(self):
     """Tests validate_result with good result."""

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -193,13 +193,17 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.assertEqual(type(new_result), TurbiniaTaskResult)
     self.assertIn('failed', new_result.status)
 
+  @mock.patch('turbinia.workers.TurbiniaTaskResult.create_result')
   @mock.patch('turbinia.state_manager.get_state_manager')
-  def testTurbiniaTaskRunWrapperSetupFail(self, _):
+  def testTurbiniaTaskRunWrapperSetupFail(self, _, mock_create_result):
     """Test that the run wrapper recovers from setup failing."""
     self.task.result = None
     canary_status = 'exception_message'
     self.task.setup = mock.MagicMock(
         side_effect=TurbiniaException('exception_message'))
+
+    self.result.no_output_manager = True
+    mock_create_result.return_value = self.result
     self.remove_files.append(
         os.path.join(self.task.base_output_dir, 'worker-log.txt'))
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -213,7 +213,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     # Checking specifically for `False` value and not whether this evaluates to
     # `False` because we don't want the `None` case to pass.
     self.assertEqual(new_result.successful, False)
-    create_results_args = mock_create_results.call_args.kwargs
+    create_results_args = mock_create_result.call_args.kwargs
     self.assertIn(canary_status, create_results_args['message'])
 
   def testTurbiniaTaskValidateResultGoodResult(self):

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -193,7 +193,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.assertEqual(type(new_result), TurbiniaTaskResult)
     self.assertIn('failed', new_result.status)
 
-  @mock.patch('turbinia.workers.TurbiniaTaskResult.create_result')
+  @mock.patch('turbinia.workers.TurbiniaTask.create_result')
   @mock.patch('turbinia.state_manager.get_state_manager')
   def testTurbiniaTaskRunWrapperSetupFail(self, _, mock_create_result):
     """Test that the run wrapper recovers from setup failing."""

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -206,7 +206,9 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     new_result = self.task.run_wrapper(self.evidence.__dict__)
     new_result = TurbiniaTaskResult.deserialize(new_result)
     self.assertEqual(type(new_result), TurbiniaTaskResult)
-    self.assertFalse(new_result.successful)
+    # Checking specifically for `False` value and not whether this evaluates to
+    # `False` because we don't want the `None` case to pass.
+    self.assertEqual(new_result.successful, False)
     self.assertIn(canary_status, new_result.status)
 
   def testTurbiniaTaskValidateResultGoodResult(self):

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -206,6 +206,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     new_result = self.task.run_wrapper(self.evidence.__dict__)
     new_result = TurbiniaTaskResult.deserialize(new_result)
     self.assertEqual(type(new_result), TurbiniaTaskResult)
+    self.assertFalse(new_result.successful)
     self.assertIn(canary_status, new_result.status)
 
   def testTurbiniaTaskValidateResultGoodResult(self):


### PR DESCRIPTION
The `TurbiniaTaskResult.successful` status was not getting updated properly upon early failures which meant that the client thought the Task was continuing to run in this case.  Calling `close()` on the result will make sure that the worker log gets saved as well.

Also adding a server side check for this condition which forcefully sets `successful=False` which allows us to recover in case there are other times where the results aren't closed properly.