### PR TITLE
Move log node name init out of config file to turbinia code and expose NODE_NAME in GKE setup to correlate pod and node name

### DIFF
--- a/docs/user/install-gke.md
+++ b/docs/user/install-gke.md
@@ -80,7 +80,7 @@ gcloud container clusters create CLUSTER_NAME \
 * The `image` variable can be optionally changed in the `turbinia-worker.yaml` and `turbinia-server.yaml` files to chose the docker images used during deployment.
 * In the `turbinia-worker.yaml` file, ensure that the path in the volume labeled `lockfolder` matches the Turbinia config variable `TMP_RESOURCE_DIR`.
 * If the Filestore `Instance ID` and `File share name` have a different name than the default name `output`, update `turbinia-worker.yaml`, `turbinia-server.yaml`, `turbinia-output-claim-filestore.yaml`, and `turbinia-output-filestore.yaml` by searching for the string `output` and replacing it with the custom name. Skip this step if the default name was used.
-* To have all logs go to the central location, update the `LOG_FILE` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom path.
+* To have all logs go to the central location, update the `LOG_DIR` variable in the `.turbiniarc` config file to the default Filestore path `/mnt/output` or if configured differently, to the custom path.
 * In `turbinia-output-filestore.yaml`, update `<IP_ADDRESS>` to the Filestore IP address.
 * If the Filestore instance size is greater than 1 TB, update the `storage` sections in `turbinia-output-claim-filestore.yaml` and `turbinia-output-filestore.yaml` with the appropriate size.
 * Ensure that the `.turbiniarc` config file has been properly configured with required GCP variables.

--- a/k8s/gcp-pubsub/turbinia-server.yaml
+++ b/k8s/gcp-pubsub/turbinia-server.yaml
@@ -35,6 +35,10 @@ spec:
                   key: TURBINIA_CONF
             - name: TURBINIA_EXTRA_ARGS
               value: "-d"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - mountPath: /mnt/output
               name: output

--- a/k8s/gcp-pubsub/turbinia-worker.yaml
+++ b/k8s/gcp-pubsub/turbinia-worker.yaml
@@ -47,6 +47,10 @@ spec:
                   key: TURBINIA_CONF
             - name: TURBINIA_EXTRA_ARGS
               value: "-d"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           volumeMounts:
             - mountPath: "/dev"
               name: dev

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -45,7 +45,7 @@ REQUIRED_VARS = [
     'INSTANCE_ID',
     'STATE_MANAGER',
     'TASK_MANAGER',
-    'LOG_FILE',
+    'LOG_DIR',
     'LOCK_FILE',
     'TMP_RESOURCE_DIR',
     'RESOURCE_FILE',

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -19,9 +19,12 @@ import logging
 
 import warnings
 import logging.handlers
-from os import uname
+from os import uname, environ
 from turbinia import config
 from turbinia import TurbiniaException
+
+# Environment variable to look for node name in
+ENVNODENAME = 'NODE_NAME'
 
 
 def setup(
@@ -66,9 +69,11 @@ def setup(
 
     # Check if user specified log name and update to default if not
     if not user_specified_log:
-      config.LOG_DIR = '{0:s}/{1:s}.log'.format(
-          config.LOG_DIR,
-          uname().nodename)
+      log_name = uname().nodename
+      # Check if NODE_NAME available for GKE setups
+      if ENVNODENAME in environ:
+        log_name = log_name + '.{0!s}'.format(environ[ENVNODENAME])
+      config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, log_name)
 
     file_handler = logging.FileHandler(config.LOG_DIR)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -19,7 +19,8 @@ import logging
 
 import warnings
 import logging.handlers
-from os import uname, environ
+import os
+
 from turbinia import config
 from turbinia import TurbiniaException
 
@@ -27,8 +28,7 @@ from turbinia import TurbiniaException
 ENVNODENAME = 'NODE_NAME'
 
 
-def setup(
-    need_file_handler=True, need_stream_handler=True, user_specified_log=False):
+def setup(need_file_handler=True, need_stream_handler=True, log_file_path=None):
   """Set up logging parameters.
 
   This will also set the root logger, which is the default logger when a named
@@ -67,15 +67,15 @@ def setup(
               exception, config.CONFIG_MSG))
       sys.exit(1)
 
-    # Check if user specified log name and update to default if not
-    if not user_specified_log:
-      log_name = uname().nodename
+    # Check if a user specified log path was provided else create default path
+    if not log_file_path:
+      log_name = os.uname().nodename
       # Check if NODE_NAME available for GKE setups
-      if ENVNODENAME in environ:
-        log_name = log_name + '.{0!s}'.format(environ[ENVNODENAME])
-      config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, log_name)
+      if ENVNODENAME in os.environ:
+        log_name = log_name + '.{0!s}'.format(os.environ[ENVNODENAME])
+      log_file_path = os.path.join(config.LOG_DIR, log_name) + '.log'
 
-    file_handler = logging.FileHandler(config.LOG_DIR)
+    file_handler = logging.FileHandler(log_file_path)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.DEBUG)

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -24,7 +24,7 @@ from turbinia import config
 from turbinia import TurbiniaException
 
 
-def setup(need_file_handler=True, need_stream_handler=True):
+def setup(need_file_handler=True, need_stream_handler=True, user_specified_log=False):
   """Set up logging parameters.
 
   This will also set the root logger, which is the default logger when a named
@@ -62,9 +62,12 @@ def setup(need_file_handler=True, need_stream_handler=True):
           'Could not load config file ({0!s}).\n{1:s}'.format(
               exception, config.CONFIG_MSG))
       sys.exit(1)
+    
+    # Check if user specified log name and update to default if not
+    if not user_specified_log:
+      config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, uname().nodename)
 
-    log_name = '{0:s}/{1:s}.log'.format(config.LOG_DIR, uname().nodename)
-    file_handler = logging.FileHandler(log_name)
+    file_handler = logging.FileHandler(config.LOG_DIR)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.DEBUG)

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -62,11 +62,9 @@ def setup(need_file_handler=True, need_stream_handler=True):
           'Could not load config file ({0!s}).\n{1:s}'.format(
               exception, config.CONFIG_MSG))
       sys.exit(1)
-    
-    log_name = uname().nodename
-    config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, log_name)
 
-    file_handler = logging.FileHandler(config.LOG_DIR)
+    log_name = '{0:s}/{1:s}.log'.format(config.LOG_DIR, uname().nodename)
+    file_handler = logging.FileHandler(log_name)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.DEBUG)

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -24,7 +24,8 @@ from turbinia import config
 from turbinia import TurbiniaException
 
 
-def setup(need_file_handler=True, need_stream_handler=True, user_specified_log=False):
+def setup(
+    need_file_handler=True, need_stream_handler=True, user_specified_log=False):
   """Set up logging parameters.
 
   This will also set the root logger, which is the default logger when a named
@@ -62,10 +63,12 @@ def setup(need_file_handler=True, need_stream_handler=True, user_specified_log=F
           'Could not load config file ({0!s}).\n{1:s}'.format(
               exception, config.CONFIG_MSG))
       sys.exit(1)
-    
+
     # Check if user specified log name and update to default if not
     if not user_specified_log:
-      config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, uname().nodename)
+      config.LOG_DIR = '{0:s}/{1:s}.log'.format(
+          config.LOG_DIR,
+          uname().nodename)
 
     file_handler = logging.FileHandler(config.LOG_DIR)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')

--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -19,6 +19,7 @@ import logging
 
 import warnings
 import logging.handlers
+from os import uname
 from turbinia import config
 from turbinia import TurbiniaException
 
@@ -61,8 +62,11 @@ def setup(need_file_handler=True, need_stream_handler=True):
           'Could not load config file ({0!s}).\n{1:s}'.format(
               exception, config.CONFIG_MSG))
       sys.exit(1)
+    
+    log_name = uname().nodename
+    config.LOG_DIR = '{0:s}/{1:s}.log'.format(config.LOG_DIR, log_name)
 
-    file_handler = logging.FileHandler(config.LOG_FILE)
+    file_handler = logging.FileHandler(config.LOG_DIR)
     formatter = logging.Formatter('%(asctime)s:%(levelname)s:%(message)s')
     file_handler.setFormatter(formatter)
     file_handler.setLevel(logging.DEBUG)

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -14,9 +14,6 @@
 # limitations under the License.
 """Turbinia Config Template"""
 
-from __future__ import unicode_literals
-from os import uname
-
 ################################################################################
 #                          Base Turbinia configuration
 #
@@ -49,7 +46,7 @@ TMP_DIR = '/tmp'
 # Default path to where logs will be stored. Note for a Kubernetes
 # environment, change the path to the shared path configured for Filestore
 # so that logs are can be easily retrieved from one central location.
-LOG_FILE = '/var/tmp/%s.log' % uname().nodename
+LOG_DIR = '/var/tmp'
 
 # Path to a lock file used for the worker tasks.
 LOCK_FILE = '%s/turbinia-worker.lock' % TMP_DIR

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -451,8 +451,10 @@ def process_args(args):
             exception, config.CONFIG_MSG))
     sys.exit(1)
 
+  user_specified_log = False
   if args.log_file:
     config.LOG_DIR = args.log_file
+    user_specified_log = True
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 
@@ -463,7 +465,7 @@ def process_args(args):
   # file explicitly set on the command line) to set a file-handler now that we
   # have the logfile path from the config.
   if server_flags_set or worker_flags_set or args.log_file:
-    logger.setup()
+    logger.setup(user_specified_log)
   if args.quiet:
     log.setLevel(logging.ERROR)
   elif args.debug:
@@ -657,12 +659,12 @@ def process_args(args):
   elif args.command == 'psqworker':
     # Set up root logger level which is normally set by the psqworker command
     # which we are bypassing.
-    logger.setup()
+    logger.setup(user_specified_log)
     worker = TurbiniaPsqWorker(
         jobs_denylist=args.jobs_denylist, jobs_allowlist=args.jobs_allowlist)
     worker.start()
   elif args.command == 'celeryworker':
-    logger.setup()
+    logger.setup(user_specified_log)
     worker = TurbiniaCeleryWorker(
         jobs_denylist=args.jobs_denylist, jobs_allowlist=args.jobs_allowlist)
     worker.start()

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -462,7 +462,7 @@ def process_args(args):
   # Run logger setup again if we're running as a server or worker (or have a log
   # file explicitly set on the command line) to set a file-handler now that we
   # have the logfile path from the config.
-  if server_flags_set or worker_flags_set:
+  if server_flags_set or worker_flags_set or args.log_file:
     if args.log_file:
       logger.setup(user_specified_log=True)
     else:

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -452,7 +452,7 @@ def process_args(args):
     sys.exit(1)
 
   if args.log_file:
-    config.LOG_FILE = args.log_file
+    config.LOG_DIR = args.log_file
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -451,10 +451,8 @@ def process_args(args):
             exception, config.CONFIG_MSG))
     sys.exit(1)
 
-  user_specified_log = False
   if args.log_file:
     config.LOG_DIR = args.log_file
-    user_specified_log = True
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 
@@ -464,8 +462,11 @@ def process_args(args):
   # Run logger setup again if we're running as a server or worker (or have a log
   # file explicitly set on the command line) to set a file-handler now that we
   # have the logfile path from the config.
-  if server_flags_set or worker_flags_set or args.log_file:
-    logger.setup(user_specified_log)
+  if server_flags_set or worker_flags_set:
+    if args.log_file:
+      logger.setup(user_specified_log=True)
+    else:
+      logger.setup()
   if args.quiet:
     log.setLevel(logging.ERROR)
   elif args.debug:
@@ -659,12 +660,12 @@ def process_args(args):
   elif args.command == 'psqworker':
     # Set up root logger level which is normally set by the psqworker command
     # which we are bypassing.
-    logger.setup(user_specified_log)
+    logger.setup()
     worker = TurbiniaPsqWorker(
         jobs_denylist=args.jobs_denylist, jobs_allowlist=args.jobs_allowlist)
     worker.start()
   elif args.command == 'celeryworker':
-    logger.setup(user_specified_log)
+    logger.setup()
     worker = TurbiniaCeleryWorker(
         jobs_denylist=args.jobs_denylist, jobs_allowlist=args.jobs_allowlist)
     worker.start()

--- a/turbinia/turbiniactl.py
+++ b/turbinia/turbiniactl.py
@@ -452,7 +452,7 @@ def process_args(args):
     sys.exit(1)
 
   if args.log_file:
-    config.LOG_DIR = args.log_file
+    user_specified_log = args.log_file
   if args.output_dir:
     config.OUTPUT_DIR = args.output_dir
 
@@ -464,7 +464,7 @@ def process_args(args):
   # have the logfile path from the config.
   if server_flags_set or worker_flags_set or args.log_file:
     if args.log_file:
-      logger.setup(user_specified_log=True)
+      logger.setup(log_file_path=user_specified_log)
     else:
       logger.setup()
   if args.quiet:


### PR DESCRIPTION
This PR moves the Python code in the Turbinia config file used to determine the node name for the default logger file name. I 've updated `LOG_FILE` back to `LOG_DIR` to take in a log directory path and added a new logic to check if user specified log name was given and if not to create the log name based on `LOG_DIR` and the host name.

In addition, the node name has been exposed through the `turbinia-server.yaml` and `turbinia-worker.yaml` file and logic added to check for `NODE_NAME` and append to the log name if it exists. This way we can correlate node name with pod name and fixes #973 