### PR TITLE
Retrieve status for bulk requests

### DIFF
--- a/tools/gcf_init/index.js
+++ b/tools/gcf_init/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 // Global
-const {Datastore} = require('@google-cloud/datastore');
+const { Datastore } = require('@google-cloud/datastore');
 // Instantiates a client
 const datastore = new Datastore();
 const turbiniaKind = 'TurbiniaTask';
@@ -37,6 +37,7 @@ const turbiniaKind = 'TurbiniaTask';
  * @param {string} req.body.start_time A date string in ISO 8601 format of the
  *    beginning of the time window to query for
  * @param {string} req.body.task_id Id of task to retrieve
+ * @param {string} req.body.group_id of tasks to retrieve
  * @param {string} req.body.request_id of tasks to retrieve
  * @param {string} req.body.user of tasks to retrieve
  * @param {object} res Cloud Function response context.
@@ -50,8 +51,8 @@ exports.gettasks = function gettasks(req, res) {
   }
 
   var query = datastore.createQuery(req.body.kind)
-                  .filter('instance', '=', req.body.instance)
-                  .order('last_update', {descending: true});
+    .filter('instance', '=', req.body.instance)
+    .order('last_update', { descending: true });
   var start_time;
 
   // Note: If you change any of these filter properties, you must also
@@ -60,6 +61,10 @@ exports.gettasks = function gettasks(req, res) {
   if (req.body.task_id) {
     console.log('Getting Turbinia Tasks by Task Id: ' + req.body.task_id);
     query = query.filter('id', '=', req.body.task_id)
+  }
+  if (req.body.group_id) {
+    console.log('Getting Turbinia Tasks by Group ID: ' + req.body.group_id);
+    query = query.filter('group_id', '=', req.body.group_id);
   }
   if (req.body.request_id) {
     console.log('Getting Turbinia Tasks by Request Id: ' + req.body.request_id);
@@ -79,7 +84,7 @@ exports.gettasks = function gettasks(req, res) {
     query = query.filter('last_update', '>=', start_time)
   }
   if (!req.body.task_id && !req.body.request_id && !req.body.user &&
-      !req.body.start_time) {
+    !req.body.start_time) {
     console.log('Getting open Turbinia Tasks.');
     query = query.filter('successful', '=', null)
   }
@@ -87,19 +92,19 @@ exports.gettasks = function gettasks(req, res) {
   console.log(query);
 
   return datastore.runQuery(query)
-      .then((results) => {
-        // Task entities found.
-        const tasks = results[0];
+    .then((results) => {
+      // Task entities found.
+      const tasks = results[0];
 
-        console.log('Turbinia Tasks:');
-        tasks.forEach((task) => console.log(task));
-        res.status(200).send(results);
-      })
-      .catch((err) => {
-        console.error('Error in runQuery' + err);
-        res.status(500).send(err);
-        return Promise.reject(err);
-      });
+      console.log('Turbinia Tasks:');
+      tasks.forEach((task) => console.log(task));
+      res.status(200).send(results);
+    })
+    .catch((err) => {
+      console.error('Error in runQuery' + err);
+      res.status(500).send(err);
+      return Promise.reject(err);
+    });
 };
 
 /**
@@ -133,13 +138,13 @@ exports.closetasks = function closetasks(req, res) {
   }
   if (!req.body.request_id && !req.body.task_id && !req.body.user) {
     throw new Error(
-        'None of Request ID, Task ID, or user provided in request.');
+      'None of Request ID, Task ID, or user provided in request.');
   }
 
   var query = datastore.createQuery(req.body.kind)
-                  .filter('instance', '=', req.body.instance)
-                  .filter('successful', '=', null)
-                  .order('last_update', {descending: true});
+    .filter('instance', '=', req.body.instance)
+    .filter('successful', '=', null)
+    .order('last_update', { descending: true });
   if (req.body.request_id) {
     console.log('Adding filter - Request Id: ' + req.body.request_id);
     query = query.filter('request_id', '=', req.body.request_id)
@@ -147,7 +152,7 @@ exports.closetasks = function closetasks(req, res) {
   if (req.body.task_id) {
     console.log('Adding filter - Task Id: ' + req.body.task_id);
     query = query.filter(
-        '__key__', '=', datastore.key([turbiniaKind, req.body.task_id]))
+      '__key__', '=', datastore.key([turbiniaKind, req.body.task_id]))
   }
   if (req.body.user) {
     console.log('Adding filter - requester: ' + req.body.user);
@@ -157,29 +162,29 @@ exports.closetasks = function closetasks(req, res) {
   console.log(query);
 
   return datastore.runQuery(query)
-      .then((results) => {
-        // Task entities found.
-        const tasks = results[0];
-        var uncompleted_tasks = [];
-        tasks.forEach((task) => {
-          console.log(task);
-          uncompleted_tasks.push(
-              {'request_id': task.request_id, 'id': task.id});
-        });
-        return uncompleted_tasks;
-      })
-      .then((uncompleted_tasks) => {
-        uncompleted_tasks.forEach((task) => {
-          module.exports.closetask(task.id, req.body.requester);
-        });
-        return uncompleted_tasks;
-      })
-      .then((uncompleted_tasks) => { res.status(200).send(uncompleted_tasks); })
-      .catch((err) => {
-        console.error('Error in runQuery' + err);
-        res.status(500).send(err);
-        return Promise.reject(err);
+    .then((results) => {
+      // Task entities found.
+      const tasks = results[0];
+      var uncompleted_tasks = [];
+      tasks.forEach((task) => {
+        console.log(task);
+        uncompleted_tasks.push(
+          { 'request_id': task.request_id, 'id': task.id });
       });
+      return uncompleted_tasks;
+    })
+    .then((uncompleted_tasks) => {
+      uncompleted_tasks.forEach((task) => {
+        module.exports.closetask(task.id, req.body.requester);
+      });
+      return uncompleted_tasks;
+    })
+    .then((uncompleted_tasks) => { res.status(200).send(uncompleted_tasks); })
+    .catch((err) => {
+      console.error('Error in runQuery' + err);
+      res.status(500).send(err);
+      return Promise.reject(err);
+    });
 };
 
 exports.closetask = function closetask(id, requester) {
@@ -193,32 +198,32 @@ exports.closetask = function closetask(id, requester) {
   const taskKey = datastore.key([turbiniaKind, id]);
   console.log('Preparing transaction.');
   transaction.run()
-      .then(() => transaction.get(taskKey))
-      .then(results => {
-        const taskEntity = results[0];
-        taskEntity.successful = false;
-        taskEntity.status = 'Task forcefully closed by ' + requester + '.';
-        var updatedEntity = {
-          key: taskKey,
-          data: taskEntity,
-        };
-        transaction.save(updatedEntity);
+    .then(() => transaction.get(taskKey))
+    .then(results => {
+      const taskEntity = results[0];
+      taskEntity.successful = false;
+      taskEntity.status = 'Task forcefully closed by ' + requester + '.';
+      var updatedEntity = {
+        key: taskKey,
+        data: taskEntity,
+      };
+      transaction.save(updatedEntity);
 
-        console.log('Committing transaction: %o', updatedEntity);
-        transaction.commit()
-            .then(() => {
-              console.log('Entity successfully saved.');
-              return updatedEntity;
-            })
-            .catch(err => {
-              console.error('Rolling back - Error in transaction (Failure)');
-              console.error(err);
-              transaction.rollback();
-            });
-      })
-      .catch((err) => {
-        console.error('Rolling back - Error in transaction (Other Reasons)');
-        console.error(err);
-        transaction.rollback();
-      });
+      console.log('Committing transaction: %o', updatedEntity);
+      transaction.commit()
+        .then(() => {
+          console.log('Entity successfully saved.');
+          return updatedEntity;
+        })
+        .catch(err => {
+          console.error('Rolling back - Error in transaction (Failure)');
+          console.error(err);
+          transaction.rollback();
+        });
+    })
+    .catch((err) => {
+      console.error('Rolling back - Error in transaction (Other Reasons)');
+      console.error(err);
+      transaction.rollback();
+    });
 };

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -847,7 +847,6 @@ class BaseTurbiniaClient:
     success_map = dict(zip(success_values, success_types))
     # This is used for group ID status
     requests = defaultdict(dict)
-
     requester = task_results[0].get('requester')
     request_id = task_results[0].get('request_id')
     task_map = defaultdict(list)
@@ -877,15 +876,17 @@ class BaseTurbiniaClient:
                 success_counts['Failed'],
                 success_counts['Scheduled or Running']))
         if full_report:
-          self.format_task_status(
-              instance, project, region, days=0, task_id=None,
-              request_id=request_id, user=user, all_fields=all_fields,
-              full_report=full_report, priority_filter=priority_filter,
-              output_json=output_json, report=report)
+          report.append(
+              self.format_task_status(
+                  instance, project, region, days=0, task_id=None,
+                  request_id=request_id, user=user, all_fields=all_fields,
+                  full_report=full_report, priority_filter=priority_filter,
+                  output_json=output_json, report=report))
 
       return '\n'.join(report)
 
     # Generate report header
+    report = []
     report.append('\n')
     report.append(fmt.heading1('Turbinia report {0:s}'.format(request_id)))
     report.append(

--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -791,7 +791,7 @@ class BaseTurbiniaClient:
   def format_task_status(
       self, instance, project, region, days=0, task_id=None, request_id=None,
       group_id=None, user=None, all_fields=False, full_report=False,
-      priority_filter=Priority.HIGH, output_json=False, report=[]):
+      priority_filter=Priority.HIGH, output_json=False, report=None):
     """Formats the recent history for Turbinia Tasks.
 
     Args:
@@ -841,6 +841,8 @@ class BaseTurbiniaClient:
       return '\n{0:s}'.format(msg)
 
     # Build up data
+    if report is None:
+      report = []
     success_types = ['Successful', 'Failed', 'Scheduled or Running']
     success_values = [True, False, None]
     # Reverse mapping values to types
@@ -870,23 +872,22 @@ class BaseTurbiniaClient:
           fmt.heading1('Turbinia report for group ID {0:s}'.format(group_id)))
       for request_id, success_counts in requests.items():
         report.append(
-            'Request Id {0:s} with {1:d} successful, {2:d} failed, and {3:d} running tasks.'
-            .format(
-                request_id, success_counts['Successful'],
-                success_counts['Failed'],
-                success_counts['Scheduled or Running']))
+            fmt.bullet(
+                'Request Id {0:s} with {1:d} successful, {2:d} failed, and {3:d} running tasks.'
+                .format(
+                    request_id, success_counts['Successful'],
+                    success_counts['Failed'],
+                    success_counts['Scheduled or Running'])))
         if full_report:
-          report.append(
-              self.format_task_status(
-                  instance, project, region, days=0, task_id=None,
-                  request_id=request_id, user=user, all_fields=all_fields,
-                  full_report=full_report, priority_filter=priority_filter,
-                  output_json=output_json, report=report))
+          self.format_task_status(
+              instance, project, region, days=0, task_id=None,
+              request_id=request_id, user=user, all_fields=all_fields,
+              full_report=full_report, priority_filter=priority_filter,
+              output_json=output_json, report=report)
 
       return '\n'.join(report)
 
     # Generate report header
-    report = []
     report.append('\n')
     report.append(fmt.heading1('Turbinia report {0:s}'.format(request_id)))
     report.append(

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -241,7 +241,8 @@ class RedisStateManager(BaseStateManager):
     return data
 
   def get_task_data(
-      self, instance, days=0, task_id=None, request_id=None, user=None):
+      self, instance, days=0, task_id=None, request_id=None, group_id=None,
+      user=None):
     """Gets task data from Redis.
 
     Args:
@@ -250,6 +251,7 @@ class RedisStateManager(BaseStateManager):
       days (int): The number of days we want history for.
       task_id (string): The Id of the task.
       request_id (string): The Id of the request we want tasks for.
+      group_id (string): Group Id of the requests.
       user (string): The user of the request we want tasks for.
 
     Returns:
@@ -279,6 +281,8 @@ class RedisStateManager(BaseStateManager):
       tasks = [task for task in tasks if task.get('task_id') == task_id]
     if request_id:
       tasks = [task for task in tasks if task.get('request_id') == request_id]
+    if group_id:
+      tasks = [task for task in tasks if task.get('group_id') == group_id]
     if user:
       tasks = [task for task in tasks if task.get('requester') == user]
 


### PR DESCRIPTION
Added a status command for group_id. By default it only returns the requests and number of successful/failed/running tasks associated with given group_id. Run with --full_report command for full details on each request.

Sample output:
```
python3 turbinia/turbiniactl.py status  -g 2c4393fdb8bb4c7bb6aa5fb1fa1bc1f1

2022-01-25 18:20:26 [INFO] Turbinia version: unknown
2022-01-25 18:20:27 [INFO] Disabling non-allowlisted jobs configured to be disabled in the config file: volatilityjob, dockercontainersenumerationjob, photorecjob


# Turbinia report for group ID 2c4393fdb8bb4c7bb6aa5fb1fa1bc1f1
Request Id a43c7d9fb1ef4d1a90c394737d777cf6 with 1 successful, 6 failed, and 0 running tasks.
Request Id 77952f84a956441c9c1c8235245a0930 with 1 successful, 6 failed, and 0 running tasks.
Request Id 0ca16d5884d3435fbec8bbd4522b3233 with 1 successful, 6 failed, and 0 running tasks.
```