### PR TITLE
Pin pyOpenSSL

### DIFF
--- a/dfvfs_requirements.txt
+++ b/dfvfs_requirements.txt
@@ -28,3 +28,4 @@ libvshadow-python >= 20160109
 libvslvm-python >= 20210807
 pytsk3 >= 20210419
 pyxattr >= 0.7.2
+pyOpenSSL<=21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ proto-plus<1.19.7
 psq
 pyparsing<3
 pyyaml>=5.4.1
+pyOpenSSL<=21.0.0
 redis
 six>=1.15.0
 urllib3[secure]


### PR DESCRIPTION
pyOpenSSL recently updated to require `cryptography>=35` which also requires a Rust compiler to build.  https://www.pyopenssl.org/en/stable/changelog.html#id1

Pinning requirement to keep the dev environment green for now and prior to the next release we can revisit all of our pinned dependencies.