### PR TITLE
Logging fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-auth<2.0.0.dev0
 google-cloud-core<2.0dev
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
-google-cloud-logging>=2.0.0
+google-cloud-logging>=2.0.0,<3.0.0
 google-cloud-pubsub==1.7.0
 google-cloud-storage
 pycryptodomex

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-auth<2.0.0.dev0
 google-cloud-core<2.0dev
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
-google-cloud-logging>=2.0.0,<3.0.0
+google-cloud-logging>=2.0.0,>3.0.0
 google-cloud-pubsub==1.7.0
 google-cloud-storage
 pycryptodomex

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ google-auth<2.0.0.dev0
 google-cloud-core<2.0dev
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
-google-cloud-logging>=2.0.0,>3.0.0
+google-cloud-logging>=2.0.0,<3.0.0dev
 google-cloud-pubsub==1.7.0
 google-cloud-storage
 pycryptodomex


### PR DESCRIPTION
Fixes a new dependency conflict with error reporting per 
```
error: google-cloud-logging 3.0.0 is installed but google-cloud-logging<3.0.0dev,>=1.14.0 is required by {'google-cloud-error-reporting'}
```