### PR TITLE
Clear partition path specs before evidence serialization

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -238,6 +238,9 @@ class Evidence:
 
   def serialize(self):
     """Return JSON serializable object."""
+    # Clear any partition path_specs before serializing
+    if hasattr(self, 'path_spec'):
+      self.path_spec = None
     serialized_evidence = self.__dict__.copy()
     if self.parent_evidence:
       serialized_evidence['parent_evidence'] = self.parent_evidence.serialize()


### PR DESCRIPTION
Partition evidence was causing evidence serialization errors due to the path_spec attribute.

Clearing the path_spec before serialization since the path_spec is not required outside of the worker.