### PR TITLE
Properly handle case when a file entry cannot be read by dfVFS

### DIFF
--- a/turbinia/workers/file_system_timeline.py
+++ b/turbinia/workers/file_system_timeline.py
@@ -75,31 +75,29 @@ class FileSystemTimelineTask(TurbiniaTask):
     try:
       bodyfile_fileobj = open(bodyfile_output, 'w', encoding='utf-8')
     except IOError as exception:
-      status = 'Unable to create bodyfile local output file: {0!s}'.format(
-          exception)
+      status = 'Failed to open local output file: {0!s}'.format(exception)
       result.close(self, success=False, status=status)
       return result
 
-    if bodyfile_fileobj:
-      file_entries = enumerate(entry_lister.ListFileEntries(base_path_specs))
-      while file_entries:
-        try:
-          _, (file_entry, path_segments) = next(file_entries)
-          bodyfile_entries = entry_lister.GetBodyfileEntries(
-              file_entry, path_segments)
-          for bodyfile_entry in bodyfile_entries:
-            bodyfile_fileobj.write(bodyfile_entry)
-            bodyfile_fileobj.write('\n')
-            number_of_entries += 1
-        except StopIteration:
-          break
-        except (dfvfs_errors.AccessError, dfvfs_errors.BackEndError,
-                dfvfs_errors.MountPointError, dfvfs_errors.PathSpecError,
-                IOError) as exception:
-          status = 'Unable to process file entry: {0!s}'.format(exception)
-          result.log(status)
+    file_entries = enumerate(entry_lister.ListFileEntries(base_path_specs))
+    while file_entries:
+      try:
+        _, (file_entry, path_segments) = next(file_entries)
+        bodyfile_entries = entry_lister.GetBodyfileEntries(
+            file_entry, path_segments)
+        for bodyfile_entry in bodyfile_entries:
+          bodyfile_fileobj.write(bodyfile_entry)
+          bodyfile_fileobj.write('\n')
+          number_of_entries += 1
+      except StopIteration:
+        break
+      except (dfvfs_errors.AccessError, dfvfs_errors.BackEndError,
+              dfvfs_errors.MountPointError, dfvfs_errors.PathSpecError,
+              IOError) as exception:
+        status = 'Unable to process file entry: {0!s}'.format(exception)
+        result.log(status)
 
-      bodyfile_fileobj.close()
+    bodyfile_fileobj.close()
 
     if number_of_entries > 0:
       output_evidence.number_of_entries = number_of_entries

--- a/turbinia/workers/file_system_timeline.py
+++ b/turbinia/workers/file_system_timeline.py
@@ -68,6 +68,7 @@ class FileSystemTimelineTask(TurbiniaTask):
     except dfvfs_errors.ScannerError as exception:
       status = 'Unable to open evidence: {0!s}'.format(exception)
       result.close(self, success=False, status=status)
+      return result
 
     # Iterate over all file entries and generate the output in bodyfile
     # format.
@@ -77,6 +78,7 @@ class FileSystemTimelineTask(TurbiniaTask):
       status = 'Unable to create bodyfile local output file: {0!s}'.format(
           exception)
       result.close(self, success=False, status=status)
+      return result
 
     if bodyfile_fileobj:
       file_entries = enumerate(entry_lister.ListFileEntries(base_path_specs))

--- a/turbinia/workers/file_system_timeline.py
+++ b/turbinia/workers/file_system_timeline.py
@@ -72,39 +72,41 @@ class FileSystemTimelineTask(TurbiniaTask):
     # Iterate over all file entries and generate the output in bodyfile
     # format.
     try:
-      file_entries = None
-      with open(bodyfile_output, 'w', encoding='utf-8') as file_object:
-        file_entries = enumerate(entry_lister.ListFileEntries(base_path_specs))
-        while file_entries:
-          try:
-            _, (file_entry, path_segments) = next(file_entries)
-            bodyfile_entries = entry_lister.GetBodyfileEntries(
-                file_entry, path_segments)
-            for bodyfile_entry in bodyfile_entries:
-              file_object.write(bodyfile_entry)
-              file_object.write('\n')
-              number_of_entries += 1
-          except StopIteration:
-            break
-          except (dfvfs_errors.AccessError, dfvfs_errors.BackEndError,
-                  dfvfs_errors.MountPointError,
-                  dfvfs_errors.PathSpecError) as exception:
-            status = 'Unable to process file entry: {0!s}'.format(exception)
-            result.log(status)
-
-      if number_of_entries > 0:
-        output_evidence.number_of_entries = number_of_entries
-        result.add_evidence(output_evidence, evidence.config)
-        status = 'Generated file system timeline containing [{0:d}] entries'.format(
-            number_of_entries)
-        result.close(self, success=True, status=status)
-      else:
-        status = 'Unable to process any file entries.'
-        result.close(self, success=False, status=status)
-
+      bodyfile_fileobj = open(bodyfile_output, 'w', encoding='utf-8')
     except IOError as exception:
       status = 'Unable to create bodyfile local output file: {0!s}'.format(
           exception)
+      result.close(self, success=False, status=status)
+
+    if bodyfile_fileobj:
+      file_entries = enumerate(entry_lister.ListFileEntries(base_path_specs))
+      while file_entries:
+        try:
+          _, (file_entry, path_segments) = next(file_entries)
+          bodyfile_entries = entry_lister.GetBodyfileEntries(
+              file_entry, path_segments)
+          for bodyfile_entry in bodyfile_entries:
+            bodyfile_fileobj.write(bodyfile_entry)
+            bodyfile_fileobj.write('\n')
+            number_of_entries += 1
+        except StopIteration:
+          break
+        except (dfvfs_errors.AccessError, dfvfs_errors.BackEndError,
+                dfvfs_errors.MountPointError, dfvfs_errors.PathSpecError,
+                IOError) as exception:
+          status = 'Unable to process file entry: {0!s}'.format(exception)
+          result.log(status)
+
+      bodyfile_fileobj.close()
+
+    if number_of_entries > 0:
+      output_evidence.number_of_entries = number_of_entries
+      result.add_evidence(output_evidence, evidence.config)
+      status = 'Generated file system timeline containing [{0:d}] entries'.format(
+          number_of_entries)
+      result.close(self, success=True, status=status)
+    else:
+      status = 'Unable to process any file entries.'
       result.close(self, success=False, status=status)
 
     return result


### PR DESCRIPTION
dfVFS raises IOError exceptions if a file system entry cannot be read. This was causing the task to fail and return as soon as the exception was caught. 

This pull request proposes a fix to ensure that the exceptions are properly handled to allow the task to continue to the next file entry if the previous file entry could not be read.

