### PR TITLE
fsstat: fix for evidence object with 'None' path_spec

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -578,13 +578,14 @@ class DiskPartition(RawDisk):
     partition_offset (int): Offset of the partition in bytes.
     partition_size (int): Size of the partition in bytes.
     path_spec (dfvfs.PathSpec): Partition path spec.
+    type_indicator (str): Partition type indicator from dfVFS.
   """
 
   POSSIBLE_STATES = [EvidenceState.ATTACHED, EvidenceState.MOUNTED]
 
   def __init__(
       self, partition_location=None, partition_offset=None, partition_size=None,
-      lv_uuid=None, path_spec=None, *args, **kwargs):
+      lv_uuid=None, path_spec=None, type_indicator=None, *args, **kwargs):
     """Initialization for raw volume evidence object."""
 
     self.partition_location = partition_location
@@ -592,6 +593,7 @@ class DiskPartition(RawDisk):
     self.partition_size = partition_size
     self.lv_uuid = lv_uuid
     self.path_spec = path_spec
+    self.type_indicator = type_indicator
     super(DiskPartition, self).__init__(*args, **kwargs)
 
     # This Evidence needs to have a parent
@@ -612,6 +614,7 @@ class DiskPartition(RawDisk):
         path_specs, self.partition_location)
     if path_spec:
       self.path_spec = path_spec
+      self.type_indicator = path_spec.type_indicator
 
     # In attaching a partition, we create a new loopback device using the
     # partition offset and size.

--- a/turbinia/workers/fsstat.py
+++ b/turbinia/workers/fsstat.py
@@ -45,7 +45,7 @@ class FsstatTask(TurbiniaTask):
 
     # Note: an evidence object that was serialized will not have a path_spec
     # because it is removed prior to JSON serialization in evidence.py:243
-    if hasattr(evidence, "path_spec"):
+    if hasattr(evidence.path_spec, "type_indicator"):
       if evidence.path_spec.type_indicator == "XFS":
         message = 'Not running fsstat since partition is XFS'
         result.log(message)

--- a/turbinia/workers/fsstat.py
+++ b/turbinia/workers/fsstat.py
@@ -44,18 +44,16 @@ class FsstatTask(TurbiniaTask):
 
     # Note: an evidence object that was serialized will not have a path_spec
     # because it is removed prior to JSON serialization in evidence.py:243
-    if hasattr(evidence.path_spec, "type_indicator"):
-      if evidence.path_spec.type_indicator == "XFS":
-        message = 'Not running fsstat since partition is XFS'
-        result.log(message)
-        result.close(self, success=True, status=message)
-        return result
-
-    output_evidence = ReportText(source_path=fsstat_output)
-    cmd = ['sudo', 'fsstat', evidence.device_path]
-    result.log('Running fsstat as [{0!s}]'.format(cmd))
-    self.execute(
-        cmd, result, stdout_file=fsstat_output, new_evidence=[output_evidence],
-        close=True)
+    if evidence.type_indicator == "XFS":
+      message = 'Not running fsstat since partition is XFS'
+      result.log(message)
+      result.close(self, success=True, status=message)
+    else:
+      output_evidence = ReportText(source_path=fsstat_output)
+      cmd = ['sudo', 'fsstat', evidence.device_path]
+      result.log('Running fsstat as [{0!s}]'.format(cmd))
+      self.execute(
+          cmd, result, stdout_file=fsstat_output,
+          new_evidence=[output_evidence], close=True)
 
     return result

--- a/turbinia/workers/fsstat.py
+++ b/turbinia/workers/fsstat.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals
 
 import os
 
-from turbinia import TurbiniaException
 from turbinia.workers import TurbiniaTask
 from turbinia.evidence import EvidenceState as state
 from turbinia.evidence import ReportText

--- a/turbinia/workers/fsstat_test.py
+++ b/turbinia/workers/fsstat_test.py
@@ -59,6 +59,18 @@ class FsstatTaskTest(TestTurbiniaTaskBase):
     # Ensure run method returns a TurbiniaTaskResult instance.
     self.assertIsInstance(result, TurbiniaTaskResult)
 
+  @mock.patch('turbinia.evidence.DiskPartition')
+  def testFsstatRunNoPathSpec(self, mock_evidence):
+    """Test fssstat task on an evidence object with no path_spec."""
+    self.task.execute = mock.MagicMock(return_value=0)
+    mock_evidence.path_spec = None
+    result = self.task.run(mock_evidence, self.result)
+
+    # Ensure execute method is not being called.
+    self.task.execute.assert_called_once()
+    # Ensure run method returns a TurbiniaTaskResult instance.
+    self.assertIsInstance(result, TurbiniaTaskResult)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/turbinia/workers/fsstat_test.py
+++ b/turbinia/workers/fsstat_test.py
@@ -39,7 +39,7 @@ class FsstatTaskTest(TestTurbiniaTaskBase):
   def testFsstatRun(self, mock_evidence):
     """Test fsstat task run."""
     self.task.execute = mock.MagicMock(return_value=0)
-    mock_evidence.path_spec.type_indicator = 'EXT'
+    mock_evidence.type_indicator = 'EXT'
     result = self.task.run(mock_evidence, self.result)
 
     # Ensure execute method is being called.
@@ -49,7 +49,7 @@ class FsstatTaskTest(TestTurbiniaTaskBase):
 
     # Test for XFS
     self.task.execute.reset_mock()
-    mock_evidence.path_spec.type_indicator = 'XFS'
+    mock_evidence.type_indicator = 'XFS'
     result = self.task.run(mock_evidence, self.result)
 
     # Ensure execute method is not being called.

--- a/turbinia/workers/fsstat_test.py
+++ b/turbinia/workers/fsstat_test.py
@@ -16,9 +16,7 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
-import textwrap
 import mock
 
 from turbinia.evidence import ReportText

--- a/turbinia/workers/partitions.py
+++ b/turbinia/workers/partitions.py
@@ -60,6 +60,7 @@ class PartitionEnumerationTask(TurbiniaTask):
     partition_offset = None
     partition_size = None
     lv_uuid = None
+    type_indicator = None
 
     # File system location / identifier
     is_lvm = False
@@ -126,7 +127,8 @@ class PartitionEnumerationTask(TurbiniaTask):
     # Not setting path_spec here as it will need to be generated for each task
     partition_evidence = DiskPartition(
         partition_location=fs_location, partition_offset=partition_offset,
-        partition_size=partition_size, lv_uuid=lv_uuid)
+        partition_size=partition_size, lv_uuid=lv_uuid,
+        type_indicator=type_indicator)
 
     return partition_evidence, status_report
 


### PR DESCRIPTION
Fixes #1006 