### PR TITLE
Truncate large report text data

### DIFF
--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -685,8 +685,7 @@ class CeleryTaskManager(BaseTaskManager):
         if timeout:
           log.warning(
               'Task {0:s} timed out on server after {1:d} seconds. '
-              'Auto-closing Task.'
-              .format(celery_task.id, timeout))
+              'Auto-closing Task.'.format(celery_task.id, timeout))
           task = self.timeout_task(task, timeout)
           completed_tasks.append(task)
 

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -684,7 +684,8 @@ class CeleryTaskManager(BaseTaskManager):
         timeout = self.check_task_timeout(task)
         if timeout:
           log.warning(
-              'Task {0:s} timed on server out after {1:d} seconds. Auto-closing Task.'
+              'Task {0:s} timed out on server after {1:d} seconds. '
+              'Auto-closing Task.'
               .format(celery_task.id, timeout))
           task = self.timeout_task(task, timeout)
           completed_tasks.append(task)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -55,7 +55,7 @@ METRICS = {}
 # datastore entities[1] less some overhead for the rest of the attributes that
 # will be saved in the response.
 # [1]https://cloud.google.com/datastore/docs/concepts/limits
-REPORT_MAXSIZE = 1048572 * 0.75
+REPORT_MAXSIZE = int(1048572 * 0.75)
 
 log = logging.getLogger('turbinia')
 
@@ -235,7 +235,7 @@ class TurbiniaTaskResult:
             'size {1:d} so truncating the response.'.format(
                 len(evidence.text_data), REPORT_MAXSIZE))
         self.log(message, logging.WARN)
-        evidence.text_data = evidence.text_data[0:REPORT_MAXSIZE] + '\n'
+        evidence.text_data = evidence.text_data[:REPORT_MAXSIZE] + '\n'
         evidence.text_data += message
 
       if not evidence.request_id:

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -228,7 +228,7 @@ class TurbiniaTaskResult:
 
       # Truncate report text data if it is approaching the size of the max
       # datastore entity size (See REPORT_MAXSIZE definition for details).
-      if (hasattr(evidence, 'text_data') and
+      if (hasattr(evidence, 'text_data') and evidence.text_data and
           len(evidence.text_data) > REPORT_MAXSIZE):
         message = (
             'The text_data attribute has a size {0:d} larger than the max '

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -125,6 +125,16 @@ class TestTurbiniaTaskBase(unittest.TestCase):
 class TestTurbiniaTask(TestTurbiniaTaskBase):
   """Test TurbiniaTask class."""
 
+  def testTurbiniaTaskCloseTruncate(self):
+    """Tests that the close method will truncate large report output."""
+    evidence_ = evidence.ReportText()
+    max_size = 10 ** 20
+    evidence_.text_data = 'A' * max_size
+    self.result.add_evidence(evidence_)
+    self.result.close(self.task, success=True)
+    self.assertIn(evidence_, 'truncating')
+    self.assert(len(evidence_.text_data) <= (max_size * 0.8))
+
   def testTurbiniaTaskSerialize(self):
     """Test that we can properly serialize/deserialize tasks."""
     out_dict = self.plaso_task.serialize()

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -134,7 +134,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.result.close(self.task, success=True)
     self.remove_files.append(
         os.path.join(self.task.base_output_dir, 'worker-log.txt'))
-    self.assertIn('truncating', evidence_.text_data)
+    self.assertIn('truncating', evidence_.text_data[-100:])
     self.assertTrue(len(evidence_.text_data) <= (max_size * 0.8))
 
   def testTurbiniaTaskSerialize(self):

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -127,8 +127,8 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
   def testTurbiniaTaskCloseTruncate(self):
     """Tests that the close method will truncate large report output."""
-    evidence_ = evidence.ReportText()
-    max_size = 10 ** 20
+    evidence_ = evidence.ReportText(source_path='/no/path')
+    max_size = 10**20
     evidence_.text_data = 'A' * max_size
     self.result.add_evidence(evidence_)
     self.result.close(self.task, success=True)
@@ -277,7 +277,6 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     # Command was executed, has the correct output saved and
     # TurbiniaTaskResult.close() was called with successful status.
     popen_mock.assert_called_with(cmd, stdout=-1, stderr=-1, cwd=None, env=None)
-    self.assertEqual(self.result.error['stdout'], str(output[0]))
     self.assertEqual(self.result.error['stderr'], str(output[1]))
     self.assertEqual(stdout_data, output[0])
     self.result.close.assert_called_with(self.task, success=True)

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -134,7 +134,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.result.close(self.task, success=True)
     self.remove_files.append(
         os.path.join(self.task.base_output_dir, 'worker-log.txt'))
-    self.assertIn(evidence_.text_data, 'truncating')
+    self.assertIn('truncating', evidence_.text_data)
     self.assertTrue(len(evidence_.text_data) <= (max_size * 0.8))
 
   def testTurbiniaTaskSerialize(self):

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -133,7 +133,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.result.add_evidence(evidence_)
     self.result.close(self.task, success=True)
     self.assertIn(evidence_, 'truncating')
-    self.assert(len(evidence_.text_data) <= (max_size * 0.8))
+    self.assertTrue(len(evidence_.text_data) <= (max_size * 0.8))
 
   def testTurbiniaTaskSerialize(self):
     """Test that we can properly serialize/deserialize tasks."""

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -132,7 +132,9 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     evidence_.text_data = 'A' * max_size
     self.result.add_evidence(evidence_, self.task._evidence_config)
     self.result.close(self.task, success=True)
-    self.assertIn(evidence_, 'truncating')
+    self.remove_files.append(
+        os.path.join(self.task.base_output_dir, 'worker-log.txt'))
+    self.assertIn(evidence_.text_data, 'truncating')
     self.assertTrue(len(evidence_.text_data) <= (max_size * 0.8))
 
   def testTurbiniaTaskSerialize(self):

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -128,7 +128,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskCloseTruncate(self):
     """Tests that the close method will truncate large report output."""
     evidence_ = evidence.ReportText(source_path='/no/path')
-    max_size = 10**20
+    max_size = 2**20
     evidence_.text_data = 'A' * max_size
     self.result.add_evidence(evidence_)
     self.result.close(self.task, success=True)

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -130,8 +130,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     evidence_ = evidence.ReportText(source_path='/no/path')
     max_size = 2**20
     evidence_.text_data = 'A' * max_size
-    self.result.add_evidence(evidence_)
-    self.result.close(self.task, success=True)
+    self.result.close(self.task, success=True, new_evidence=[evidence_])
     self.assertIn(evidence_, 'truncating')
     self.assertTrue(len(evidence_.text_data) <= (max_size * 0.8))
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -130,7 +130,8 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     evidence_ = evidence.ReportText(source_path='/no/path')
     max_size = 2**20
     evidence_.text_data = 'A' * max_size
-    self.result.close(self.task, success=True, new_evidence=[evidence_])
+    self.result.add_evidence(evidence_, self.task._evidence_config)
+    self.result.close(self.task, success=True)
     self.assertIn(evidence_, 'truncating')
     self.assertTrue(len(evidence_.text_data) <= (max_size * 0.8))
 


### PR DESCRIPTION
Sets the maximum size that the report can be before truncating it.  This is a best effort estimate and not a guarantee and comes from the limit for datastore entities[1] less some overhead for the rest of the attributes that will be saved in the response.

This also removes the stdout from the response object because this can also cause the size to grow too large and it is saved as a file anyway if we need it.

Fixes #1009