### PR TITLE
Allow yara rules for existing recipes and remove PsortJob

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -207,8 +207,6 @@ class BaseTurbiniaClient:
         recipe['globals']['jobs_denylist'] = jobs_denylist
       if jobs_allowlist:
         recipe['globals']['jobs_allowlist'] = jobs_allowlist
-      if yara_rules:
-        recipe['globals']['yara_rules'] = yara_rules
     else:
       # Load custom recipe from given path or name.
       if (jobs_denylist or jobs_allowlist or filter_patterns or yara_rules):
@@ -240,6 +238,8 @@ class BaseTurbiniaClient:
       recipe['globals']['debug_tasks'] = debug_tasks
     if group_id:
       recipe['globals']['group_id'] = group_id
+    if yara_rules:
+      recipe['globals']['yara_rules'] = yara_rules
 
     return recipe
 

--- a/turbinia/config/recipes/triage-linux.yaml
+++ b/turbinia/config/recipes/triage-linux.yaml
@@ -5,7 +5,6 @@ globals:
     - CronExtractionJob
     - CronAnalysisJob
     - PlasoJob
-    - PsortJob
     - FileSystemTimelineJob
 
 plaso_base:

--- a/turbinia/config/recipes/triage-macos.yml
+++ b/turbinia/config/recipes/triage-macos.yml
@@ -4,7 +4,6 @@ globals:
   jobs_allowlist:
     - FileSystemTimelineJob
     - PlasoJob
-    - PsortJob
 
 plaso_base:
   task: 'PlasoTask'

--- a/turbinia/config/recipes/triage-windows.yaml
+++ b/turbinia/config/recipes/triage-windows.yaml
@@ -4,7 +4,6 @@ globals:
   jobs_allowlist:
     - FileSystemTimelineJob
     - PlasoJob
-    - PsortJob
 
 plaso_base:
   task: 'PlasoTask'

--- a/turbinia/config/recipes/triage.yaml
+++ b/turbinia/config/recipes/triage.yaml
@@ -4,4 +4,3 @@ globals:
   jobs_allowlist: 
     - FileSystemTimelineJob
     - PlasoJob
-    - PsortJob


### PR DESCRIPTION
This PR removes PsortJob from the triage recipes and allows the Turbinia client to specify yara rules when loading an existing recipe file.

The reason to remove PosrtJob from the recipes is because other tools like Timesketch can read plaso format files directly so running psort is a bit redundant.