### PR TITLE
Reference Task instead of Task stub

### DIFF
--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -804,7 +804,7 @@ class PSQTaskManager(BaseTaskManager):
         if timeout:
           log.warning(
               'Task {0:s} timed on server out after {0:d} seconds. Auto-closing Task.'
-              .format(psq_task.id, timeout))
+              .format(task.id, timeout))
           task = self.timeout_task(task, timeout)
           completed_tasks.append(task)
 


### PR DESCRIPTION
The Task stub doesn't seem to get set before the Task is actually returned from the worker but we can still grab the relevant data from the task object itself.

Fixes #1025