### PR TITLE
Pin google-cloud-storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
 google-cloud-logging>=2.0.0,<3.0.0dev
 google-cloud-pubsub==1.7.0
-google-cloud-storage
+google-cloud-storage<=2.2.1
 pycryptodomex
 prometheus_client
 libcloudforensics


### PR DESCRIPTION
Fixes #1040 

Pinning because google-cloud-storage was updated to require an incompatible google-cloud-core here:
https://github.com/googleapis/python-storage/pull/741/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7

