### PR TITLE
Add container mount state requirement to file extractions

### DIFF
--- a/turbinia/workers/artifact.py
+++ b/turbinia/workers/artifact.py
@@ -27,7 +27,7 @@ from turbinia.workers import TurbiniaTask
 class FileArtifactExtractionTask(TurbiniaTask):
   """Task to run image_export (log2timeline)."""
 
-  REQUIRED_STATES = [state.ATTACHED]
+  REQUIRED_STATES = [state.ATTACHED, state.CONTAINER_MOUNTED]
 
   def __init__(self, artifact_name='FileArtifact'):
     super(FileArtifactExtractionTask, self).__init__()


### PR DESCRIPTION
Otherwise these Tasks won't be able to run on the mounted container and will get errors about `local_path` not being set.

Fixes #1037 