### PR TITLE
Missing sys module import in logger.py

### DIFF
--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -20,6 +20,7 @@ import logging
 import warnings
 import logging.handlers
 import os
+import sys
 
 from turbinia import config
 from turbinia import TurbiniaException


### PR DESCRIPTION
Add missing import in logger module

https://github.com/google/turbinia/blob/16c5862641f79ce3cf53a32d925d36cebc76ef98/turbinia/config/logger.py#L69

Fixes #1071 