### PR TITLE
Change default logger to stdout from stderr

### DIFF
--- a/turbinia/config/logger.py
+++ b/turbinia/config/logger.py
@@ -82,7 +82,7 @@ def setup(need_file_handler=True, need_stream_handler=True, log_file_path=None):
     file_handler.setLevel(logging.DEBUG)
     logger.addHandler(file_handler)
 
-  console_handler = logging.StreamHandler()
+  console_handler = logging.StreamHandler(sys.stdout)
   formatter = logging.Formatter(
       '%(asctime)s [%(levelname)s] %(message)s', "%Y-%m-%d %H:%M:%S")
   console_handler.setFormatter(formatter)


### PR DESCRIPTION
What it says on the tin: The default stream logger goes to stderr, swapping to stdout.