### PR TITLE
Fixes for k8s scripts

### DIFF
--- a/k8s/gcp-pubsub/turbinia-server.yaml
+++ b/k8s/gcp-pubsub/turbinia-server.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: turbinia-server
     spec:
+      serviceAccountName: <SA_NAME>
       initContainers:
         - name: init-filestore
           image: busybox:1.28

--- a/k8s/gcp-pubsub/turbinia-worker.yaml
+++ b/k8s/gcp-pubsub/turbinia-worker.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: turbinia-worker
     spec:
+      serviceAccountName: <SA_NAME>
       # The grace period needs to be set to the largest task timeout as
       # set in the turbinia configuration file.
       terminationGracePeriodSeconds: 86400

--- a/k8s/tools/.clusterconfig
+++ b/k8s/tools/.clusterconfig
@@ -18,6 +18,7 @@ DEPLOYMENT_FOLDER="deployment/$INSTANCE_ID"
 # not currently support multi-zone operation.
 ZONE='us-central1-f'
 REGION='us-central1'
+DATASTORE_REGION='us-central'
 
 # VPC network to configure the cluster in.
 VPC_NETWORK='default'

--- a/k8s/tools/cleanup-pubsub-gke.sh
+++ b/k8s/tools/cleanup-pubsub-gke.sh
@@ -101,8 +101,12 @@ if [[ "$*" != *--no-filestore* ]] ; then
   gcloud -q --project $DEVSHELL_PROJECT_ID filestore instances delete $FILESTORE_NAME --zone $ZONE
 fi
 if [[ "$*" != *--no-dfdewey* ]] ; then
-  echo "Deleting Filestore instance $FILESTORE_DFDEWEY_NAME"
-  gcloud -q --project $DEVSHELL_PROJECT_ID filestore instances delete $FILESTORE_DFDEWEY_NAME --zone $ZONE
+  if [[ -z "$(gcloud -q --project $DEVSHELL_PROJECT_ID filestore instances list --format='value(name)' --filter=name:$FILESTORE_DFDEWEY_NAME)" ]] ; then
+    echo "Filestore instance $FILESTORE_DFDEWEY_NAME does not exist"
+  else
+    echo "Deleting Filestore instance $FILESTORE_DFDEWEY_NAME"
+    gcloud -q --project $DEVSHELL_PROJECT_ID filestore instances delete $FILESTORE_DFDEWEY_NAME --zone $ZONE
+  fi
 fi
 
 # Remove cloud functions

--- a/k8s/tools/cleanup-pubsub-gke.sh
+++ b/k8s/tools/cleanup-pubsub-gke.sh
@@ -100,6 +100,7 @@ if [[ "$*" != *--no-filestore* ]] ; then
   echo "Deleting Filestore instance $FILESTORE_NAME"
   gcloud -q --project $DEVSHELL_PROJECT_ID filestore instances delete $FILESTORE_NAME --zone $ZONE
 fi
+# Delete the dfDewey Filestore instance
 if [[ "$*" != *--no-dfdewey* ]] ; then
   if [[ -z "$(gcloud -q --project $DEVSHELL_PROJECT_ID filestore instances list --format='value(name)' --filter=name:$FILESTORE_DFDEWEY_NAME)" ]] ; then
     echo "Filestore instance $FILESTORE_DFDEWEY_NAME does not exist"

--- a/k8s/tools/deploy-pubsub-gke.sh
+++ b/k8s/tools/deploy-pubsub-gke.sh
@@ -159,16 +159,15 @@ if [[ "$*" != *--no-cloudfunctions* ]] ; then
   done
 fi
 
-# Enable App Engine
-if [[ "$*" != *--no-appengine* ]] ; then
-  echo "Enabling App Engine"
-  gcloud -q --project $DEVSHELL_PROJECT_ID app create --region=$DATASTORE_REGION
-fi
-
 # Deploy Datastore indexes
 if [[ "$*" != *--no-datastore* ]] ; then
   echo "Enabling Datastore API and deploying datastore index"
   gcloud -q --project $DEVSHELL_PROJECT_ID services enable datastore.googleapis.com
+  # Enable App Engine
+  if [[ "$*" != *--no-appengine* ]] ; then
+    echo "Enabling App Engine"
+    gcloud -q --project $DEVSHELL_PROJECT_ID app create --region=$DATASTORE_REGION
+  fi
   gcloud -q --project $DEVSHELL_PROJECT_ID datastore databases create --region=$DATASTORE_REGION
   gcloud -q --project $DEVSHELL_PROJECT_ID datastore indexes create ../tools/gcf_init/index.yaml
 fi

--- a/k8s/tools/deploy-pubsub-gke.sh
+++ b/k8s/tools/deploy-pubsub-gke.sh
@@ -22,7 +22,7 @@ if [[ "$*" == *--help ]] ; then
   echo "Options:"
   echo "--build-dev                    Deploy Turbinia development docker image"
   echo "--build-experimental           Deploy Turbinia experimental docker image"
-  echo "--no-gcloud-auth               Create service key instead of using gcloud authentication"
+  echo "--no-gcloud-auth               Use Turbinia service account instead of gcloud authentication"
   echo "--no-cloudfunctions            Do not deploy Turbinia Cloud Functions"
   echo "--no-appengine                 Do not enable App Engine"
   echo "--no-datastore                 Do not configure Turbinia Datastore"

--- a/k8s/tools/deploy-pubsub-gke.sh
+++ b/k8s/tools/deploy-pubsub-gke.sh
@@ -77,7 +77,7 @@ gcloud -q --project $DEVSHELL_PROJECT_ID services enable iam.googleapis.com
 SA_NAME="turbinia"
 SA_MEMBER="serviceAccount:$SA_NAME@$DEVSHELL_PROJECT_ID.iam.gserviceaccount.com"
 
-if ! gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts list |grep $SA_NAME; then
+if [[ -z "$(gcloud -q --project $DEVSHELL_PROJECT_ID iam service-accounts list --format='value(name)' --filter=name:/$SA_NAME@)" ]] ; then
   # Create service account
   gcloud --project $DEVSHELL_PROJECT_ID iam service-accounts create "${SA_NAME}" --display-name "${SA_NAME}"
 fi


### PR DESCRIPTION
* Check whether dfDewey is deployed before trying to remove the Filestore
* Replace `--build-release-test` flag with `--build-experimental`
* Compute API is required to check VPC networks
* App Engine is required to create Datastore database
* Add Kubernetes service account and assign permissions used Workload Identity
  * Kubernetes will now use this service account rather than the default compute service acccount