### PR TITLE
Add evidence name to task output

### DIFF
--- a/turbinia/client.py
+++ b/turbinia/client.py
@@ -474,6 +474,9 @@ class BaseTurbiniaClient:
     status = task.get('status') or 'No task status'
 
     report.append(fmt.heading2(task.get('name')))
+    line = '{0:s} {1:s}'.format(
+        fmt.bold('Evidence:'), task.get('evidence_name'))
+    report.append(fmt.bullet(line))
     line = '{0:s} {1:s}'.format(fmt.bold('Status:'), status)
     report.append(fmt.bullet(line))
     report.append(fmt.bullet('Task Id: {0!s}'.format(task.get('id'))))
@@ -525,7 +528,10 @@ class BaseTurbiniaClient:
     report = []
     saved_paths = task.get('saved_paths') or []
     status = task.get('status') or 'No task status'
-    report.append(fmt.bullet('{0:s}: {1:s}'.format(task.get('name'), status)))
+    report.append(
+        fmt.bullet(
+            '{0:s} ({1:s}): {2:s}'.format(
+                task.get('name'), task.get('evidence_name'), status)))
     if show_files:
       for path in saved_paths:
         report.append(fmt.bullet(fmt.code(path), level=2))

--- a/turbinia/client_test.py
+++ b/turbinia/client_test.py
@@ -37,13 +37,13 @@ SHORT_REPORT = textwrap.dedent(
     * Processed 3 Tasks for user myuser
 
     # High Priority Tasks
-    * TaskName2: This second fake task executed
+    * TaskName2 (EvidenceName2): This second fake task executed
 
     # Successful Tasks
-    * TaskName: This fake task executed
+    * TaskName (EvidenceName): This fake task executed
 
     # Failed Tasks
-    * TaskName3: Third Task Failed...
+    * TaskName3 (EvidenceName3): Third Task Failed...
 
     # Scheduled or Running Tasks
     * None
@@ -56,6 +56,7 @@ LONG_REPORT = textwrap.dedent(
 
     # High Priority Tasks
     ## TaskName2
+    * **Evidence:** EvidenceName2
     * **Status:** This second fake task executed
     * Task Id: 0xfakeTaskId2
     * Executed on worker fake_worker2
@@ -65,10 +66,10 @@ LONG_REPORT = textwrap.dedent(
     * Fake Bullet
 
     # Successful Tasks
-    * TaskName: This fake task executed
+    * TaskName (EvidenceName): This fake task executed
 
     # Failed Tasks
-    * TaskName3: Third Task Failed...
+    * TaskName3 (EvidenceName3): Third Task Failed...
 
     # Scheduled or Running Tasks
     * None
@@ -81,6 +82,7 @@ LONG_REPORT_FILES = textwrap.dedent(
 
     # High Priority Tasks
     ## TaskName2
+    * **Evidence:** EvidenceName2
     * **Status:** This second fake task executed
     * Task Id: 0xfakeTaskId2
     * Executed on worker fake_worker2
@@ -95,13 +97,13 @@ LONG_REPORT_FILES = textwrap.dedent(
 
 
     # Successful Tasks
-    * TaskName: This fake task executed
+    * TaskName (EvidenceName): This fake task executed
         * `/no/path/`
         * `/fake/path`
 
 
     # Failed Tasks
-    * TaskName3: Third Task Failed...
+    * TaskName3 (EvidenceName3): Third Task Failed...
         * `/no/path/3`
         * `/fake/path/3`
 
@@ -225,6 +227,7 @@ class TestTurbiniaClient(unittest.TestCase):
             'instance': 'MyTurbiniaInstance',
             'last_update': last_update,
             'name': 'TaskName',
+            'evidence_name': 'EvidenceName',
             'report_data': '#### Fake Low priority Report\n* Fake Bullet',
             'report_priority': 80,
             'request_id': '0xFakeRequestId',
@@ -239,6 +242,7 @@ class TestTurbiniaClient(unittest.TestCase):
             'instance': 'MyTurbiniaInstance',
             'last_update': last_update + timedelta(minutes=20),
             'name': 'TaskName2',
+            'evidence_name': 'EvidenceName2',
             'report_data': '#### Fake High priority Report\n* Fake Bullet',
             'report_priority': 10,
             'request_id': '0xFakeRequestId',
@@ -253,6 +257,7 @@ class TestTurbiniaClient(unittest.TestCase):
             'instance': 'MyTurbiniaInstance',
             'last_update': last_update,
             'name': 'TaskName3',
+            'evidence_name': 'EvidenceName3',
             'report_data': '',
             'report_priority': 80,
             'request_id': '0xFakeRequestId2',

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -407,6 +407,7 @@ class BaseTaskManager:
       return
 
     evidence_.config = job.evidence.config
+    task.evidence_name = evidence_.name
     task.base_output_dir = config.OUTPUT_DIR
     task.requester = evidence_.config.get('globals', {}).get('requester')
     task.group_name = evidence_.config.get('globals', {}).get('group_name')

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -441,8 +441,8 @@ class TurbiniaTask:
 
   # The list of attributes that we will persist into storage
   STORED_ATTRIBUTES = [
-      'id', 'job_id', 'last_update', 'name', 'request_id', 'requester',
-      'group_name', 'reason', 'all_args', 'group_id'
+      'id', 'job_id', 'last_update', 'name', 'evidence_name', 'request_id',
+      'requester', 'group_name', 'reason', 'all_args', 'group_id'
   ]
 
   # The list of evidence states that are required by a Task in order to run.
@@ -475,6 +475,7 @@ class TurbiniaTask:
     self.job_name = None
     self.last_update = datetime.now()
     self.name = name if name else self.__class__.__name__
+    self.evidence_name = None
     self.output_dir = None
     self.output_manager = output_manager.OutputManager()
     self.result = None


### PR DESCRIPTION
Fixes: #1078 

Added task evidence name to Datastore to be queried at output time.

Example output:

```
# Turbinia report ee1ef4df8a5f469c8f83007ec177aa8a
* Processed 64 Tasks for user dfjxs

# High Priority Tasks
* LokiAnalysisTask (evidence-test-cloud-disk:/p1): Loki analysis found 11 alert(s)
    * `/var/tmp/ee1ef4df8a5f469c8f83007ec177aa8a/1657170977-f31f93a869304255bf30dea47251d383-LokiAnalysisTask/loki.log`
[...]
```