### PR TITLE
Disambiguate Manual/Quick GKE install docs

### DIFF
--- a/docs/user/install-gke-manual.md
+++ b/docs/user/install-gke-manual.md
@@ -1,8 +1,10 @@
-# Turbinia GKE Installation Instructions
+# Turbinia GKE Manual Installation Instructions
 
 ## **Introduction**
 
-Turbinia can be run within Google Kubernetes Engine (https://cloud.google.com/kubernetes-engine). This allows Turbinia Workers to scale based on processing demand. Currently, this is done through scaling on CPU utilization, which is determined when available Turbinia Workers process Tasks and reach a pre-defined CPU threshold. The GKE architecture closely resembles the [cloud architecture](how-it-works.md) with GKE being used to scale Turbinia Woker pods.
+These instructions cover how to manually install Turbinia using [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).  It is recommended to use the [Turbinia GKE Quick Installation Instructions](install-gke.html) for an easier and more automated deployment.
+
+Installing Turbinia in GKE allows Turbinia Workers to scale based on processing demand. Currently, this is done through scaling on CPU utilization, which is determined when available Turbinia Workers process Tasks and reach a pre-defined CPU threshold. The GKE architecture closely resembles the [cloud architecture](how-it-works.md) with GKE being used to scale Turbinia Woker pods.
 
 All steps in this document are required for getting Turbinia running on GKE. Please ensure you have followed the GCP setup prior to configuring the GKE cluster as it's required for Turbinia components to properly function together.
 


### PR DESCRIPTION
The headers were previously the same so you couldn't tell the difference in the doc index.