### PR TITLE
Unique names per Yara task

### DIFF
--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -74,8 +74,8 @@ class YaraAnalysisTask(TurbiniaTask):
     return result
 
   def runFraken(self, result, evidence):
-    stdout_file = os.path.join(self.output_dir, 'fraken_stdout.log')
-    stderr_file = os.path.join(self.output_dir, 'fraken_stderr.log')
+    stdout_file = os.path.join(self.output_dir, '{0:s}_fraken_stdout.log'.format(self.id))
+    stderr_file = os.path.join(self.output_dir, '{0:s}_fraken_stderr.log'.format(self.id))
 
     cmd = [
         'sudo', '/opt/fraken/fraken', '-rules', '/opt/signature-base/',

--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -74,8 +74,10 @@ class YaraAnalysisTask(TurbiniaTask):
     return result
 
   def runFraken(self, result, evidence):
-    stdout_file = os.path.join(self.output_dir, '{0:s}_fraken_stdout.log'.format(self.id))
-    stderr_file = os.path.join(self.output_dir, '{0:s}_fraken_stderr.log'.format(self.id))
+    stdout_file = os.path.join(
+        self.output_dir, '{0:s}_fraken_stdout.log'.format(self.id))
+    stderr_file = os.path.join(
+        self.output_dir, '{0:s}_fraken_stderr.log'.format(self.id))
 
     cmd = [
         'sudo', '/opt/fraken/fraken', '-rules', '/opt/signature-base/',

--- a/turbinia/workers/analysis/yara_test.py
+++ b/turbinia/workers/analysis/yara_test.py
@@ -41,8 +41,12 @@ class YaraAnalysisTaskTest(TestTurbiniaTaskBase):
     self.task.tmp_dir = tempfile.gettempdir()
     self.task.output_dir = self.task.base_output_dir
     self.remove_files.extend([
-        os.path.join(self.task.output_dir, '{0:s}_fraken_stdout.log'.format(self.task.id)),
-        os.path.join(self.task.output_dir, '{0:s}_fraken_stderr.log'.format(self.task.id)),
+        os.path.join(
+            self.task.output_dir, '{0:s}_fraken_stdout.log'.format(
+                self.task.id)),
+        os.path.join(
+            self.task.output_dir, '{0:s}_fraken_stderr.log'.format(
+                self.task.id)),
     ])
 
   def test_yara(self):

--- a/turbinia/workers/analysis/yara_test.py
+++ b/turbinia/workers/analysis/yara_test.py
@@ -41,8 +41,8 @@ class YaraAnalysisTaskTest(TestTurbiniaTaskBase):
     self.task.tmp_dir = tempfile.gettempdir()
     self.task.output_dir = self.task.base_output_dir
     self.remove_files.extend([
-        os.path.join(self.task.output_dir, 'fraken_stdout.log'),
-        os.path.join(self.task.output_dir, 'fraken_stderr.log'),
+        os.path.join(self.task.output_dir, '{0:s}_fraken_stdout.log'.format(self.task.id)),
+        os.path.join(self.task.output_dir, '{0:s}_fraken_stderr.log'.format(self.task.id)),
     ])
 
   def test_yara(self):


### PR DESCRIPTION
Prepend the task_id to output files, since subsequent ones get clobbered by dftimewolf when pulling them down from GCS