### PR TITLE
Different extensions for output_format

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -826,13 +826,13 @@ class PlasoFile(Evidence):
     self.save_metadata = True
 
 
-class PlasoCsvFile(Evidence):
+class PlasoFile(Evidence):
   """Psort output file evidence.  """
 
   def __init__(self, plaso_version=None, *args, **kwargs):
     """Initialization for Plaso File evidence."""
     self.plaso_version = plaso_version
-    super(PlasoCsvFile, self).__init__(copyable=True, *args, **kwargs)
+    super(PlasoFile, self).__init__(copyable=True, *args, **kwargs)
     self.save_metadata = False
 
 

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -826,13 +826,13 @@ class PlasoFile(Evidence):
     self.save_metadata = True
 
 
-class PlasoFile(Evidence):
+class PlasoCsvFile(Evidence):
   """Psort output file evidence.  """
 
   def __init__(self, plaso_version=None, *args, **kwargs):
     """Initialization for Plaso File evidence."""
     self.plaso_version = plaso_version
-    super(PlasoFile, self).__init__(copyable=True, *args, **kwargs)
+    super(PlasoCsvFile, self).__init__(copyable=True, *args, **kwargs)
     self.save_metadata = False
 
 

--- a/turbinia/workers/psort.py
+++ b/turbinia/workers/psort.py
@@ -20,7 +20,7 @@ import os
 
 from turbinia import config
 from turbinia.workers import TurbiniaTask
-from turbinia.evidence import PlasoFile
+from turbinia.evidence import PlasoCsvFile
 
 
 class PsortTask(TurbiniaTask):
@@ -76,7 +76,7 @@ class PsortTask(TurbiniaTask):
     else:
       output_suffix = 'csv'
     psort_file = os.path.join(self.output_dir, '{0:s}.{1:s}'.format(self.id, output_suffix))
-    psort_evidence = PlasoFile(source_path=psort_file)
+    psort_evidence = PlasoCsvFile(source_path=psort_file)
     psort_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
 
     cmd = self.build_plaso_command('psort.py', self.task_config)

--- a/turbinia/workers/psort.py
+++ b/turbinia/workers/psort.py
@@ -75,7 +75,8 @@ class PsortTask(TurbiniaTask):
       output_suffix = self.task_config.get('output_format')
     else:
       output_suffix = 'csv'
-    psort_file = os.path.join(self.output_dir, '{0:s}.{1:s}'.format(self.id, output_suffix))
+    psort_file = os.path.join(
+        self.output_dir, '{0:s}.{1:s}'.format(self.id, output_suffix))
     psort_evidence = PlasoCsvFile(source_path=psort_file)
     psort_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
 

--- a/turbinia/workers/psort.py
+++ b/turbinia/workers/psort.py
@@ -71,7 +71,12 @@ class PsortTask(TurbiniaTask):
 
     config.LoadConfig()
 
-    psort_file = os.path.join(self.output_dir, '{0:s}.csv'.format(self.id))
+    if self.task_config.get('output_format'):
+      output_suffix = self.task_config.get('output_format')
+    else:
+      output_suffix = 'csv'
+    psort_file = os.path.join(self.output_dir, '{0:s}.{1:s}'.format(self.id, output_suffix))
+    
     psort_evidence = PlasoCsvFile(source_path=psort_file)
     psort_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
 

--- a/turbinia/workers/psort.py
+++ b/turbinia/workers/psort.py
@@ -20,7 +20,7 @@ import os
 
 from turbinia import config
 from turbinia.workers import TurbiniaTask
-from turbinia.evidence import PlasoCsvFile
+from turbinia.evidence import PlasoFile
 
 
 class PsortTask(TurbiniaTask):
@@ -76,8 +76,7 @@ class PsortTask(TurbiniaTask):
     else:
       output_suffix = 'csv'
     psort_file = os.path.join(self.output_dir, '{0:s}.{1:s}'.format(self.id, output_suffix))
-    
-    psort_evidence = PlasoCsvFile(source_path=psort_file)
+    psort_evidence = PlasoFile(source_path=psort_file)
     psort_log = os.path.join(self.output_dir, '{0:s}.log'.format(self.id))
 
     cmd = self.build_plaso_command('psort.py', self.task_config)


### PR DESCRIPTION
psort.py now retrieves the output_format to be able to output files with different extensions. One issue right now is that the value found in output_format is directly used as an extension (e.g. "--output-format dynamic" ends up as "xxx.dynamic"). It is possible to just change the extension as with the original implementation (just a .csv).

PlasoCsvFile can be renamed to cover all output formats, since it seems to work well with different outputs. If this is not wanted, a new class(es) can be made to cover the other output formats.