### PR TITLE
Filter Partitions Processed by Default

### DIFF
--- a/turbinia/e2e/e2e-local.sh
+++ b/turbinia/e2e/e2e-local.sh
@@ -12,6 +12,7 @@ sudo chmod 777 ./evidence
 
 echo "==> Copy test artifacts to /evidence"
 cp ./test_data/artifact_disk.dd ./evidence/
+cp ./turbinia/e2e/e2e-recipe.yaml ./evidence/
 
 echo "==> Startup local turbinia docker-compose stack"
 export TURBINIA_EXTRA_ARGS="-d"
@@ -34,8 +35,8 @@ echo "==> Show container logs"
 docker logs turbinia-server
 docker logs turbinia-worker
 
-echo "==> Create  Turbinia request"
-docker exec -t turbinia-server turbiniactl -r 123456789 rawdisk -l /evidence/artifact_disk.dd
+echo "==> Create Turbinia request"
+docker exec -t turbinia-server turbiniactl -r 123456789 -P /evidence/e2e-recipe.yaml rawdisk -l /evidence/artifact_disk.dd
 
 echo "==> Sleep for 150 seconds to let Turbinia process evidence"
 sleep 150s

--- a/turbinia/e2e/e2e-recipe.yaml
+++ b/turbinia/e2e/e2e-recipe.yaml
@@ -1,3 +1,5 @@
+globals:
+
 partitionenumeration_base:
   task: 'PartitionEnumerationTask'
   process_unimportant: True

--- a/turbinia/e2e/e2e-recipe.yaml
+++ b/turbinia/e2e/e2e-recipe.yaml
@@ -1,0 +1,3 @@
+partitionenumeration_base:
+  task: 'PartitionEnumerationTask'
+  process_unimportant: True

--- a/turbinia/e2e/e2e-recipe.yaml
+++ b/turbinia/e2e/e2e-recipe.yaml
@@ -1,4 +1,5 @@
 globals:
+  'debug_tasks': True
 
 partitionenumeration_base:
   task: 'PartitionEnumerationTask'

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -599,7 +599,7 @@ class DiskPartition(RawDisk):
 
   def __init__(
       self, partition_location=None, partition_offset=None, partition_size=None,
-      lv_uuid=None, path_spec=None, *args, **kwargs):
+      lv_uuid=None, path_spec=None, important=True, *args, **kwargs):
     """Initialization for raw volume evidence object."""
 
     self.partition_location = partition_location
@@ -607,6 +607,7 @@ class DiskPartition(RawDisk):
     self.partition_size = partition_size
     self.lv_uuid = lv_uuid
     self.path_spec = path_spec
+    self.important = important
     super(DiskPartition, self).__init__(*args, **kwargs)
 
     # This Evidence needs to have a parent

--- a/turbinia/workers/partitions.py
+++ b/turbinia/workers/partitions.py
@@ -51,7 +51,9 @@ class PartitionEnumerationTask(TurbiniaTask):
       # Process important partitions
       'process_important': True,
       # Process unimportant partitions
-      'process_unimportant': False
+      'process_unimportant': False,
+      # Minimum important partition size (default 100M)
+      'minimum_size': 104857600
   }
 
   def _GetLocation(self, path_spec):
@@ -150,11 +152,12 @@ class PartitionEnumerationTask(TurbiniaTask):
               location, path_spec.type_indicator))
 
     # Is partition important based on size? (100M or larger)
-    if partition_size and partition_size < 104857600:
+    minimum_size = self.task_config.get('minimum_size')
+    if partition_size and partition_size < minimum_size:
       important = False
       log.info(
-          'Marking partition {0:s} unimportant (size {1!s} bytes)'.format(
-              location, partition_size))
+          'Marking partition {0:s} unimportant (size {1!s} < {2!s})'.format(
+              location, partition_size, minimum_size))
 
     # If LVM, we need to deactivate the Volume Group
     if lv_uuid:

--- a/turbinia/workers/partitions_test.py
+++ b/turbinia/workers/partitions_test.py
@@ -56,6 +56,7 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
 
     mock_getbasepathspecs.return_value = [tsk_spec]
 
+    self.task.task_config['process_unimportant'] = True
     result = self.task.run(self.evidence, self.result)
 
     # Ensure run method returns a TurbiniaTaskResult instance.
@@ -65,9 +66,9 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
     expected_report = []
     expected_report.append(
         fmt.heading4(
-            'Found 1 partition(s) in [{0:s}]:'.format(
-                self.evidence.local_path)))
+            'Found 1 partition(s) in [{0:s}]'.format(self.evidence.local_path)))
     expected_report.append(fmt.heading5('/p1:'))
+    expected_report.append(fmt.bullet('Important: False'))
     expected_report.append(fmt.bullet('Filesystem: NTFS'))
     expected_report.append(fmt.bullet('Partition index: 2'))
     expected_report.append(fmt.bullet('Partition offset: 512'))
@@ -88,10 +89,13 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
     test_raw_path_spec = path_spec_factory.Factory.NewPathSpec(
         dfvfs_definitions.TYPE_INDICATOR_RAW, parent=test_os_path_spec)
     test_apfs_container_path_spec = path_spec_factory.Factory.NewPathSpec(
-        dfvfs_definitions.TYPE_INDICATOR_APFS_CONTAINER, location='/apfs1',
-        volume_index=0, parent=test_raw_path_spec)
+        dfvfs_definitions.TYPE_INDICATOR_APFS_CONTAINER, volume_index=0,
+        parent=test_raw_path_spec)
+    test_apfs_path_spec = path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_APFS, location='/apfs1',
+        parent=test_apfs_container_path_spec)
 
-    mock_getbasepathspecs.return_value = [test_apfs_container_path_spec]
+    mock_getbasepathspecs.return_value = [test_apfs_path_spec]
 
     result = self.task.run(self.evidence, self.result)
 
@@ -99,10 +103,10 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
     expected_report = []
     expected_report.append(
         fmt.heading4(
-            'Found 1 partition(s) in [{0:s}]:'.format(
-                self.evidence.local_path)))
+            'Found 1 partition(s) in [{0:s}]'.format(self.evidence.local_path)))
     expected_report.append(fmt.heading5('/apfs1:'))
-    expected_report.append(fmt.bullet('Filesystem: APFS_CONTAINER'))
+    expected_report.append(fmt.bullet('Important: True'))
+    expected_report.append(fmt.bullet('Filesystem: APFS'))
     expected_report.append(fmt.bullet('Volume index: 0'))
     expected_report = '\n'.join(expected_report)
     self.assertEqual(result.report_data, expected_report)
@@ -134,9 +138,9 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
     expected_report = []
     expected_report.append(
         fmt.heading4(
-            'Found 1 partition(s) in [{0:s}]:'.format(
-                self.evidence.local_path)))
+            'Found 1 partition(s) in [{0:s}]'.format(self.evidence.local_path)))
     expected_report.append(fmt.heading5('/p1:'))
+    expected_report.append(fmt.bullet('Important: False'))
     expected_report.append(fmt.bullet('Filesystem: EXT'))
     expected_report.append(fmt.bullet('Source evidence is a volume image'))
     expected_report = '\n'.join(expected_report)
@@ -163,15 +167,16 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
 
     mock_getbasepathspecs.return_value = [test_xfs_path_spec]
 
-    result = self.task.run(self.evidence, self.result)
+    with mock.patch('turbinia.processors.mount_local.PostprocessDeleteLosetup'):
+      result = self.task.run(self.evidence, self.result)
 
     # Ensure run method returns a TurbiniaTaskResult instance.
     expected_report = []
     expected_report.append(
         fmt.heading4(
-            'Found 1 partition(s) in [{0:s}]:'.format(
-                self.evidence.local_path)))
+            'Found 1 partition(s) in [{0:s}]'.format(self.evidence.local_path)))
     expected_report.append(fmt.heading5('/lvm1:'))
+    expected_report.append(fmt.bullet('Important: False'))
     expected_report.append(fmt.bullet('Filesystem: XFS'))
     expected_report.append(fmt.bullet('Source evidence is a volume image'))
     expected_report = '\n'.join(expected_report)

--- a/turbinia/workers/partitions_test.py
+++ b/turbinia/workers/partitions_test.py
@@ -35,6 +35,7 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
         task_class=partitions.PartitionEnumerationTask,
         evidence_class=partitions.DiskPartition)
     self.setResults(mock_run=False)
+    self.task.task_config['minimum_size'] = 104857600
 
   @mock.patch('turbinia.state_manager.get_state_manager')
   @mock.patch('dfvfs.helpers.volume_scanner.VolumeScanner.GetBasePathSpecs')

--- a/turbinia/workers/partitions_test.py
+++ b/turbinia/workers/partitions_test.py
@@ -182,6 +182,42 @@ class PartitionEnumerationTaskTest(TestTurbiniaTaskBase):
     expected_report = '\n'.join(expected_report)
     self.assertEqual(result.report_data, expected_report)
 
+  @mock.patch('turbinia.state_manager.get_state_manager')
+  @mock.patch('dfvfs.helpers.volume_scanner.VolumeScanner.GetBasePathSpecs')
+  def testPartitionEnumerationRunOther(self, mock_getbasepathspecs, _):
+    """Test PartitionEnumeration task run on unsupported FS."""
+    self.result.setup(self.task)
+    filedir = os.path.dirname(os.path.realpath(__file__))
+    test_data = os.path.join(filedir, '..', '..', 'test_data', 'gpt.raw')
+
+    test_os_path_spec = path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_OS, location=test_data)
+    test_raw_path_spec = path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_RAW, parent=test_os_path_spec)
+    test_gpt_path_spec = path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_GPT, location='/p1',
+        parent=test_raw_path_spec)
+    test_tar_path_spec = path_spec_factory.Factory.NewPathSpec(
+        dfvfs_definitions.TYPE_INDICATOR_TAR, location='/',
+        parent=test_gpt_path_spec)
+
+    mock_getbasepathspecs.return_value = [test_tar_path_spec]
+
+    result = self.task.run(self.evidence, self.result)
+
+    # Ensure run method returns a TurbiniaTaskResult instance.
+    expected_report = []
+    expected_report.append(
+        fmt.heading4(
+            'Found 1 partition(s) in [{0:s}]'.format(self.evidence.local_path)))
+    expected_report.append(fmt.heading5('/p1:'))
+    expected_report.append(fmt.bullet('Important: False'))
+    expected_report.append(fmt.bullet('Filesystem: TAR'))
+    expected_report.append(fmt.bullet('Source evidence is a volume image'))
+    expected_report = '\n'.join(expected_report)
+    self.assertEqual(result.report_data, expected_report)
+    self.assertEqual(len(result.evidence), 0)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
* Filtering partitions processed by default based on filesystem and size
* Adding task config options to control which partitions are processed

Fixes: #729 