### PR TITLE
Standardizing stdout and sterr for docker and system executions

### DIFF
--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -663,12 +663,12 @@ class TurbiniaTask:
         if shell:
           proc = subprocess.Popen(
               cmd, shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-              cwd=cwd, env=env)
+              cwd=cwd, env=env, text=True, encoding="utf-8")
           stdout, stderr = proc.communicate(timeout=timeout_limit)
         else:
           proc = subprocess.Popen(
               cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE, cwd=cwd,
-              env=env)
+              env=env, text=True, encoding="utf-8")
           stdout, stderr = proc.communicate(timeout=timeout_limit)
       except subprocess.TimeoutExpired as exception:
         proc.kill()
@@ -696,7 +696,7 @@ class TurbiniaTask:
             suffix='.txt', prefix='stderr-', dir=self.output_dir)
       result.log(
           'Writing stderr to {0:s}'.format(stderr_file), level=logging.DEBUG)
-      with open(stderr_file, 'wb') as fh:
+      with open(stderr_file, 'w+') as fh:
         fh.write(stderr)
       log_files.append(stderr_file)
 
@@ -710,7 +710,7 @@ class TurbiniaTask:
             suffix='.txt', prefix='stdout-', dir=self.output_dir)
       result.log(
           'Writing stdout to {0:s}'.format(stdout_file), level=logging.DEBUG)
-      with open(stdout_file, 'wb') as fh:
+      with open(stdout_file, 'w+') as fh:
         fh.write(stdout)
       log_files.append(stdout_file)
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -34,16 +34,16 @@ from prometheus_client import REGISTRY
 class TestTurbiniaTaskBase(unittest.TestCase):
   """Test TurbiniaTask class.
 
-  Attributes:
-    class_task(TurbiniaTask): The class the test should instantiated
-    remove_file(list(str)): Files that will be removed after the test run
-    remove_dirs(list(str)): Dirs that will be removed after the test run
-    base_output_dir(str): The base output directory used by the Task
-    task(TurbiniaTask): The instantiated Task under test
-    test_stdout_path(str): A path we can use to send temporary stdout too
-    evidence(Evidence): The test evidence object used by the Task
-    result(TurbiniaResult): The result object used by the Task
-  """
+    Attributes:
+      class_task(TurbiniaTask): The class the test should instantiated
+      remove_file(list(str)): Files that will be removed after the test run
+      remove_dirs(list(str)): Dirs that will be removed after the test run
+      base_output_dir(str): The base output directory used by the Task
+      task(TurbiniaTask): The instantiated Task under test
+      test_stdout_path(str): A path we can use to send temporary stdout too
+      evidence(Evidence): The test evidence object used by the Task
+      result(TurbiniaResult): The result object used by the Task
+    """
 
   def setUp(self, task_class=TurbiniaTask, evidence_class=evidence.RawDisk):
     self.task_class = task_class
@@ -92,12 +92,12 @@ class TestTurbiniaTaskBase(unittest.TestCase):
       self, setup=None, run=None, validate_result=None, mock_run=True):
     """Set up mock returns in TurbiniaTaskResult object.
 
-    Args:
-      setup: What value to return from setup()
-      run: What value to return from run()
-      validate_result: What value to return from validate_result()
-      mock_run(bool): Whether to mock out the run method
-    """
+        Args:
+          setup: What value to return from setup()
+          run: What value to return from run()
+          validate_result: What value to return from validate_result()
+          mock_run(bool): Whether to mock out the run method
+        """
     if setup is None:
       setup = self.result
     if run is None:
@@ -262,7 +262,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecute(self, popen_mock):
     """Test execution with success case."""
     cmd = 'test cmd'
-    output = (b'test stdout', b'test stderr')
+    output = ('test stdout', 'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -273,12 +273,14 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
     self.task.execute(
         cmd, self.result, stdout_file=self.test_stdout_path, close=True)
 
-    with open(self.test_stdout_path, 'rb') as stdout_path:
+    with open(self.test_stdout_path, 'r') as stdout_path:
       stdout_data = stdout_path.read()
 
     # Command was executed, has the correct output saved and
     # TurbiniaTaskResult.close() was called with successful status.
-    popen_mock.assert_called_with(cmd, stdout=-1, stderr=-1, cwd=None, env=None)
+    popen_mock.assert_called_with(
+        cmd, stdout=-1, stderr=-1, cwd=None, env=None, text=True,
+        encoding='utf-8')
     self.assertEqual(self.result.error['stderr'], str(output[1]))
     self.assertEqual(stdout_data, output[0])
     self.result.close.assert_called_with(self.task, success=True)
@@ -287,7 +289,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteFailure(self, popen_mock):
     """Test execution with failure case."""
     cmd = 'test cmd'
-    output = (b'test stdout', b'test stderr')
+    output = ('test stdout', 'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -299,7 +301,9 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
     # Command was executed and TurbiniaTaskResult.close() was called with
     # unsuccessful status.
-    popen_mock.assert_called_with(cmd, stdout=-1, stderr=-1, cwd=None, env=None)
+    popen_mock.assert_called_with(
+        cmd, stdout=-1, stderr=-1, cwd=None, env=None, text=True,
+        encoding='utf-8')
     self.result.close.assert_called_with(
         self.task, success=False, status=mock.ANY)
 
@@ -323,7 +327,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteEvidenceExists(self, popen_mock):
     """Test execution with new evidence that has valid a source_path."""
     cmd = 'test cmd'
-    output = (b'test stdout', b'test stderr')
+    output = ('test stdout', 'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -343,7 +347,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteEvidenceDoesNotExist(self, popen_mock):
     """Test execution with new evidence that does not have a source_path."""
     cmd = 'test cmd'
-    output = (b'test stdout', b'test stderr')
+    output = ('test stdout', 'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()
@@ -359,7 +363,7 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   def testTurbiniaTaskExecuteEvidenceExistsButEmpty(self, popen_mock):
     """Test execution with new evidence source_path that exists but is empty."""
     cmd = 'test cmd'
-    output = (b'test stdout', b'test stderr')
+    output = ('test stdout', 'test stderr')
 
     self.result.close = mock.MagicMock()
     proc_mock = mock.MagicMock()


### PR DESCRIPTION
Switching to string for all stdout and sterr values, such that the file handlers can be set to string as well.
For more detail see #1121