### PR TITLE
set redis default to localhost as just having redis, breaks dev envir…

### DIFF
--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -288,7 +288,7 @@ STACKDRIVER_TRACEBACK = False
 ################################################################################
 
 # Use Redis for state management
-REDIS_HOST = 'redis'
+REDIS_HOST = 'localhost'
 REDIS_PORT = '6379'
 REDIS_DB = '0'
 


### PR DESCRIPTION
set Redis default to localhost as just having Redis, breaks dev environment . Plus default config other than GKE would be localhost