### PR TITLE
Api k8s pod and service

### DIFF
--- a/k8s/celery/turbinia-api-server.yaml
+++ b/k8s/celery/turbinia-api-server.yaml
@@ -21,12 +21,12 @@ spec:
       initContainers:
         - name: init-filestore
           image: busybox:1.28
-          command: ['sh', '-c', 'chmod go+w /mnt/turbiniavolume2']
+          command: ['sh', '-c', 'chmod go+w /mnt/turbiniavolume']
           volumeMounts:
-            - mountPath: "/mnt/turbiniavolume2"
-              name: turbiniavolume2
+            - mountPath: "/mnt/turbiniavolume"
+              name: turbiniavolume
       containers:
-        - name: server
+        - name: api
           image: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server:latest
           env:
             - name: TURBINIA_CONF
@@ -39,8 +39,8 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - mountPath: /mnt/turbiniavolume2
-              name: turbiniavolume2
+            - mountPath: /mnt/turbiniavolume
+              name: turbiniavolume
           ports:
             - containerPort: 9200
             - containerPort: 8000
@@ -53,7 +53,7 @@ spec:
               memory: "4096Mi"
               cpu: "2000m"
       volumes:
-        - name: turbiniavolume2
+        - name: turbiniavolume
           persistentVolumeClaim:
-            claimName: turbiniavolume2-claim
+            claimName: turbiniavolume-claim
             readOnly: false

--- a/k8s/celery/turbinia-api-server.yaml
+++ b/k8s/celery/turbinia-api-server.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: turbinia-api-server
+  labels:
+    app: turbinia-api-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: turbinia-api-server
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9200"
+        prometheus.io/scrape: "true"
+      labels:
+        app: turbinia-api-server
+    spec:
+      serviceAccountName: turbinia
+      initContainers:
+        - name: init-filestore
+          image: busybox:1.28
+          command: ['sh', '-c', 'chmod go+w /mnt/turbiniavolume2']
+          volumeMounts:
+            - mountPath: "/mnt/turbiniavolume2"
+              name: turbiniavolume2
+      containers:
+        - name: server
+          image: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server:latest
+          env:
+            - name: TURBINIA_CONF
+              valueFrom:
+                configMapKeyRef:
+                  name: turbinia-config
+                  key: TURBINIA_CONF
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /mnt/turbiniavolume2
+              name: turbiniavolume2
+          ports:
+            - containerPort: 9200
+            - containerPort: 8000
+            - containerPort: 8080
+          resources: 
+            requests:
+              memory: "256Mi"
+              cpu: "500m"
+            limits:
+              memory: "4096Mi"
+              cpu: "2000m"
+      volumes:
+        - name: turbiniavolume2
+          persistentVolumeClaim:
+            claimName: turbiniavolume2-claim
+            readOnly: false

--- a/k8s/celery/turbinia-api-service.yaml
+++ b/k8s/celery/turbinia-api-service.yaml
@@ -6,7 +6,14 @@ metadata:
     app: turbinia-api-service
 spec:
   ports:
-  - port: 8000
+  - name: web
+    port: 8000
     targetPort: 8000
+  - name: oauth2
+    port: 8080
+    targetPort: 8080
+  - name: metrics
+    port: 9200
+    targetPort: 9200
   selector:
     app: turbinia-api-server

--- a/k8s/celery/turbinia-api-service.yaml
+++ b/k8s/celery/turbinia-api-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: turbinia-api-service
+  labels:
+    app: turbinia-api-service
+spec:
+  ports:
+  - port: 8000
+    targetPort: 8000
+  selector:
+    app: turbinia-api-server


### PR DESCRIPTION
Adds k8s container for the Turbinia API server. Still need to figure out the oauth2 setup component at bootstrap + using turbiniamgmt cli, but adding this in as a first step which will spin up the API server and can be accessed locally within the cluster. 