### PR TITLE
grpcio-status / protobuf dep conflict pinning 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,13 +10,13 @@ google-auth<2.0.0.dev0
 google-cloud-core<2.0dev
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
-google-cloud-logging
+google-cloud-logging>=2.0.0,<3.0.0dev
 google-cloud-pubsub==1.7.0
 google-cloud-storage<=2.2.1
 pycryptodomex
 prometheus_client
 libcloudforensics
-protobuf>=4.21.3
+protobuf>=3.19.0,<4.0.0dev
 proto-plus<2.0.0dev,>=1.22.0
 psq
 pyparsing<3
@@ -30,4 +30,4 @@ uvicorn>=0.17.6
 vine>=5.0.0
 PyJWT[crypto]<2
 idna==2.10
-grpcio-status<2.0dev,>=1.33.2
+grpcio-status<1.49.0,>=1.33.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ google-auth<2.0.0.dev0
 google-cloud-core<2.0dev
 google-cloud-datastore<=2.0.0
 google-cloud-error-reporting
-google-cloud-logging>=2.0.0,<3.0.0dev
+google-cloud-logging
 google-cloud-pubsub==1.7.0
 google-cloud-storage<=2.2.1
 pycryptodomex

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ google-cloud-storage<=2.2.1
 pycryptodomex
 prometheus_client
 libcloudforensics
-protobuf>=3.19.0,<4.0.0dev
+protobuf>=4.21.3
 proto-plus<2.0.0dev,>=1.22.0
 psq
 pyparsing<3


### PR DESCRIPTION
Was getting the following error when building dependencies
```
error: protobuf 3.20.2 is installed but protobuf>=4.21.3 is required by {'grpcio-status'}
```

Due to new release in [grpcio-status](https://pypi.org/project/grpcio-status/#history). Pinning  grpcio-status<1.49.0,>=1.33.2 to fix issue