### PR TITLE
Fix Docker config file mapping

### DIFF
--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
         volumes:
             - $PWD/evidence:/evidence
-            - $PWD/conf/:/etc/turbinia/
+            - $PWD/conf/turbinia.conf:/etc/turbinia/turbinia.conf
 
         environment:
             - LC_ALL=C.UTF-8
@@ -36,7 +36,7 @@ services:
 
         volumes:
             - $PWD/evidence:/evidence
-            - $PWD/conf/:/etc/turbinia/
+            - $PWD/conf/turbinia.conf:/etc/turbinia/turbinia.conf
 
         environment:
             - LC_ALL=C.UTF-8
@@ -51,7 +51,7 @@ services:
 
         volumes:
             - $PWD/evidence:/evidence
-            - $PWD/conf/:/etc/turbinia/
+            - $PWD/conf/turbinia.conf:/etc/turbinia/turbinia.conf
 
         environment:
             - LC_ALL=C.UTF-8

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -66,7 +66,7 @@ services:
 
     #     volumes:
     #      - $PWD/evidence:/evidence
-    #      - $PWD/conf/:/etc/turbinia/
+    #      - $PWD/conf/turbinia.conf:/etc/turbinia/turbinia.conf
 
     #     environment:
     #      - LC_ALL=C.UTF-8


### PR DESCRIPTION
Fixes permission issues with mounting turbinia config file into container and code being able to recognize it. Also since nothing else should be created in that path, makes it a little more secure.