### PR TITLE
Tighten Cron rule to not match on legit Kubernetes

### DIFF
--- a/turbinia/config/rules/suspicious_cron.yar
+++ b/turbinia/config/rules/suspicious_cron.yar
@@ -15,5 +15,5 @@ rule suspicious_cron {
         $shell = "sh"
         $pgmem = "pg_mem"
    condition:
-      (filepath matches /cron/ or filepath matches /spool\/at/) and (($wget or all of ($options*)) or any of ($curl*) or $shm or $pgmem or (for all i in (1..#shell) : (@shell[i] > @pipechar[i])))
+      (filepath matches /cron/ or filepath matches /spool\/at/) and (($wget or all of ($options*)) or any of ($curl*) or $shm or $pgmem or (for all i in (1..#shell) : ((@shell[i] > @pipechar[i]) and (@shell[i] < @pipechar[i] + 10))))
 }


### PR DESCRIPTION
Currently firing on `/usr/lib64/python3.6/site-packages/sos/report/plugins/__pycache__/cron.cpython-36*` files