### PR TITLE
Devcontainer: Run apt-update before installing packages

### DIFF
--- a/docker/vscode/Dockerfile
+++ b/docker/vscode/Dockerfile
@@ -11,6 +11,9 @@ RUN rm /usr/local/bin/turbiniactl
 RUN mkdir /evidence && chmod 777 /evidence
 RUN mkdir -p /tmp/turbinia-mounts && chmod 777 /tmp/turbinia-mounts
 
+# Run apt-update before installing any packages
+RUN apt-get update -y
+
 # Install pylint, yapf and test tools
 RUN pip install pylint yapf
 RUN pip install mock nose coverage tox


### PR DESCRIPTION
This PR ensures the devcontainer builds using updated apt packages. I noticed the build can fail due to stale deb packages when rebuilding the container as it runs different apt install commands.