### PR TITLE
fix typo in turbinia api config 

### DIFF
--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -113,7 +113,7 @@ API_SERVER_ADDRESS = '0.0.0.0'
 API_SERVER_PORT = 8000
 
 # Allowed CORS origins
-API_ALLOWED_ORIGINS = ['http;//localhost:8000', 'http://localhost']
+API_ALLOWED_ORIGINS = ['http://localhost:8000', 'http://localhost']
 
 # Enable/Disable API authentication. This will determine whether the API server will
 # check for OAuth 2.0 bearer tokens in the 'Authorization' header.


### PR DESCRIPTION
fix typo in turbinia api config causing allowed origins for local testing to not correctly be set