### PR TITLE
Escape forward slashes in rule metadata

### DIFF
--- a/tools/fraken/main.go
+++ b/tools/fraken/main.go
@@ -207,7 +207,7 @@ func fungeRules(filePath string) (string, error) {
 					not = "not "
 					filepath = filepath[1:]
 				}
-				t = t + fmt.Sprintf(" and %vfilepath matches /%v/", not, filepath)
+				t = t + fmt.Sprintf(" and %vfilepath matches /%v/", not, strings.ReplaceAll(filepath, `/`, `\/`))
 				filepath = ""
 				not = ""
 			}
@@ -216,7 +216,7 @@ func fungeRules(filePath string) (string, error) {
 					not = "not "
 					filename = filename[1:]
 				}
-				t = t + fmt.Sprintf(" and %vfilename matches /%v/", not, filename)
+				t = t + fmt.Sprintf(" and %vfilename matches /%v/", not, strings.ReplaceAll(filename, `/`, `\/`))
 				filename = ""
 				not = ""
 			}
@@ -259,6 +259,7 @@ func fungeRules(filePath string) (string, error) {
 		}
 		ret = append(ret, t)
 	}
+	log.Println(strings.Join(ret, "\n"))
 	return strings.Join(ret, "\n"), nil
 }
 

--- a/tools/fraken/main.go
+++ b/tools/fraken/main.go
@@ -259,7 +259,6 @@ func fungeRules(filePath string) (string, error) {
 		}
 		ret = append(ret, t)
 	}
-	log.Println(strings.Join(ret, "\n"))
 	return strings.Join(ret, "\n"), nil
 }
 

--- a/tools/fraken/main_test.go
+++ b/tools/fraken/main_test.go
@@ -39,7 +39,7 @@ rule TEST_BADCOND_RULE {
 rule TEST_EXTVAR_RULE {
 	meta:
 		description = "Is an external variable test rule"
-		filepath = "ls"
+		filepath = "bin/ls"
 	strings:
 		$s = "test" ascii
 	condition:
@@ -49,11 +49,11 @@ rule TEST_EXTVAR_RULE {
 rule TEST_EXTVAR_RULE {
 	meta:
 		description = "Is an external variable test rule"
-		filepath = "ls"
+		filepath = "bin/ls"
 	strings:
 		$s = "test" ascii
 	condition:
-		all of them and filepath matches /ls/
+		all of them and filepath matches /bin\/ls/
 }`
 )
 

--- a/turbinia/workers/analysis/jenkins.py
+++ b/turbinia/workers/analysis/jenkins.py
@@ -71,7 +71,7 @@ class JenkinsAnalysisTask(TurbiniaTask):
       return result
 
     jenkins_artifacts = []
-    jenkins_re = re.compile(r'^.*jenkins[^\/]*(\/users\/[^\/]+)*\/config\.xml$')
+    jenkins_re = re.compile(r'^.*jenkins[^\/]*(\/home)?(\/users\/[^\/]+)*\/config\.xml$')
     for collected_artifact in collected_artifacts:
       if re.match(jenkins_re, collected_artifact):
         jenkins_artifacts.append(collected_artifact)

--- a/turbinia/workers/analysis/jenkins.py
+++ b/turbinia/workers/analysis/jenkins.py
@@ -71,7 +71,8 @@ class JenkinsAnalysisTask(TurbiniaTask):
       return result
 
     jenkins_artifacts = []
-    jenkins_re = re.compile(r'^.*jenkins[^\/]*(\/home)?(\/users\/[^\/]+)*\/config\.xml$')
+    jenkins_re = re.compile(
+        r'^.*jenkins[^\/]*(\/home)?(\/users\/[^\/]+)*\/config\.xml$')
     for collected_artifact in collected_artifacts:
       if re.match(jenkins_re, collected_artifact):
         jenkins_artifacts.append(collected_artifact)


### PR DESCRIPTION
Escape `/` to `\/` in metadata regex expressions so they can be both stored _and_ parsed