### PR TITLE
Changes to EwfDisk required attributes

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -1091,7 +1091,7 @@ class EwfDisk(Evidence):
     ewf_path (str): Path to mounted EWF image.
     ewf_mount_path (str): Path to EWF mount directory.
   """
-  REQUIRED_ATTRIBUTES = ['source_path', 'ewf_path', 'ewf_mount_path']
+  REQUIRED_ATTRIBUTES = ['source_path']
   POSSIBLE_STATES = [EvidenceState.ATTACHED]
 
   def __init__(


### PR DESCRIPTION
- Make ewf_path and ewf_mount_path optional as they are set via the _preprocess method and based on source_path
- 
Fixes #1216 