### PR TITLE
Add APFS Support

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -53,6 +53,7 @@ RUN pip3 install dfDewey
 #   dfImageTools
 #   docker-explorer
 #   libbde-tools
+#   libfsapfs-tools
 #   Plaso
 #   Sleuthkit
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \
@@ -65,6 +66,7 @@ RUN apt-get update && apt-get -y install \
     libewf \
     libewf-python3 \
     libewf-tools \
+    libfsapfs-tools \
     plaso-tools \
     python3-dfimagetools \
     python3-dfvfs \

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -208,7 +208,7 @@ DEPENDENCIES = [{
     'timeout': 14400
 }, {
     'job': 'PartitionEnumerationJob',
-    'programs': ['bdemount', 'blockdev'],
+    'programs': ['bdemount', 'blockdev', 'fsapfsmount'],
     'docker_image': None,
     'timeout': 1200
 }, {

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -788,8 +788,12 @@ class DiskPartition(Evidence):
         self.local_path = self.device_path
 
     if EvidenceState.MOUNTED in required_states or self.has_child_evidence:
-      self.mount_path = mount_local.PreprocessMountPartition(
-          self.device_path, self.path_spec.type_indicator)
+      if self.path_spec.type_indicator == 'APFS':
+        self.mount_path = mount_local.PreprocessAPFS(
+            self.device_path, self.parent_evidence.credentials)
+      else:
+        self.mount_path = mount_local.PreprocessMountPartition(
+            self.device_path, self.path_spec.type_indicator)
       if self.mount_path:
         self.local_path = self.mount_path
         self.state[EvidenceState.MOUNTED] = True

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -505,7 +505,7 @@ def PreprocessMountPartition(partition_path, filesystem_type):
     mounted = False
     log.info('Mount failed: {0!s}'.format(exception))
 
-  if filesystem_type == 'EXT':
+  if filesystem_type == 'EXT' and not mounted:
     # ext2 will not mount with the noload option, so this may be the cause of
     # the error.
     mounted = True

--- a/turbinia/processors/mount_local_test.py
+++ b/turbinia/processors/mount_local_test.py
@@ -86,6 +86,79 @@ class MountLocalProcessorTest(unittest.TestCase):
   @mock.patch('os.path.isdir')
   @mock.patch('os.path.exists')
   @mock.patch('os.makedirs')
+  def testPreprocessAPFS(
+      self, _, mock_path_exists, mock_path_isdir, mock_subprocess, mock_mkdtemp,
+      mock_config):
+    """Test PreprocessAPFS method."""
+    mock_config.MOUNT_DIR_PREFIX = '/mnt/turbinia'
+    mock_path_exists.side_effect = _mock_bitlocker_returns
+    mock_mkdtemp.return_value = '/mnt/turbinia/turbinia0ckdntz0'
+
+    current_path = os.path.abspath(os.path.dirname(__file__))
+    source_path = os.path.join(
+        current_path, '..', '..', 'test_data', 'apfs.raw')
+    credentials = [('password', '123456')]
+
+    # Test APFS volume
+    mock_path_isdir.return_value = True
+    mount_path = mount_local.PreprocessAPFS(source_path, credentials=None)
+    expected_args = [
+        'sudo', 'fsapfsmount', '-X', 'allow_other', source_path,
+        '/mnt/turbinia/turbinia0ckdntz0'
+    ]
+    mock_subprocess.assert_called_once_with(expected_args)
+    self.assertEqual(mount_path, '/mnt/turbinia/turbinia0ckdntz0')
+
+    # Test encrypted APFS volume
+    mock_subprocess.reset_mock()
+    mount_path = mount_local.PreprocessAPFS(
+        source_path, credentials=credentials)
+    expected_args = [
+        'sudo', 'fsapfsmount', '-p', '123456', '-X', 'allow_other', source_path,
+        '/mnt/turbinia/turbinia0ckdntz0'
+    ]
+    mock_subprocess.assert_called_once_with(expected_args)
+    self.assertEqual(mount_path, '/mnt/turbinia/turbinia0ckdntz0')
+
+    # Test with recovery password
+    mock_subprocess.reset_mock()
+    credentials = [('recovery_password', '123456')]
+    mount_local.PreprocessAPFS(source_path, credentials=credentials)
+    expected_args = [
+        'sudo', 'fsapfsmount', '-r', '123456', '-X', 'allow_other', source_path,
+        '/mnt/turbinia/turbinia0ckdntz0'
+    ]
+    mock_subprocess.assert_called_once_with(expected_args)
+
+    # Test if source does not exist
+    with self.assertRaises(TurbiniaException):
+      mount_local.PreprocessAPFS('/dev/loop0p4', credentials=credentials)
+
+    # Test if mount path not directory
+    mock_path_isdir.return_value = False
+    with self.assertRaises(TurbiniaException):
+      mount_local.PreprocessAPFS(source_path, credentials=credentials)
+    mock_path_isdir.return_value = True
+
+    # Test decryption failure
+    mock_subprocess.reset_mock()
+    mock_subprocess.side_effect = CalledProcessError(1, 'fsapfsmount')
+    mount_path = mount_local.PreprocessAPFS(
+        source_path, credentials=credentials)
+    self.assertEqual(mount_path, None)
+
+    # Test with unsupported credential type
+    mock_subprocess.reset_mock()
+    credentials = [('startup_key', 'key.BEK')]
+    mount_local.PreprocessAPFS(source_path, credentials=credentials)
+    mock_subprocess.assert_not_called()
+
+  @mock.patch('turbinia.processors.mount_local.config')
+  @mock.patch('tempfile.mkdtemp')
+  @mock.patch('subprocess.check_call')
+  @mock.patch('os.path.isdir')
+  @mock.patch('os.path.exists')
+  @mock.patch('os.makedirs')
   def testPreprocessBitLocker(
       self, _, mock_path_exists, mock_path_isdir, mock_subprocess, mock_mkdtemp,
       mock_config):


### PR DESCRIPTION
Adding support for APFS via pre-processors.

APFS volumes can't be "attached", so we attach the containing partition, or the whole disk if there isn't a containing partition.