### PR TITLE
Fix yara DL in dockerbuild

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,7 +85,7 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s -L "$(curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
+RUN cd /opt/fraken/yara && curl -s --retry 5 "$(curl -s --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
 RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,10 +85,8 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | YARA_DL=sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' | export YARA_DL | echo $YARA_DL
-
-RUN wget -O -q $YARA_DL | tar -xz --strip-components=1 \
-    && ./bootstrap.sh \
+RUN cd /opt/fraken/yara && wget -O - -q "$(curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
+RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig
 RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc" -o fraken

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,7 +85,9 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' | xargs -n1 wget -O - -q | tar -xz --strip-components=1 \
+RUN cd /opt/fraken/yara && curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | export YARA_DL=sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' | echo $YARA_DL
+
+RUN wget -O -q $YARA_DL | tar -xz --strip-components=1 \
     && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,7 +85,7 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -L "$(curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
+RUN cd /opt/fraken/yara && curl -s -L "$(curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
 RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,7 +85,8 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s --retry 5 "$(curl -s --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
+RUN curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' > /opt/fraken/yara/YARA_VERSION
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
 RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,7 +85,7 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | export YARA_DL=sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' | echo $YARA_DL
+RUN cd /opt/fraken/yara && curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | YARA_DL=sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' | export YARA_DL | echo $YARA_DL
 
 RUN wget -O -q $YARA_DL | tar -xz --strip-components=1 \
     && ./bootstrap.sh \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,7 +85,7 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && wget -O - -q "$(curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
+RUN cd /opt/fraken/yara && curl -L "$(curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
 RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -85,8 +85,7 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' > /opt/fraken/yara/YARA_VERSION
-RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
 RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig


### PR DESCRIPTION
Step in Worker Dockerfile seems to fail at random when pulling Yara repo from github. Re wrote slightly differently and seems like using `curl -L` allows it to be more reliable.

Failure we are seeing in Worker build:
```
wget: missing URL
Usage: wget [OPTION]... [URL]...

Try `wget --help' for more options.

gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
The command '/bin/sh -c cd /opt/fraken/yara && curl -s https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p' | xargs -n1 wget -O - -q | tar -xz --strip-components=1     && ./bootstrap.sh     && ./configure     && make && sudo make install && sudo ldconfig' returned a non-zero code: 2
```