### PR TITLE
Fix for duplicate UUID issue in XFS image mounts

### DIFF
--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -495,7 +495,7 @@ def PreprocessMountPartition(partition_path, filesystem_type):
     # everything read-only.
     mount_cmd.extend(['-o', 'noload'])
   elif filesystem_type == 'XFS':
-    mount_cmd.extend(['-o', 'norecovery'])
+    mount_cmd.extend(['-o', 'norecovery', '-o', 'nouuid'])
   mount_cmd.extend([partition_path, mount_path])
 
   log.info('Running: {0:s}'.format(' '.join(mount_cmd)))

--- a/turbinia/processors/mount_local_test.py
+++ b/turbinia/processors/mount_local_test.py
@@ -371,8 +371,8 @@ class MountLocalProcessorTest(unittest.TestCase):
     mock_subprocess.reset_mock()
     mount_path = mount_local.PreprocessMountPartition('/dev/loop0', 'XFS')
     expected_args = [
-        'sudo', 'mount', '-o', 'ro', '-o', 'norecovery', '-o', 'nouuid', '/dev/loop0',
-        '/mnt/turbinia/turbinia0ckdntz0'
+        'sudo', 'mount', '-o', 'ro', '-o', 'norecovery', '-o', 'nouuid',
+        '/dev/loop0', '/mnt/turbinia/turbinia0ckdntz0'
     ]
     mock_subprocess.assert_called_once_with(expected_args)
     self.assertEqual(mount_path, '/mnt/turbinia/turbinia0ckdntz0')

--- a/turbinia/processors/mount_local_test.py
+++ b/turbinia/processors/mount_local_test.py
@@ -371,7 +371,7 @@ class MountLocalProcessorTest(unittest.TestCase):
     mock_subprocess.reset_mock()
     mount_path = mount_local.PreprocessMountPartition('/dev/loop0', 'XFS')
     expected_args = [
-        'sudo', 'mount', '-o', 'ro', '-o', 'norecovery', '/dev/loop0',
+        'sudo', 'mount', '-o', 'ro', '-o', 'norecovery', '-o', 'nouuid', '/dev/loop0',
         '/mnt/turbinia/turbinia0ckdntz0'
     ]
     mock_subprocess.assert_called_once_with(expected_args)


### PR DESCRIPTION
Fixes issue where two workers on same machine try to mount an XFS image causing an error with msg`Filesystem has duplicate UUID`, which has been the culprit to some failed Tasks we've been seeing from testing.

Adding in `-o nouuid` flag to ignore the UUID for XFS images when mounting, which in our case is fine as the UUID is not being used for anything in Turbinia.