### PR TITLE
Logging, filelock, sleep updates

### DIFF
--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -143,9 +143,6 @@ def LoadConfig(config_file=None):
   # pylint: disable=global-statement
   global CONFIG
   if CONFIG and not config_file:
-    log.debug(
-        'Returning cached config from {0:s} instead of reloading config'.format(
-            CONFIG.configSource))
     return CONFIG
 
   if not config_file:

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -462,20 +462,31 @@ class Evidence:
         raise TurbiniaException(
             'Evidence of type {0:s} needs parent_evidence to be set'.format(
                 self.type))
+      log.debug(
+          'Evidence is context dependent. Running preprocess for parent_evidence '
+          '{0:s}'.format(self.parent_evidence.name))
       self.parent_evidence.preprocess(task_id, tmp_dir, required_states)
     try:
-      log.debug('Starting pre-processor for evidence {0:s}'.format(self.name))
+      log.info('Starting preprocessor for evidence {0:s}'.format(self.name))
       if self.resource_tracked:
         # Track resource and task id in state file
+        log.debug(
+            'Evidence {0:s} is resource tracked. Acquiring filelock for'
+            'pre-processing'.format(self.name))
         with filelock.FileLock(config.RESOURCE_FILE_LOCK):
           resource_manager.PreprocessResourceState(self.resource_id, task_id)
-      self._preprocess(tmp_dir, required_states)
+          self._preprocess(tmp_dir, required_states)
+      else:
+        log.debug(
+            'Evidence {0:s} is not resource tracked. Running preprocess.'
+            .format(self.name))
+        self._preprocess(tmp_dir, required_states)
     except TurbiniaException as exception:
       log.error(
           'Error running preprocessor for {0:s}: {1!s}'.format(
               self.name, exception))
 
-    log.debug(
+    log.info(
         'Pre-processing evidence {0:s} is complete, and evidence is in state '
         '{1:s}'.format(self.name, self.format_state()))
 
@@ -492,26 +503,39 @@ class Evidence:
     log.info('Starting post-processor for evidence {0:s}'.format(self.name))
     log.debug('Evidence state: {0:s}'.format(self.format_state()))
 
-    is_detachable = True
     if self.resource_tracked:
+      log.debug(
+          'Evidence: {0:s} is resource tracked. Acquiring filelock for '
+          'postprocessing.'.format(self.name))
       with filelock.FileLock(config.RESOURCE_FILE_LOCK):
         # Run postprocess to either remove task_id or resource_id.
         is_detachable = resource_manager.PostProcessResourceState(
             self.resource_id, task_id)
         if not is_detachable:
-          # Prevent from running post process code if there are other tasks running.
+          # Skip post process if there are other tasks still processing the
+          # Evidence.
           log.info(
-              'Resource ID {0:s} still in use. Skipping detaching Evidence...'
+              'Resource ID {0:s} still in use. Skipping detaching Evidence.'
               .format(self.resource_id))
         else:
           self._postprocess()
-          # Set to False to prevent postprocess from running twice.
-          is_detachable = False
-
-    if is_detachable:
+          if self.parent_evidence:
+            log.debug(
+                'Evidence {0:s} has parent_evidence. Running postprocess '
+                'for parent evidence {1:s}.'.format(
+                    self.name, self.parent_evidence.name))
+            self.parent_evidence.postprocess(task_id)
+    else:
+      log.debug(
+          'Evidence {0:s} is not resource tracked. '
+          'Running postprocess.'.format(self.name))
       self._postprocess()
-    if self.parent_evidence:
-      self.parent_evidence.postprocess(task_id)
+      if self.parent_evidence:
+        log.debug(
+            'Evidence {0:s} has parent_evidence. Running postprocess '
+            'for parent evidence {1:s}.'.format(
+                self.name, self.parent_evidence.name))
+        self.parent_evidence.postprocess(task_id)
 
   def format_state(self):
     """Returns a string representing the current state of evidence.
@@ -852,16 +876,12 @@ class GoogleCloudDisk(Evidence):
     # DiskPartition evidence will be used. In this case we're breaking the
     # evidence layer isolation and having the child evidence manage the
     # mounting and unmounting.
-
-    # Explicitly lock this method to prevent race condition with two workers
-    # attempting to attach disk at same time, given delay with attaching in GCP.
-    with filelock.FileLock(config.RESOURCE_FILE_LOCK):
-      if EvidenceState.ATTACHED in required_states:
-        self.device_path, partition_paths = google_cloud.PreprocessAttachDisk(
-            self.disk_name)
-        self.partition_paths = partition_paths
-        self.local_path = self.device_path
-        self.state[EvidenceState.ATTACHED] = True
+    if EvidenceState.ATTACHED in required_states:
+      self.device_path, partition_paths = google_cloud.PreprocessAttachDisk(
+          self.disk_name)
+      self.partition_paths = partition_paths
+      self.local_path = self.device_path
+      self.state[EvidenceState.ATTACHED] = True
 
   def _postprocess(self):
     if self.state[EvidenceState.ATTACHED]:

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -472,7 +472,7 @@ class Evidence:
         # Track resource and task id in state file
         log.debug(
             'Evidence {0:s} is resource tracked. Acquiring filelock for'
-            'pre-processing'.format(self.name))
+            'preprocessing'.format(self.name))
         with filelock.FileLock(config.RESOURCE_FILE_LOCK):
           resource_manager.PreprocessResourceState(self.resource_id, task_id)
           self._preprocess(tmp_dir, required_states)
@@ -487,7 +487,7 @@ class Evidence:
               self.name, exception))
 
     log.info(
-        'Pre-processing evidence {0:s} is complete, and evidence is in state '
+        'Preprocessing evidence {0:s} is complete, and evidence is in state '
         '{1:s}'.format(self.name, self.format_state()))
 
   def postprocess(self, task_id):
@@ -500,7 +500,7 @@ class Evidence:
     Args:
       task_id(str): The id of a given Task.
     """
-    log.info('Starting post-processor for evidence {0:s}'.format(self.name))
+    log.info('Starting postprocessor for evidence {0:s}'.format(self.name))
     log.debug('Evidence state: {0:s}'.format(self.format_state()))
 
     if self.resource_tracked:

--- a/turbinia/processors/google_cloud.py
+++ b/turbinia/processors/google_cloud.py
@@ -32,6 +32,7 @@ from turbinia import TurbiniaException
 log = logging.getLogger('turbinia')
 
 RETRY_MAX = 10
+SLEEP_TIME = 3
 
 turbinia_nonexisting_disk_path = Gauge(
     'turbinia_nonexisting_disk_path',
@@ -120,7 +121,9 @@ def PreprocessAttachDisk(disk_name):
       log.info(
           'Block device {0:s} mode is {1}'.format(path,
                                                   os.stat(path).st_mode))
-    time.sleep(1)
+
+    # Final sleep to allow time between API calls
+    time.sleep(SLEEP_TIME)
 
   message = None
   if not os.path.exists(path):
@@ -168,4 +171,7 @@ def PostprocessDetachDisk(disk_name, local_path):
     if not os.path.exists(path):
       log.info('Block device {0:s} is no longer attached'.format(path))
       break
-    time.sleep(5)
+    time.sleep(SLEEP_TIME)
+
+  # Final sleep to allow time between API calls
+  time.sleep(SLEEP_TIME)

--- a/turbinia/processors/google_cloud.py
+++ b/turbinia/processors/google_cloud.py
@@ -121,9 +121,10 @@ def PreprocessAttachDisk(disk_name):
       log.info(
           'Block device {0:s} mode is {1}'.format(path,
                                                   os.stat(path).st_mode))
-
-    # Final sleep to allow time between API calls
     time.sleep(SLEEP_TIME)
+
+  # Final sleep to allow time between API calls.
+  time.sleep(SLEEP_TIME)
 
   message = None
   if not os.path.exists(path):
@@ -173,5 +174,5 @@ def PostprocessDetachDisk(disk_name, local_path):
       break
     time.sleep(SLEEP_TIME)
 
-  # Final sleep to allow time between API calls
+  # Final sleep to allow time between API calls.
   time.sleep(SLEEP_TIME)

--- a/turbinia/processors/google_cloud.py
+++ b/turbinia/processors/google_cloud.py
@@ -32,7 +32,8 @@ from turbinia import TurbiniaException
 log = logging.getLogger('turbinia')
 
 RETRY_MAX = 10
-SLEEP_TIME = 3
+ATTACH_SLEEP_TIME = 3
+DETACH_SLEEP_TIME = 5
 
 turbinia_nonexisting_disk_path = Gauge(
     'turbinia_nonexisting_disk_path',
@@ -121,10 +122,10 @@ def PreprocessAttachDisk(disk_name):
       log.info(
           'Block device {0:s} mode is {1}'.format(path,
                                                   os.stat(path).st_mode))
-    time.sleep(SLEEP_TIME)
+    time.sleep(ATTACH_SLEEP_TIME)
 
   # Final sleep to allow time between API calls.
-  time.sleep(SLEEP_TIME)
+  time.sleep(ATTACH_SLEEP_TIME)
 
   message = None
   if not os.path.exists(path):
@@ -172,7 +173,7 @@ def PostprocessDetachDisk(disk_name, local_path):
     if not os.path.exists(path):
       log.info('Block device {0:s} is no longer attached'.format(path))
       break
-    time.sleep(SLEEP_TIME)
+    time.sleep(DETACH_SLEEP_TIME)
 
   # Final sleep to allow time between API calls.
-  time.sleep(SLEEP_TIME)
+  time.sleep(DETACH_SLEEP_TIME)

--- a/turbinia/processors/resource_manager.py
+++ b/turbinia/processors/resource_manager.py
@@ -84,9 +84,18 @@ def PreprocessResourceState(resource_id, task_id):
   # Write back to state file.
   with open(config.RESOURCE_FILE, 'w', encoding='utf-8') as fh:
     json.dump(json_load, fh)
-    log.debug('The resource state file has been successfully updated.')
+    log.info('The resource state file has been successfully updated.') 
   fh.close()
-
+  
+  # Confirm resource state was properly updated.
+  curr_state = RetrieveResourceState()
+  if json_load != curr_state:
+    msg = ('Warning resource state mismatch detected. Intended state: {0:s} '
+           'Current state: {1:s}'
+           .format(json.dumps(json_load), json.dumps(curr_state)))
+    log.error(msg)
+    raise TurbiniaException(msg)
+  log.debug('Current resource state: {0:s}'.format(json.dumps(curr_state)))
 
 def PostProcessResourceState(resource_id, task_id):
   """Removes the Evidence resource_id and/or task_id from the state file
@@ -121,7 +130,17 @@ def PostProcessResourceState(resource_id, task_id):
   # Write back to state file.
   with open(config.RESOURCE_FILE, 'w', encoding='utf-8') as fh:
     json.dump(json_load, fh)
-    log.debug('The resource state file has been successfully updated.')
+    log.info('The resource state file has been successfully updated.')
   fh.close()
+
+  # Confirm resource state was properly updated.
+  curr_state = RetrieveResourceState()
+  if json_load != curr_state:
+    msg = ('Warning resource state mismatch detected. Intended state: {0:s} '
+           'Current state: {1:s}'
+           .format(json.dumps(json_load), json.dumps(curr_state)))
+    log.error(msg)
+    raise TurbiniaException(msg)
+  log.debug('Current resource state: {0:s}'.format(json.dumps(curr_state))) 
 
   return is_detachable

--- a/turbinia/processors/resource_manager.py
+++ b/turbinia/processors/resource_manager.py
@@ -84,18 +84,20 @@ def PreprocessResourceState(resource_id, task_id):
   # Write back to state file.
   with open(config.RESOURCE_FILE, 'w', encoding='utf-8') as fh:
     json.dump(json_load, fh)
-    log.info('The resource state file has been successfully updated.') 
+    log.info('The resource state file has been successfully updated.')
   fh.close()
-  
+
   # Confirm resource state was properly updated.
   curr_state = RetrieveResourceState()
   if json_load != curr_state:
-    msg = ('Warning resource state mismatch detected. Intended state: {0:s} '
-           'Current state: {1:s}'
-           .format(json.dumps(json_load), json.dumps(curr_state)))
+    msg = (
+        'Warning resource state mismatch detected. Intended state: {0:s} '
+        'Current state: {1:s}'.format(
+            json.dumps(json_load), json.dumps(curr_state)))
     log.error(msg)
     raise TurbiniaException(msg)
   log.debug('Current resource state: {0:s}'.format(json.dumps(curr_state)))
+
 
 def PostProcessResourceState(resource_id, task_id):
   """Removes the Evidence resource_id and/or task_id from the state file
@@ -136,11 +138,12 @@ def PostProcessResourceState(resource_id, task_id):
   # Confirm resource state was properly updated.
   curr_state = RetrieveResourceState()
   if json_load != curr_state:
-    msg = ('Warning resource state mismatch detected. Intended state: {0:s} '
-           'Current state: {1:s}'
-           .format(json.dumps(json_load), json.dumps(curr_state)))
+    msg = (
+        'Warning resource state mismatch detected. Intended state: {0:s} '
+        'Current state: {1:s}'.format(
+            json.dumps(json_load), json.dumps(curr_state)))
     log.error(msg)
     raise TurbiniaException(msg)
-  log.debug('Current resource state: {0:s}'.format(json.dumps(curr_state))) 
+  log.debug('Current resource state: {0:s}'.format(json.dumps(curr_state)))
 
   return is_detachable


### PR DESCRIPTION
In response to this https://github.com/google/turbinia/issues/1249, adding following changes:
* Add more debug statements for evidence.preprocess and evidence.postprocess to more closely track each step.
* Move filelock in preprocess and postprocess to filelock any resource tracked evidence which essentially only allows for 1 attach or detach event, helped to further eliminate any race conditions between attaching and detaching a disk. 
* Add debug statement for resource manager to track resource state and add check to ensure intended resource state matches the resource state that was written (in the event with issues writing to the file).
* Sleep on attachDisk and detachDisk to allow time between API calls.
* Remove noisy debug statement with loading the config file