### PR TITLE
Small fix for image_export.py

### DIFF
--- a/turbinia/lib/utils.py
+++ b/turbinia/lib/utils.py
@@ -119,7 +119,7 @@ def extract_files(file_name, disk_path, output_dir, credentials=[]):
 
   image_export_cmd = [
       'sudo', 'image_export.py', '--name', file_name, '--write', output_dir,
-      '--partitions', 'all'
+      '--partitions', 'all', '--volumes', 'all'
   ]
 
   if credentials:


### PR DESCRIPTION
Adding `--volumes` flag to `image_export.py` command. Without it, the worker would pause for user input on LVM (and other non-partition) volumes.