### PR TITLE
Fix worker lock

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// start redis-server after subsequent start of the devcontainer
 	"postStartCommand": "/etc/init.d/redis-server start",
 	// Set *default* container specific settings.json values on container create.
-	"mounts": ["source=/dev,target=/dev,type=bind"],
+	"mounts": ["source=/dev,target=/dev,type=bind", "source=/evidence,target=/mnt/turbinia,type=bind,consistency=cached"],
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"terminal.integrated.env.linux": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// start redis-server after subsequent start of the devcontainer
 	"postStartCommand": "/etc/init.d/redis-server start",
 	// Set *default* container specific settings.json values on container create.
-	"mounts": ["source=/dev,target=/dev,type=bind", "source=/evidence,target=/mnt/turbinia,type=bind,consistency=cached"],
+	"mounts": ["source=/dev,target=/dev,type=bind"],
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"terminal.integrated.env.linux": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-boto3>=1.26.127
-botocore>=1.29.127
 celery>=5.2.2
 cryptography>=2.0.2,>3.8
 docker

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ google-cloud-storage<=2.2.1
 httpx
 pycryptodomex
 prometheus_client
-libcloudforensics
+libcloudforensics==20230601
 pandas
 protobuf>=3.19.0,<4.0.0dev
 proto-plus<2.0.0dev,>=1.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+boto3>=1.26.127
+botocore>=1.29.127
 celery>=5.2.2
 cryptography>=2.0.2,>3.8
 docker

--- a/turbinia/api/cli/setup.py
+++ b/turbinia/api/cli/setup.py
@@ -15,7 +15,7 @@ REQUIRES = [
 ]
 
 this_directory = Path(__file__).parent
-README = (this_directory / "README.md").read_text()
+README = (this_directory / "README.rst").read_text()
 
 setup(
     name=NAME, 


### PR DESCRIPTION
Add a file lock for celery workers.

This would prevent GKE pods from being terminated by GKE when downscaling if a worker has an active task.