### PR TITLE
Minor updates to auth_helper, turbinia-client and API server

### DIFF
--- a/turbinia/api/cli/setup.py
+++ b/turbinia/api/cli/setup.py
@@ -12,6 +12,7 @@ VERSION = "1.0.1"
 REQUIRES = [
     "click",
     "turbinia-api-lib",
+    'google-auth-oauthlib'
 ]
 
 this_directory = Path(__file__).parent

--- a/turbinia/api/cli/turbinia_client/helpers/auth_helper.py
+++ b/turbinia/api/cli/turbinia_client/helpers/auth_helper.py
@@ -59,7 +59,7 @@ def get_oauth2_credentials(credentials_path, client_secrets_path):
         'Starting local HTTP server on localhost:8888 for OAUTH flow. '
         'If running turbinia-client remotely over SSH you will need to tunnel '
         'port 8888.')
-    appflow.run_local_server(host='localhost', port=8888)
+    appflow.run_local_server(host='localhost', port=8888, open_browser=False)
     credentials = appflow.credentials
 
     # Save credentials

--- a/turbinia/api/models/request_status.py
+++ b/turbinia/api/models/request_status.py
@@ -102,7 +102,7 @@ class RequestStatus(BaseModel):
             self.last_task_update_time).strftime(
                 turbinia_config.DATETIME_FORMAT)
 
-    if self.running_tasks > 0:
+    if self.running_tasks > 0 or self.queued_tasks > 0:
       self.status = 'running'
     elif self.failed_tasks == self.task_count:
       self.status = 'failed'


### PR DESCRIPTION
Minor changes.
- Added ```google-auth-oauthlib``` to setup.py for turbinia-client.
- Bugfix for API server request status.
- Don't auto open a browser window when trying to perform OAuth2 flows (issues when running over ssh / console)