### PR TITLE
Add bug, FR, and PR request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,36 @@
+name: 🐞 Bug
+description: Create a report to help us improve
+title: "[Bug]: "
+labels: ["bug", "Needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Please fill in as much of the following form as you're able.
+  - type: textarea
+    attributes:
+      label: What steps will reproduce the bug?
+      description: Enter details about your bug.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the expected behavior?
+      description: If possible please provide textual output instead of screenshots.
+  - type: textarea
+    attributes:
+      label: What do you see instead?
+      description: If possible please provide textual output instead of screenshots.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Tell us anything else you think we should know.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,13 +11,13 @@ body:
         Please fill in as much of the following form as you're able.
   - type: textarea
     attributes:
-      label: What is the problem this feature will solve?
+      label: What would this feature improve or what problem would it solve?
     validations:
       required: true
   - type: textarea
     attributes:
-      label: What is the feature you are proposing to solve the problem?
-      description: Describe the requests. If you already have something in mind... PRs are welcome!
+      label: What is the feature you are proposing?
+      description: Describe the feature. If you already have something in mind... PRs are welcome!
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -7,6 +7,7 @@ body:
     attributes:
       value: |
         Thank you for suggesting an idea to improve Turbinia.
+        
         Please fill in as much of the following form as you're able.
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,24 @@
+name: "Feature request"
+description: Suggest an idea for this project
+title: "[FR]: "
+labels: ["enhancement", "Needs triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting an idea to improve Turbinia.
+        Please fill in as much of the following form as you're able.
+  - type: textarea
+    attributes:
+      label: What is the problem this feature will solve?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the feature you are proposing to solve the problem?
+      description: Describe the requests. If you already have something in mind... PRs are welcome!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What alternatives have you considered?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+ Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:
+
+ - Describe what the change does.
+ - Please run any tests that can exercise your modified code.
+ - Please have an issue created and ready to be linked to the PR. 
+ -->
+
+### Description of the change
+
+<!-- Describe what the change does. -->
+
+### Applicable issues
+
+<!-- Enter any applicable Issues here (You can reference an issue using #) -->
+- fixes #
+
+### Additional information
+
+<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
+
+### Checklist
+
+<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
+
+- [ ] All tests succeed.
+- [ ] Unit tests added.
+- [ ] Documentation updated.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 
  - Describe what the change does.
  - Please run any tests that can exercise your modified code.
- - Please have an issue created and ready to be linked to the PR. 
+ - Please add links for any issues that are related to this PR.
  -->
 
 ### Description of the change
@@ -23,6 +23,6 @@
 
 <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
 
-- [ ] All tests succeed.
+- [ ] All tests were successful.
 - [ ] Unit tests added.
 - [ ] Documentation updated.


### PR DESCRIPTION
Fixes #1307 

Adds:
  * bug_report.yaml -> For filing bugs and by default adds "bug", "Needs triage" labels.
  * feature_request.yaml -> For filing feature requests and by default adds "enhancement", "Needs triage" labels
  * pull_request_template.md -> for submitting PRs

I was also considering breaking it down to more FR options for example one for Web UI, one for API/Celery, one for a new task, etc, but I feel like it will cause redundancy minus the added benefit of adding an extra label + descriptive title name.

At least this way if we add "Needs triage" then anyone reviewing the issue can update the labels after their review is done, but lmk if you prefer another way/if any other template will help!