### PR TITLE
Remove curl gpg key command for GIFT PPA worker Docker build

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -60,7 +60,7 @@ RUN pip3 install dfDewey
 #   Plaso
 #   Sleuthkit
 
-RUN curl -sS https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3ed1eaece81894b171d7da5b5e80511b10c598b8 | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gift.gpg
+#RUN curl -sS https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3ed1eaece81894b171d7da5b5e80511b10c598b8 | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gift.gpg
 #RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get -y install \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -4,8 +4,7 @@ FROM ubuntu:22.04
 ARG PPA_TRACK=stable
 
 ENV DEBIAN_FRONTEND=noninteractive
-#RUN apt-get update && apt-get -y upgrade
-RUN apt-get update
+RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install \
     apt-transport-https \
     apt-utils \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -60,8 +60,6 @@ RUN pip3 install dfDewey
 #   Plaso
 #   Sleuthkit
 
-#RUN curl -sS https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3ed1eaece81894b171d7da5b5e80511b10c598b8 | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gift.gpg
-#RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get -y install \
     bulk-extractor \


### PR DESCRIPTION
### Description of the change
Remove the command to pull the GIFT PPA key manually in the worker Dockerfile. add-apt-repository handles this for us.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.
