### PR TITLE
Update worker to be Celery >6.0 compatible

### DIFF
--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -4,8 +4,7 @@ FROM ubuntu:22.04
 ARG PPA_TRACK=stable
 
 ENV DEBIAN_FRONTEND=noninteractive
-#RUN apt-get update && apt-get -y upgrade
-RUN apt-get update
+RUN apt-get update && apt-get -y upgrade
 RUN apt-get -y install \
     apt-transport-https \
     apt-utils \

--- a/turbinia/tcelery.py
+++ b/turbinia/tcelery.py
@@ -53,6 +53,7 @@ class TurbiniaCelery:
     self.app = celery.Celery(
         'turbinia', broker=config.CELERY_BROKER, backend=config.CELERY_BACKEND)
     self.app.conf.update(
+        broker_connection_retry_on_startup=True,
         task_default_queue=config.INSTANCE_ID,
         accept_content=['json'],
         task_acks_late=True,


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please add links for any issues that are related to this PR.
 -->

### Description of the change
Update worker to be Celery >6.0 compatible by setting broker_connection_retry_on_startup to True

<!-- Describe what the change does. -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
```
turbinia-worker        | [2023-07-27 15:51:02,971: WARNING/MainProcess] /usr/local/lib/python3.10/dist-packages/celery/worker/consumer/consumer.py:498: CPendingDeprecationWarning: The broker_connection_retry configuration setting will no longer determine
turbinia-worker        | whether broker connection retries are made during startup in Celery 6.0 and above.
turbinia-worker        | If you wish to retain the existing behavior for retrying connections on startup,
turbinia-worker        | you should set broker_connection_retry_on_startup to True.
```


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.
