### PR TITLE
Optimize Turbinia worker and server docker image.

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive 
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get -y install \
+ENV PIP_NO_CACHE_DIR=1
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     apt-transport-https \
     apt-utils \
     ca-certificates \
@@ -11,19 +11,17 @@ RUN apt-get -y install \
     python3-pip \
     software-properties-common \
     sudo \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-RUN pip3 install pip --upgrade
-RUN pip3 install urllib3 cryptography requests --upgrade
-
-ADD requirements.txt /tmp/
-RUN cd /tmp/ && pip3 install -r requirements.txt
+RUN pip3 install pip --upgrade \
+    && pip3 install urllib3 cryptography requests --upgrade
 
 ADD . /tmp/
-# unshallow and fetch all tags so our build systems pickup the correct git tag if it's a shallow clone
-RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi
+RUN cd /tmp/ && pip3 install -r requirements.txt
 
-RUN cd /tmp/ && python3 setup.py install
+# unshallow and fetch all tags so our build systems pickup the correct git tag if it's a shallow clone
+RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi \
+    && cd /tmp/ && python3 setup.py install
 
 RUN useradd -r -s /bin/nologin -u 999 turbinia
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -6,8 +6,7 @@ ARG PPA_TRACK=stable
 ENV PIP_NO_CACHE_DIR=1
 ENV DEBIAN_FRONTEND=noninteractive
 RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get -y upgrade &&
-    apt-get -y install \
+    apt-get update && apt-get -y upgrade && apt-get -y install \
     apt-transport-https \
     apt-utils \
     automake \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -23,25 +23,23 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
 # Install latest golang as ubuntu base image provides outdated version.
 ARG GOVERSION=1.20.6
 RUN curl -LO https://go.dev/dl/go$GOVERSION.linux-amd64.tar.gz
-RUN tar -C /usr/local -xvf go$GOVERSION.linux-amd64.tar.gz
+RUN tar -C /usr/local -xf go$GOVERSION.linux-amd64.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"
 
 RUN mkdir -p /opt/fraken/yara
 RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
 RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig 
 COPY tools/fraken/* /opt/fraken/
-# TODO(rbdebere): Rework to use musl-gcc for full static build! 
+# TODO(rbdebeer): Rework to use musl-gcc for full static build! 
 #RUN cd /opt/fraken && CGO_ENABLED=1 CC=musl-gcc go build --ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
 RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
 
 # Build 1 - Turbinia Worker
 FROM ubuntu:22.04 AS worker-builder
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_NO_CACHE_DIR=1
 
 ARG PPA_TRACK=stable
-
-ENV PIP_NO_CACHE_DIR=1
-ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     apt-transport-https \
@@ -102,23 +100,27 @@ RUN apt-get update && apt-get -y install \
     python3-dfvfs \
     python3-plaso \
     sleuthkit \
-#    --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60 \
-     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
 RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia
 
 # RUN pip3 install --no-cache-dir impacket --no-deps
 
-# Install fraken and yara rules.
+# Install yara rules and fraken.
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \
     && sudo chown -R turbinia:turbinia /opt/signature-base \
-    && find /opt/signature-base/ -type f ! -iname "*.yar*" -delete
+    && find /opt/signature/base -type f -not -iname '*.yar' -not -iname '*.yara' -not -iname 'file-type-signatures.txt' -delete
 COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 # Install fraken binary from multi-stage build 
 RUN mkdir -p /opt/fraken
 COPY --chown=turbinia:turbinia --from=fraken-builder /opt/fraken/fraken /opt/fraken/fraken
+
+# Install container-explorer
+RUN wget -O /tmp/container-explorer-setup.sh https://raw.githubusercontent.com/google/container-explorer/main/script/setup.sh
+RUN chmod +x /tmp/container-explorer-setup.sh
+RUN sudo /tmp/container-explorer-setup.sh install
 
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
     && mkdir -p /etc/turbinia/ && chown -R turbinia:turbinia /etc/turbinia/ \
@@ -135,11 +137,6 @@ RUN cp /home/turbinia/password.lst /root/
 
 # Copy Kubernetes support tool to home folder
 COPY --chown=turbinia:turbinia k8s/tools/check-lockfile.py /home/turbinia/check-lockfile.py
-
-# Install container-explorer
-RUN wget -O /tmp/container-explorer-setup.sh https://raw.githubusercontent.com/google/container-explorer/main/script/setup.sh
-RUN chmod +x /tmp/container-explorer-setup.sh
-RUN sudo /tmp/container-explorer-setup.sh install
 
 ADD . /tmp/
 # unshallow and fetch all tags so our build systems pickup the correct git tag if it's a shallow clone

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,4 +1,29 @@
 FROM ubuntu:22.04
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
+    automake \
+    curl \
+    dh-autoreconf \
+    gcc \
+    golang-1.20 \
+    go-bindata \
+    libjemalloc-dev \
+    libprotobuf-c-dev \
+    libssl-dev \
+    libtool \
+    make \
+    pkg-config \
+    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/fraken/yara
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 \
+    && cd /opt/fraken/yara && ./bootstrap.sh \
+    && ./configure \
+    && make && sudo make install && sudo ldconfig \
+    && cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static -extldflags=-ljemalloc" -o fraken \
+    && find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
+
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Use: docker build --no-cache --build-arg PPA_TRACK="[staging|stable]"
 ARG PPA_TRACK=stable
@@ -98,16 +123,9 @@ RUN cd /opt \
 
 COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
-RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
-COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 \
-    && cd /opt/fraken/yara && ./bootstrap.sh \
-    && ./configure \
-    && make && sudo make install && sudo ldconfig \
-    && cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static -extldflags=-ljemalloc" -o fraken \
-    && find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
-
-RUN ls -al /opt/fraken
+# copy fraken in
+RUN mkdir -p /opt/fraken
+COPY --chown=turbinia:turbinia --from=0 /opt/fraken/fraken /opt/fraken/fraken
 
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
     && mkdir -p /etc/turbinia/ && chown -R turbinia:turbinia /etc/turbinia/ \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -31,7 +31,7 @@ RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make in
 COPY tools/fraken/* /opt/fraken/
 # TODO(rbdebeer): Rework to use musl-gcc for full static build! 
 #RUN cd /opt/fraken && CGO_ENABLED=1 CC=musl-gcc go build --ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
-RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
+RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc -extldflags=-static" -tags yara_static -o fraken 
 
 # Build 1 - Turbinia Worker
 FROM ubuntu:22.04 AS worker-builder

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -145,7 +145,7 @@ COPY --chown=turbinia:turbinia k8s/tools/check-lockfile.py /home/turbinia/check-
 # install turbinia and cleanup /tmp
 ADD . /tmp/
 RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi \
-    && cd /tmp/ && python3 setup.py install \
+    && cd /tmp/ && python3 setup.py install
 
 COPY docker/worker/start.sh /home/turbinia/start.sh
 RUN chmod +rwx /home/turbinia/start.sh

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -37,7 +37,8 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     sudo \
     testdisk \
     wget \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
 
 # Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
 RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
@@ -81,7 +82,8 @@ RUN apt-get update && apt-get -y install \
     python3-plaso \
     sleuthkit \
     --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60 \
-     && apt-get clean && rm -rf /var/lib/apt/lists/*
+     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
 
 
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
@@ -91,21 +93,19 @@ RUN pip3 install --no-cache-dir impacket --no-deps
 
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \
-    && sudo chown -R turbinia:turbinia /opt/signature-base
-# Cleanup folder as Fraken only uses rules with .yar or .yara extensions
-RUN find /opt/signature-base/ -type f ! -iname "*.yar*" -delete
+    && sudo chown -R turbinia:turbinia /opt/signature-base \
+    && find /opt/signature-base/ -type f ! -iname "*.yar*" -delete
 
 COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 RUN mkdir -p /opt/fraken/yara && chown -R turbinia:turbinia /opt/fraken
 COPY --chown=turbinia:turbinia tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
-RUN cd /opt/fraken/yara && ./bootstrap.sh \
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 \
+    && cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
-    && make && sudo make install && sudo ldconfig
-RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc" -o fraken
-#  Cleanup fraken build folder and yara library source
-RUN find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
+    && make && sudo make install && sudo ldconfig \
+    && cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc" -o fraken \
+    && find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
 
 
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
@@ -132,10 +132,10 @@ RUN sudo /tmp/container-explorer-setup.sh install
 
 ADD . /tmp/
 # unshallow and fetch all tags so our build systems pickup the correct git tag if it's a shallow clone
-RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi
-RUN cd /tmp/ && python3 setup.py install
-# Cleanup /tmp folder (including dot files)
-RUN find /tmp/ -mindepth 1 -delete
+# install turbinia and cleanup /tmp
+RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi \
+    && cd /tmp/ && python3 setup.py install \
+    && find /tmp/ -mindepth 1 -delete
 
 COPY docker/worker/start.sh /home/turbinia/start.sh
 RUN chmod +rwx /home/turbinia/start.sh

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Add a symlink as we install the non-default golang compiler
+# Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
 RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
 
 ADD requirements.txt /tmp/
@@ -63,8 +63,6 @@ RUN pip3 install --no-cache-dir dfDewey
 #   Plaso
 #   Sleuthkit
 
-RUN curl -sS https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3ed1eaece81894b171d7da5b5e80511b10c598b8 | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gift.gpg
-#RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get -y install \
     bulk-extractor \
@@ -83,6 +81,7 @@ RUN apt-get update && apt-get -y install \
     sleuthkit \
     --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60
 
+# Cleanup apt files
 RUN apt-get clean
 
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
@@ -93,6 +92,8 @@ RUN pip3 install --no-cache-dir impacket --no-deps
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \
     && sudo chown -R turbinia:turbinia /opt/signature-base
+# Cleanup folder as Fraken only uses rules with .yar or .yara extensions
+RUN find /opt/signature-base/ -type f ! -iname "*.yar*" -delete
 
 COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
@@ -103,6 +104,9 @@ RUN cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig
 RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc" -o fraken
+#  Cleanup fraken build folder and yara library source
+RUN find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
+
 
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
     && mkdir -p /etc/turbinia/ && chown -R turbinia:turbinia /etc/turbinia/ \
@@ -130,6 +134,8 @@ ADD . /tmp/
 # unshallow and fetch all tags so our build systems pickup the correct git tag if it's a shallow clone
 RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi
 RUN cd /tmp/ && python3 setup.py install
+# Cleanup /tmp folder (including dot files)
+RUN find /tmp/ -mindepth 1 -delete
 
 COPY docker/worker/start.sh /home/turbinia/start.sh
 RUN chmod +rwx /home/turbinia/start.sh

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -3,9 +3,11 @@ FROM ubuntu:22.04
 # Use: docker build --no-cache --build-arg PPA_TRACK="[staging|stable]"
 ARG PPA_TRACK=stable
 
+ENV PIP_NO_CACHE_DIR=1
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get -y upgrade
-RUN apt-get -y install \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update && apt-get -y upgrade &&
+    apt-get -y install \
     apt-transport-https \
     apt-utils \
     automake \
@@ -14,7 +16,7 @@ RUN apt-get -y install \
     dh-autoreconf \
     gcc \
     git \
-    golang \
+    golang-1.20 \
     gpg \
     go-bindata \
     john \
@@ -63,7 +65,8 @@ RUN pip3 install dfDewey
 RUN curl -sS https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3ed1eaece81894b171d7da5b5e80511b10c598b8 | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gift.gpg
 #RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
-RUN apt-get update && apt-get -y install \
+RUN --mount=type=cache,target=/var/cache/apt \ 
+    apt-get update && apt-get -y install \
     bulk-extractor \
     dfimagetools-tools \
     docker-explorer-tools \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -146,7 +146,6 @@ COPY --chown=turbinia:turbinia k8s/tools/check-lockfile.py /home/turbinia/check-
 ADD . /tmp/
 RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi \
     && cd /tmp/ && python3 setup.py install \
-    && rm -fr /tmp/.git
 
 COPY docker/worker/start.sh /home/turbinia/start.sh
 RUN chmod +rwx /home/turbinia/start.sh

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,3 +1,5 @@
+# Multi-stage build
+# Build 0 - fraken
 FROM ubuntu:22.04
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     automake \
@@ -12,16 +14,17 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     libtool \
     make \
     pkg-config \
-    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+    sudo 
+# Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
+RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
 
 RUN mkdir -p /opt/fraken/yara
-RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 \
-    && cd /opt/fraken/yara && ./bootstrap.sh \
-    && ./configure \
-    && make && sudo make install && sudo ldconfig \
-    && cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static -extldflags=-ljemalloc" -o fraken \
-    && find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
+RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig 
+COPY tools/fraken/* /opt/fraken/
+RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static -extldflags=-ljemalloc" -o fraken 
 
+# Build 1 - Turbinia Worker
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -52,9 +55,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     wget \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-
-# Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
-RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
 
 ADD requirements.txt /tmp/
 RUN cd /tmp/ && pip3 install --no-cache-dir -r requirements.txt
@@ -96,8 +96,6 @@ RUN apt-get update && apt-get -y install \
     sleuthkit \
     --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60 \
      && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
-
-
 
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
 RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -14,11 +14,11 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     libtool \
     make \
     pkg-config \
-    sudo 
+    sudo \
  #   musl-dev \
- #   musl-tools
-# Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
-#RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
+ #   musl-tools \
+    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+
 
 # Install latest golang as ubuntu base image provides outdated version.
 ARG GOVERSION=1.20.6
@@ -64,7 +64,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     wget \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
-
 ADD requirements.txt /tmp/
 RUN cd /tmp/ && pip3 install --no-cache-dir -r requirements.txt
 
@@ -74,8 +73,8 @@ RUN pip3 install --no-cache-dir urllib3 cryptography --upgrade
 
 # Install third-party worker dependencies
 RUN pip3 install --no-cache-dir dfDewey
-# TODO(hacktobeer) uncomment when protobuf lib dependency if fixed upstream
-# RUN pip3 install pyhindsight
+RUN pip3 install --no-cache-dir pyhindsight
+RUN pip3 install --no-cache-dir impacket --no-deps
 
 # Install various packages from the GIFT PPA
 #   bulkextractor
@@ -103,22 +102,21 @@ RUN apt-get update && apt-get -y install \
     python3-dfvfs \
     python3-plaso \
     sleuthkit \
-    --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60 \
+#    --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60 \
      && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
 RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia
 
-RUN pip3 install --no-cache-dir impacket --no-deps
+# RUN pip3 install --no-cache-dir impacket --no-deps
 
+# Install fraken and yara rules.
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \
     && sudo chown -R turbinia:turbinia /opt/signature-base \
     && find /opt/signature-base/ -type f ! -iname "*.yar*" -delete
-
 COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
-
-# copy fraken in
+# Install fraken binary from multi-stage build 
 RUN mkdir -p /opt/fraken
 COPY --chown=turbinia:turbinia --from=fraken-builder /opt/fraken/fraken /opt/fraken/fraken
 
@@ -129,7 +127,7 @@ RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia
     && chown -R turbinia:turbinia /var/log/turbinia/ \
     && mkdir -p /home/turbinia && chown -R turbinia:turbinia /home/turbinia
 
-# Get a decent password list
+# Get a decent password list for john/hashcat
 RUN cd /home/turbinia && echo "" > password.lst
 RUN cd /home/turbinia && curl -s https://raw.githubusercontent.com/danielmiessler/SecLists/285474cf9bff85f3323c5a1ae436f78acd1cb62c/Passwords/UserPassCombo-Jay.txt >> password.lst
 RUN cd /home/turbinia && curl -s https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10-million-password-list-top-1000000.txt >> password.lst

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -146,7 +146,7 @@ COPY --chown=turbinia:turbinia k8s/tools/check-lockfile.py /home/turbinia/check-
 ADD . /tmp/
 RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi \
     && cd /tmp/ && python3 setup.py install \
-    && find /tmp/ -mindepth 1 -delete
+    && rm -fr /tmp/.git
 
 COPY docker/worker/start.sh /home/turbinia/start.sh
 RUN chmod +rwx /home/turbinia/start.sh

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -111,7 +111,7 @@ RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \
     && sudo chown -R turbinia:turbinia /opt/signature-base \
-    && find /opt/signature/base -type f -not -iname '*.yar' -not -iname '*.yara' -not -iname 'file-type-signatures.txt' -delete
+    && find /opt/signature-base -type f -not -iname '*.yar' -not -iname '*.yara' -not -iname 'file-type-signatures.txt' -delete
 COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 # Install fraken binary from multi-stage build 
 RUN mkdir -p /opt/fraken

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -5,8 +5,7 @@ ARG PPA_TRACK=stable
 
 ENV PIP_NO_CACHE_DIR=1
 ENV DEBIAN_FRONTEND=noninteractive
-RUN --mount=type=cache,target=/var/cache/apt \
-    apt-get update && apt-get -y upgrade && apt-get -y install \
+RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     apt-transport-https \
     apt-utils \
     automake \
@@ -40,14 +39,14 @@ RUN --mount=type=cache,target=/var/cache/apt \
     && rm -rf /var/lib/apt/lists/*
 
 ADD requirements.txt /tmp/
-RUN cd /tmp/ && pip3 install -r requirements.txt
+RUN cd /tmp/ && pip3 install --no-cache-dir -r requirements.txt
 
-RUN pip3 install pip --upgrade
-RUN pip3 install requests --upgrade
-RUN pip3 install urllib3 cryptography --upgrade
+RUN pip3 install --no-cache-dir pip --upgrade
+RUN pip3 install --no-cache-dir requests --upgrade
+RUN pip3 install --no-cache-dir urllib3 cryptography --upgrade
 
 # Install third-party worker dependencies
-RUN pip3 install dfDewey
+RUN pip3 install --no-cache-dir dfDewey
 # TODO(hacktobeer) uncomment when protobuf lib dependency if fixed upstream
 # RUN pip3 install pyhindsight
 
@@ -64,8 +63,7 @@ RUN pip3 install dfDewey
 RUN curl -sS https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x3ed1eaece81894b171d7da5b5e80511b10c598b8 | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/gift.gpg
 #RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x5e80511b10c598b8 \
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
-RUN --mount=type=cache,target=/var/cache/apt \ 
-    apt-get update && apt-get -y install \
+RUN apt-get update && apt-get -y install \
     bulk-extractor \
     dfimagetools-tools \
     docker-explorer-tools \
@@ -82,10 +80,12 @@ RUN --mount=type=cache,target=/var/cache/apt \
     sleuthkit \
     --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60
 
+RUN apt-get clean
+
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
 RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia
 
-RUN pip3 install impacket --no-deps
+RUN pip3 install --no-cache-dir impacket --no-deps
 
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -38,6 +38,9 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
+# Add a symlink as we install the non-default golang compiler
+RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
+
 ADD requirements.txt /tmp/
 RUN cd /tmp/ && pip3 install --no-cache-dir -r requirements.txt
 

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -2,34 +2,51 @@
 # Use: docker build --no-cache --build-arg PPA_TRACK="[staging|stable] GOVERSION=[1.20.6|1.18|?]"
 
 # Build 0 - fraken
-FROM ubuntu:22.04 AS fraken-builder
-RUN apt-get update && apt-get -y upgrade && apt-get -y install \
-    automake \
-    curl \
-    dh-autoreconf \
-    gcc \
-    libjemalloc-dev \
-    libprotobuf-c-dev \
-    libssl-dev \
-    libtool \
-    make \
-    pkg-config \
-    sudo \
-    && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
+FROM golang:alpine AS fraken-builder
+RUN apk add --no-cache -t .build-deps \
+  autoconf \
+  automake \
+  bison \
+  build-base \
+  curl \
+  file \
+  file-dev \
+  flex \
+  git \
+  jansson \
+  jansson-dev \
+  jansson-static \
+  libc-dev \
+  libmagic \
+  libmagic-static \
+  libtool \
+  linux-headers \
+  openssl \
+  openssl-dev \
+  openssl-libs-static \
+  py3-setuptools \
+  python3 \
+  python3-dev \
+  sudo
+  
+RUN set -x \
+  && echo "Compiling Yara from source..." 
 
-
-# Install latest golang as ubuntu base image provides outdated version.
-ARG GOVERSION=1.20.6
-RUN curl -LO https://go.dev/dl/go$GOVERSION.linux-amd64.tar.gz
-RUN tar -C /usr/local -xf go$GOVERSION.linux-amd64.tar.gz
-ENV PATH="$PATH:/usr/local/go/bin"
-
-# Fetch and compile libyara and fraken
+# Fetch and compile libyara
 RUN mkdir -p /opt/fraken/yara
+WORKDIR /opt/fraken/yara 
 RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
-RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig
+RUN ./bootstrap.sh 
+RUN sync 
+RUN ./configure --with-crypto \
+  --enable-magic \
+  --enable-cuckoo 
+RUN make 
+RUN sudo make install 
+
+# Compile fraken statically
 COPY tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken && go build -a -v -ldflags="-linkmode=external  -extldflags=-ljemalloc -extldflags=-static" -tags yara_static -o fraken
+RUN cd /opt/fraken && GOOS=linux GOARCH=amd64 go build -a -v -ldflags="-linkmode=external -extldflags=-static" -installsuffix netgo -tags yara_static,osusergo,netgo -o fraken
 
 # Build 1 - Turbinia Worker
 FROM ubuntu:22.04 AS worker-builder
@@ -83,7 +100,6 @@ RUN pip3 install impacket --no-deps
 #   libluksde-tools
 #   Plaso
 #   Sleuthkit
-
 RUN add-apt-repository -y ppa:gift/$PPA_TRACK
 RUN apt-get update && apt-get -y install \
     bulk-extractor \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -104,9 +104,10 @@ RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://
     && cd /opt/fraken/yara && ./bootstrap.sh \
     && ./configure \
     && make && sudo make install && sudo ldconfig \
-    && cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc" -o fraken \
+    && cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static -extldflags=-ljemalloc" -o fraken \
     && find /opt/fraken/ -type f ! -iname "fraken" -delete && rm -fr /opt/fraken/yara
 
+RUN ls -al /opt/fraken
 
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
     && mkdir -p /etc/turbinia/ && chown -R turbinia:turbinia /etc/turbinia/ \
@@ -122,8 +123,7 @@ RUN cd /home/turbinia && curl -s https://raw.githubusercontent.com/danielmiessle
 RUN cp /home/turbinia/password.lst /root/
 
 # Copy Kubernetes support tool to home folder
-COPY k8s/tools/check-lockfile.py /home/turbinia/check-lockfile.py
-RUN chown turbinia:turbinia /home/turbinia/check-lockfile.py
+COPY --chown=turbinia:turbinia k8s/tools/check-lockfile.py /home/turbinia/check-lockfile.py
 
 # Install container-explorer
 RUN wget -O /tmp/container-explorer-setup.sh https://raw.githubusercontent.com/google/container-explorer/main/script/setup.sh

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -34,29 +34,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     apt-transport-https \
     apt-utils \
-    automake \
     ca-certificates \
     curl \
-    dh-autoreconf \
-    gcc \
     git \
-    golang-1.20 \
-    gpg \
-    go-bindata \
     john \
     john-data \
     hashcat \
     hashcat-data \
-    libjemalloc-dev \
     libleveldb1d \
     libleveldb-dev \
-    libprotobuf-c-dev \
-    libssl-dev \
     libterm-readline-gnu-perl \
-    libtool \
     lvm2 \
-    make \
-    pkg-config \
     python3-pip \
     software-properties-common \
     sudo \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -15,8 +15,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     make \
     pkg-config \
     sudo \
- #   musl-dev \
- #   musl-tools \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 
@@ -26,6 +24,7 @@ RUN curl -LO https://go.dev/dl/go$GOVERSION.linux-amd64.tar.gz
 RUN tar -C /usr/local -xf go$GOVERSION.linux-amd64.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"
 
+# Fetch and compile libyara and fraken
 RUN mkdir -p /opt/fraken/yara
 RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
 RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig 
@@ -63,16 +62,19 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 ADD requirements.txt /tmp/
-RUN cd /tmp/ && pip3 install --no-cache-dir -r requirements.txt
+RUN cd /tmp/ && pip3 install -r requirements.txt
 
-RUN pip3 install --no-cache-dir pip --upgrade
-RUN pip3 install --no-cache-dir requests --upgrade
-RUN pip3 install --no-cache-dir urllib3 cryptography --upgrade
+RUN pip3 install pip --upgrade
+RUN pip3 install requests --upgrade
+RUN pip3 install urllib3 cryptography --upgrade
 
-# Install third-party worker dependencies
-RUN pip3 install --no-cache-dir dfDewey
-RUN pip3 install --no-cache-dir pyhindsight
-RUN pip3 install --no-cache-dir impacket --no-deps
+# Install third-party dependencies
+#   dfwdewey
+#   pyhindsight
+#   impacket
+RUN pip3 install dfDewey
+RUN pip3 install pyhindsight
+RUN pip3 install impacket --no-deps
 
 # Install various packages from the GIFT PPA
 #   bulkextractor
@@ -102,12 +104,11 @@ RUN apt-get update && apt-get -y install \
     sleuthkit \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
+# Add turbinia user to system and sudoers
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
 RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia
 
-# RUN pip3 install --no-cache-dir impacket --no-deps
-
-# Install yara rules and fraken.
+# Install yara rules and fraken binary.
 RUN cd /opt \
     && git clone https://github.com/Neo23x0/signature-base.git \
     && sudo chown -R turbinia:turbinia /opt/signature-base \
@@ -122,6 +123,7 @@ RUN wget -O /tmp/container-explorer-setup.sh https://raw.githubusercontent.com/g
 RUN chmod +x /tmp/container-explorer-setup.sh
 RUN sudo /tmp/container-explorer-setup.sh install
 
+# Setup turbinia user folders and permissions
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
     && mkdir -p /etc/turbinia/ && chown -R turbinia:turbinia /etc/turbinia/ \
     && mkdir -p /var/log/turbinia/ && chown -R turbinia:turbinia /mnt/turbinia/ \
@@ -138,9 +140,10 @@ RUN cp /home/turbinia/password.lst /root/
 # Copy Kubernetes support tool to home folder
 COPY --chown=turbinia:turbinia k8s/tools/check-lockfile.py /home/turbinia/check-lockfile.py
 
-ADD . /tmp/
+# Install Turbinia
 # unshallow and fetch all tags so our build systems pickup the correct git tag if it's a shallow clone
 # install turbinia and cleanup /tmp
+ADD . /tmp/
 RUN if $(cd /tmp/ && git rev-parse --is-shallow-repository); then cd /tmp/ && git fetch --prune --unshallow && git fetch --depth=1 origin +refs/tags/*:refs/tags/*; fi \
     && cd /tmp/ && python3 setup.py install \
     && find /tmp/ -mindepth 1 -delete

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build
 # Build 0 - fraken
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS fraken-builder
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     automake \
     curl \
@@ -15,6 +15,8 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     make \
     pkg-config \
     sudo 
+ #   musl-dev \
+ #   musl-tools
 # Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
 RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
 
@@ -22,10 +24,12 @@ RUN mkdir -p /opt/fraken/yara
 RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
 RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig 
 COPY tools/fraken/* /opt/fraken/
-RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static -extldflags=-ljemalloc" -o fraken 
+#RUN cd /opt/fraken && CGO_ENABLED=1 CC=musl-gcc go build --ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
+RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
+RUN ldd /opt/fraken/fraken
 
 # Build 1 - Turbinia Worker
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS worker-builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Use: docker build --no-cache --build-arg PPA_TRACK="[staging|stable]"
@@ -111,7 +115,7 @@ COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
 
 # copy fraken in
 RUN mkdir -p /opt/fraken
-COPY --chown=turbinia:turbinia --from=0 /opt/fraken/fraken /opt/fraken/fraken
+COPY --chown=turbinia:turbinia --from=fraken-builder /opt/fraken/fraken /opt/fraken/fraken
 
 RUN mkdir /etc/turbinia && mkdir -p /mnt/turbinia/ && mkdir -p /var/lib/turbinia/ \
     && mkdir -p /etc/turbinia/ && chown -R turbinia:turbinia /etc/turbinia/ \

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -5,6 +5,7 @@ ARG PPA_TRACK=stable
 
 ENV PIP_NO_CACHE_DIR=1
 ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     apt-transport-https \
     apt-utils \
@@ -36,7 +37,7 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     sudo \
     testdisk \
     wget \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
 RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
@@ -79,10 +80,9 @@ RUN apt-get update && apt-get -y install \
     python3-dfvfs \
     python3-plaso \
     sleuthkit \
-    --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60
+    --option Acquire::ForceIPv4=true --option Acquire::Retries=100 --option Acquire::http::Timeout=60 \
+     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Cleanup apt files
-RUN apt-get clean
 
 RUN useradd -r -s /bin/nologin -G disk,sudo -u 999 turbinia
 RUN echo "turbinia ALL = (root) NOPASSWD: ALL" > /etc/sudoers.d/turbinia

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -1,4 +1,6 @@
 # Multi-stage build
+# Use: docker build --no-cache --build-arg PPA_TRACK="[staging|stable] GOVERSION=[1.20.6|1.18|?]"
+
 # Build 0 - fraken
 FROM ubuntu:22.04 AS fraken-builder
 RUN apt-get update && apt-get -y upgrade && apt-get -y install \
@@ -6,8 +8,6 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
     curl \
     dh-autoreconf \
     gcc \
-    golang-1.20 \
-    go-bindata \
     libjemalloc-dev \
     libprotobuf-c-dev \
     libssl-dev \
@@ -18,21 +18,26 @@ RUN apt-get update && apt-get -y upgrade && apt-get -y install \
  #   musl-dev \
  #   musl-tools
 # Add a symlink as we install the non-default golang 1.20 compiler (latest for 22.04)
-RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
+#RUN ln -s /usr/lib/go-1.20/bin/go /usr/bin/go
+
+# Install latest golang as ubuntu base image provides outdated version.
+ARG GOVERSION=1.20.6
+RUN curl -LO https://go.dev/dl/go$GOVERSION.linux-amd64.tar.gz
+RUN tar -C /usr/local -xvf go$GOVERSION.linux-amd64.tar.gz
+ENV PATH="$PATH:/usr/local/go/bin"
 
 RUN mkdir -p /opt/fraken/yara
 RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
 RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig 
 COPY tools/fraken/* /opt/fraken/
+# TODO(rbdebere): Rework to use musl-gcc for full static build! 
 #RUN cd /opt/fraken && CGO_ENABLED=1 CC=musl-gcc go build --ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
 RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
-RUN ldd /opt/fraken/fraken
 
 # Build 1 - Turbinia Worker
 FROM ubuntu:22.04 AS worker-builder
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Use: docker build --no-cache --build-arg PPA_TRACK="[staging|stable]"
 ARG PPA_TRACK=stable
 
 ENV PIP_NO_CACHE_DIR=1

--- a/docker/worker/Dockerfile
+++ b/docker/worker/Dockerfile
@@ -26,12 +26,10 @@ ENV PATH="$PATH:/usr/local/go/bin"
 
 # Fetch and compile libyara and fraken
 RUN mkdir -p /opt/fraken/yara
-RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1 
-RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig 
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
+RUN cd /opt/fraken/yara && ./bootstrap.sh && ./configure && make && sudo make install && sudo ldconfig
 COPY tools/fraken/* /opt/fraken/
-# TODO(rbdebeer): Rework to use musl-gcc for full static build! 
-#RUN cd /opt/fraken && CGO_ENABLED=1 CC=musl-gcc go build --ldflags="-linkmode=external -extldflags=-static" -tags yara_static -o fraken 
-RUN cd /opt/fraken && go build -ldflags="-linkmode=external -extldflags=-ljemalloc -extldflags=-static" -tags yara_static -o fraken 
+RUN cd /opt/fraken && go build -a -v -ldflags="-linkmode=external  -extldflags=-ljemalloc -extldflags=-static" -tags yara_static -o fraken
 
 # Build 1 - Turbinia Worker
 FROM ubuntu:22.04 AS worker-builder


### PR DESCRIPTION
### Description of the change
Optimize Turbinia worker docker image and bring size down with 32%. From 1.15 GB to 780MB.

* Bundle RUN requests including apt cleanup
* Disable pip caching
* Refactor out fraken build in different multi-stage build with latest golang to minimize vulnerability alerts
* Cleanup several git pulled folders
* remove apt installed libs not needed anymore due to above optimizations
* add more extensive comments and restructure RUN blocks more logically

Some smaller Turbinia server docker image updates.

### Applicable issues
Turbinia worker docker image was large. 

<!-- Enter any applicable Issues here (You can reference an issue using #) -->


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.

