### PR TITLE
Validate newly created evidence output files after processing

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -978,7 +978,7 @@ class PlasoFile(Evidence):
     total_file_events = 0
 
     try:
-      log.info('Running pinfo.py to validate Plaso file')
+      log.info(f'Running pinfo.py to validate PlasoFile {self.local_path}')
       command = subprocess.run(cmd, capture_output=True, check=True)
       storage_counters_json = command.stdout.decode('utf-8').strip()
       storage_counters = json.loads(storage_counters_json)
@@ -987,7 +987,7 @@ class PlasoFile(Evidence):
       log.info(f'pinfo.py found {total_file_events} events.')
       if not total_file_events:
         raise TurbiniaException(
-            'PlasoFile validation failed, pinfo found no events.')
+            'PlasoFile validation failed, pinfo.py found no events.')
     except subprocess.CalledProcessError as exception:
       raise TurbiniaException(
           f'Error validating plaso file: {exception!s}') from exception

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -546,6 +546,14 @@ class Evidence:
       output.append(f'{state.name:s}: {value!s}')
     return f"[{', '.join(output):s}]"
 
+  def _validate(self):
+    """Runs additional logic to validate evidence requirements.
+    
+    Evidence subclasses can override this method to perform custom
+    validation of evidence objects.
+    """
+    pass
+
   def validate(self):
     """Runs validation to verify evidence meets minimum requirements.
 
@@ -565,6 +573,8 @@ class Evidence:
             '{1:s} is not set. Please check original request.'.format(
                 attribute, self.type))
         raise TurbiniaException(message)
+
+    self._validate()
 
 
 class EvidenceCollection(Evidence):
@@ -966,7 +976,12 @@ class PlasoFile(Evidence):
     self.copyable = True
     self.plaso_version = plaso_version
 
-  def validate(self):
+  def _validate(self):
+    """Validates whether the Plaso file contains any events.
+    
+    Raises:
+      TurbiniaException: if validation fails.
+    """
     cmd = [
         'pinfo.py',
         '--output-format',

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -49,7 +49,7 @@ def GetDiskSize(source_path):
   Returns:
     int: the size of the disk in bytes.
   """
-  size = None
+  size = 0
 
   if not os.path.exists(source_path):
     log.error(
@@ -57,21 +57,22 @@ def GetDiskSize(source_path):
     return None
 
   cmd = ['blockdev', '--getsize64', source_path]
-  log.info(f'Running {cmd!s}')
+  log.info(f'Getting evidence size via {cmd!s}')
 
   # Run blockdev first, this will fail if evidence is not a block device
   try:
     cmd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).split()
     size = int(cmd_output[0].decode('utf-8'))
   except subprocess.CalledProcessError:
-    log.debug('blockdev failed, attempting to get file size')
+    log.warning('blockdev failed, attempting to get file size')
   except ValueError:
-    log.debug(
+    log.warning(
         f"Unexpected output from blockdev: {cmd_output[0].decode('utf-8'):s}")
 
-  if size is None:
+  if not size:
     # evidence is not a block device, check image file size
     try:
+      log.info('Getting evidence size using stat()')
       size = os.stat(source_path).st_size
     except OSError as exception:
       log.warning(f'Checking disk size failed: {exception!s}')

--- a/turbinia/processors/mount_local.py
+++ b/turbinia/processors/mount_local.py
@@ -64,7 +64,8 @@ def GetDiskSize(source_path):
     cmd_output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).split()
     size = int(cmd_output[0].decode('utf-8'))
   except subprocess.CalledProcessError:
-    log.warning('blockdev failed, attempting to get file size')
+    log.debug(
+        'blockdev failed, attempting to get file size using stat() instead')
   except ValueError:
     log.warning(
         f"Unexpected output from blockdev: {cmd_output[0].decode('utf-8'):s}")
@@ -72,7 +73,6 @@ def GetDiskSize(source_path):
   if not size:
     # evidence is not a block device, check image file size
     try:
-      log.info('Getting evidence size using stat()')
       size = os.stat(source_path).st_size
     except OSError as exception:
       log.warning(f'Checking disk size failed: {exception!s}')

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -102,7 +102,7 @@ class TurbiniaTaskResult:
           be used to order report sections.
       request_id (str): The id of the initial request to process this evidence.
       run_time (datetime): Length of time the task ran for.
-      saved_Fpaths (list(str)): Paths where output has been saved.
+      saved_paths (list(str)): Paths where output has been saved.
       status (str): A one line descriptive task status.
       successful (bool): Indicates success status.
       task_id (str): Task ID of the parent task.

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -767,7 +767,7 @@ class TurbiniaTask:
           except TurbiniaException as exception:
             message = (
                 f'Not adding evidence {evidence.local_path} from task '
-                f'{result.task_name}:{result.task_id} because evidence '
+                f'{result.task_name}:{result.task_id}. Evidence '
                 f'validation failed with error: {exception!s}')
             result.log(message, level=logging.INFO)
       if close:

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -760,6 +760,11 @@ class TurbiniaTask:
               'Evidence {0:s} source_path {1:s} is empty. Not returning '
               'empty new Evidence.'.format(evidence.name, evidence.source_path))
           result.log(message, level=logging.WARN)
+        elif not evidence.validate():
+          message = (
+              f'Not running {result.task_name}:{result.task_id} because '
+              f'evidence validation failed.')
+          result.log(message, level=logging.INFO)
         else:
           result.add_evidence(evidence, self._evidence_config)
 

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -102,7 +102,7 @@ class TurbiniaTaskResult:
           be used to order report sections.
       request_id (str): The id of the initial request to process this evidence.
       run_time (datetime): Length of time the task ran for.
-      saved_paths (list(str)): Paths where output has been saved.
+      saved_Fpaths (list(str)): Paths where output has been saved.
       status (str): A one line descriptive task status.
       successful (bool): Indicates success status.
       task_id (str): Task ID of the parent task.
@@ -927,9 +927,10 @@ class TurbiniaTask:
           evidence.validate()
         except TurbiniaException as exception:
           validation_error = (
-              f'Not adding evidence {evidence.local_path}. Evidence '
+              f'Not adding evidence {evidence.source_path}. Evidence '
               f'validation failed with error: {exception!s}')
           result.evidence.remove(evidence)
+          result.saved_paths.remove(evidence.source_path)
       # Append evidence validation error messages to the result
       # so the client knows what happened
       if validation_error:

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -932,8 +932,9 @@ class TurbiniaTask:
           result.evidence.remove(evidence)
       # Append evidence validation error messages to the result
       # so the client knows what happened
-      result.log(validation_error)
-      result.status = f'{result.status}. {validation_error}'
+      if validation_error:
+        result.log(validation_error)
+        result.status = f'{result.status}. {validation_error}'
     else:
       # Handle any serialization type errors
       log.error(serialization_error)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -760,14 +760,16 @@ class TurbiniaTask:
               'Evidence {0:s} source_path {1:s} is empty. Not returning '
               'empty new Evidence.'.format(evidence.name, evidence.source_path))
           result.log(message, level=logging.WARN)
-        elif not evidence.validate():
-          message = (
-              f'Not running {result.task_name}:{result.task_id} because '
-              f'evidence validation failed.')
-          result.log(message, level=logging.INFO)
         else:
-          result.add_evidence(evidence, self._evidence_config)
-
+          try:
+            evidence.validate()
+            result.add_evidence(evidence, self._evidence_config)
+          except TurbiniaException as exception:
+            message = (
+                f'Not adding evidence {evidence.local_path} from task '
+                f'{result.task_name}:{result.task_id} because evidence '
+                f'validation failed with error: {exception!s}')
+            result.log(message, level=logging.INFO)
       if close:
         result.close(self, success=True)
 


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please add links for any issues that are related to this PR.
 -->

### Description of the change

This PR implements the ```validate``` method for PlasoFile evidence objects. Validation will fail if the Plaso file contains no events. Validation is done by invoking ```pinfo.py``` which should be available in Turbinia workers.

This change will avoid the inclusion of Plaso files with no events to tasks ```saved_paths``` and will not be added to the task results, so further processing will not happen for Plaso output files with no events.

I also included some small changes to logging and returning an integer size in mount_local.py

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1327

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
