### PR TITLE
Fixed issue of blank evidence name in the Web API 

### DIFF
--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -64,7 +64,6 @@ class testTurbiniaAPIServer(unittest.TestCase):
   _REQUEST_TEST_DATA = {
       'evidence_name': '/evidence/test.tgz',
       'failed_tasks': 0,
-      'task_start_time': '2022-04-01T19:15:14.791074Z',
       'last_task_update_time': '2022-04-01T19:17:14.791074Z',
       'queued_tasks': 0,
       'reason': None,
@@ -196,12 +195,12 @@ class testTurbiniaAPIServer(unittest.TestCase):
     self.assertEqual(expected_result, result)
 
   @mock.patch('turbinia.state_manager.RedisStateManager.get_task_data')
-  def testRequestEvidenceName(self, testTaskData):
-    """Test getting Turbinia Request evidence name."""
+  def testRequestEvidenceNoArgs(self, testTaskData):
+    """Test getting Turbinia Request evidence name without all_args."""
     redis_client = fakeredis.FakeStrictRedis()
-    self._TASK_TEST_DATA.pop('all_args')
     input_task = TurbiniaTask().deserialize(self._TASK_TEST_DATA)
     input_task_serialized = input_task.serialize()
+    input_task_serialized.pop('all_args')
     expected_result = self._REQUEST_TEST_DATA['evidence_name']
 
     redis_client.set(
@@ -214,8 +213,10 @@ class testTurbiniaAPIServer(unittest.TestCase):
     ]
 
     result = self.client.get('/api/request/summary')
-    result = json.loads(result.content).get('evidence_name')
-    self.assertEqual(expected_result, result)
+    result = json.loads(result.content)
+    evidence_name = result['requests_status'][0]['evidence_name']
+
+    self.assertEqual(expected_result, evidence_name)
 
   @mock.patch('turbinia.state_manager.RedisStateManager.get_task_data')
   def testRequestNotFound(self, testTaskData):

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -307,6 +307,7 @@ class RedisStateManager(BaseStateManager):
     task_data = self.get_task_dict(task)
     task_data['last_update'] = task_data['last_update'].strftime(
         DATETIME_FORMAT)
+    task_data['start_time'] = task_data['start_time'].strftime(DATETIME_FORMAT)
     # Need to use json.dumps, else redis returns single quoted string which
     # is invalid json
     if not self.client.set(key, json.dumps(task_data)):
@@ -318,6 +319,7 @@ class RedisStateManager(BaseStateManager):
     task_data = self.get_task_dict(task)
     task_data['last_update'] = task_data['last_update'].strftime(
         DATETIME_FORMAT)
+    task_data['start_time'] = task_data['start_time'].strftime(DATETIME_FORMAT)
     if not task_data.get('status'):
       task_data['status'] = 'Task scheduled at {0:s}'.format(
           datetime.now().strftime(DATETIME_FORMAT))

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -441,8 +441,9 @@ class TurbiniaTask:
 
   # The list of attributes that we will persist into storage
   STORED_ATTRIBUTES = [
-      'id', 'job_id', 'last_update', 'name', 'evidence_name', 'evidence_size',
-      'request_id', 'requester', 'group_name', 'reason', 'all_args', 'group_id'
+      'id', 'job_id', 'start_time', 'last_update', 'name', 'evidence_name',
+      'evidence_size', 'request_id', 'requester', 'group_name', 'reason',
+      'all_args', 'group_id'
   ]
 
   # The list of evidence states that are required by a Task in order to run.


### PR DESCRIPTION
### Description of the change

The name of the evidence for each request was appearing blank in the web API when the request had not "all_args", this should be fixed now. I also added one extra unit test to test this case.

### Applicable issues
Solved issue #1331

### Checklist
- [X] All tests were successful.
- [X] Unit tests added.