### PR TITLE
Reformatted the TaskMarkdownReport and the RequestMarkdownReport

### DIFF
--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -121,9 +121,14 @@ def get_jobs(ctx: click.Context) -> None:
 @click.pass_context
 @click.argument('request_id')
 @click.option(
+    '--show_all', '-a', help='Shows all field regardless of priority.',
+    is_flag=True, required=False)
+@click.option(
     '--json_dump', '-j', help='Generates JSON output.', is_flag=True,
     required=False)
-def get_request(ctx: click.Context, request_id: str, json_dump: bool) -> None:
+def get_request(
+    ctx: click.Context, request_id: str, show_all: bool,
+    json_dump: bool) -> None:
   """Gets Turbinia request status."""
   client: api_client.ApiClient = ctx.obj.api_client
   api_instance = turbinia_requests_api.TurbiniaRequestsApi(client)
@@ -137,7 +142,8 @@ def get_request(ctx: click.Context, request_id: str, json_dump: bool) -> None:
     if json_dump:
       formatter.echo_json(api_response)
     else:
-      report = formatter.RequestMarkdownReport(api_response).generate_markdown()
+      report = formatter.RequestMarkdownReport(api_response).generate_markdown(
+          show_all=show_all)
       click.echo(report)
   except exceptions.ApiException as exception:
     log.error(
@@ -180,9 +186,13 @@ def get_requests_summary(ctx: click.Context, json_dump: bool) -> None:
 @click.pass_context
 @click.argument('task_id')
 @click.option(
+    '--show_all', '-a', help='Shows all field regardless of priority.',
+    is_flag=True, required=False)
+@click.option(
     '--json_dump', '-j', help='Generates JSON output.', is_flag=True,
     required=False)
-def get_task(ctx: click.Context, task_id: str, json_dump: bool) -> None:
+def get_task(
+    ctx: click.Context, task_id: str, show_all: bool, json_dump: bool) -> None:
   """Gets Turbinia task status."""
   client: api_client.ApiClient = ctx.obj.api_client
   api_instance = turbinia_tasks_api.TurbiniaTasksApi(client)
@@ -191,7 +201,8 @@ def get_task(ctx: click.Context, task_id: str, json_dump: bool) -> None:
     if json_dump:
       formatter.echo_json(api_response)
     else:
-      report = formatter.TaskMarkdownReport(api_response).generate_markdown()
+      report = formatter.TaskMarkdownReport(api_response).generate_markdown(
+          show_all=show_all)
       click.echo(report)
   except exceptions.ApiException as exception:
     log.error(

--- a/turbinia/api/cli/turbinia_client/helpers/formatter.py
+++ b/turbinia/api/cli/turbinia_client/helpers/formatter.py
@@ -23,6 +23,10 @@ from click import echo as click_echo
 import logging
 import json
 
+MEDIUM_PRIORITY = 50
+HIGH_PRIORITY = 20
+CRITICAL_PRIORITY = 10
+
 log = logging.getLogger('turbinia')
 
 
@@ -183,34 +187,54 @@ class TaskMarkdownReport(MarkdownReportComponent):
     super().__init__()
     self._request_data: dict = request_data
 
-  def generate_markdown(self) -> str:
+  def generate_markdown(self, show_all=False, compact=False) -> str:
     """Generate a markdown report."""
     report: list[str] = []
     task: dict = self._request_data
     if not task:
       return ''
 
+    priority = task.get('report_priority') if task.get(
+        'report_priority') else MEDIUM_PRIORITY
+
+    if priority <= CRITICAL_PRIORITY:
+      name = f'{task.get("name")} ({"CRITICAL PRIORITY"})'
+    elif priority <= HIGH_PRIORITY:
+      name = f'{task.get("name")} ({"HIGH PRIORITY"})'
+    elif priority <= MEDIUM_PRIORITY:
+      name = f'{task.get("name")} ({"MEDIUM PRIORITY"})'
+    else:
+      name = f'{task.get("name")} ({"LOW PRIORITY"})'
+
     try:
-      report.append(self.heading2(task.get('name')))
+      report.append(self.heading2(name))
       line = f"{self.bold('Evidence:'):s} {task.get('evidence_name')!s}"
       report.append(self.bullet(line))
       line = f"{self.bold('Status:'):s} {task.get('status')!s}"
       report.append(self.bullet(line))
-      report.append(self.bullet(f"Task Id: {task.get('id')!s}"))
-      report.append(
-          self.bullet(f"Executed on worker {task.get('worker_name')!s}"))
-      if task.get('report_data'):
-        report.append('')
-        report.append(self.heading3('Task Reported Data'))
-        report.extend(task.get('report_data').splitlines())
-      report.append('')
-      report.append(self.heading3('Saved Task Files:'))
-
-      saved_paths = task.get('saved_paths')
-      if saved_paths:
-        for path in saved_paths:
-          report.append(self.bullet(self.code(path)))
+      if show_all or priority <= MEDIUM_PRIORITY:
+        report.append(self.bullet(f"Task Id: {task.get('id')!s}"))
+        report.append(
+            self.bullet(f"Executed on worker {task.get('worker_name')!s}"))
+      if show_all or priority <= HIGH_PRIORITY:
+        if task.get('report_data'):
+          if not compact:
+            report.append('')
+          report.append(self.heading3('Task Reported Data'))
+          report.extend(task.get('report_data').splitlines())
+        if not compact:
           report.append('')
+      if show_all or priority <= CRITICAL_PRIORITY:
+        if not compact:
+          report.append('')
+        report.append(self.heading3('Saved Task Files:'))
+        saved_paths = task.get('saved_paths')
+        if saved_paths:
+          for path in saved_paths:
+            report.append(self.bullet(self.code(path)))
+            if not compact:
+              report.append('')
+      report.append('')
     except TypeError as exception:
       log.warning(f'Error formatting the Markdown report: {exception!s}')
 
@@ -226,7 +250,10 @@ class RequestMarkdownReport(MarkdownReportComponent):
     super().__init__()
     self._request_data: dict = request_data
 
-    tasks = [TaskMarkdownReport(task) for task in request_data.get('tasks')]
+    sorted_tasks = sorted(
+        request_data.get('tasks'), key=lambda x: x['report_priority'])
+
+    tasks = [TaskMarkdownReport(task) for task in sorted_tasks]
     self.add_components(tasks)
 
   def add(self, component: MarkdownReportComponent) -> None:
@@ -244,7 +271,7 @@ class RequestMarkdownReport(MarkdownReportComponent):
         self.components.append(component)
         component.parent = self
 
-  def generate_markdown(self) -> str:
+  def generate_markdown(self, show_all=False) -> str:
     """Generates a Markdown version of Requests results."""
     report: list[str] = []
     request_dict: dict = self._request_data
@@ -278,7 +305,7 @@ class RequestMarkdownReport(MarkdownReportComponent):
       log.warning(f'Error formatting the Markdown report: {exception!s}')
 
     for task in self.components:
-      report.append(task.generate_markdown())
+      report.append(task.generate_markdown(show_all=show_all, compact=True))
 
     self.report = '\n'.join(report)
     return self.report


### PR DESCRIPTION
### Description of the change
The task markdown report in turbinia-client was reformatted to only show essential information for low-priority tasks. A new option, show_all (-a), has been added to the command to show all fields, regardless of priority. This change will also affect the tasks in the requests markdown report. Additionally, the requests report has been reformatted to order tasks by priority.
This is what the new `turbinia-client status request` output looks like:
![Screenshot 2023-08-29 9 51 32 AM](https://github.com/google/turbinia/assets/71235730/86f0205b-16ec-47e1-84d7-ba488915a777)

### Checklist
- [X] All tests were successful.
