### PR TITLE
Filter ContainerEnumeration output

### DIFF
--- a/k8s/tools/get-system-pods-list.py
+++ b/k8s/tools/get-system-pods-list.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to enumerate system pods.
+
+This is to generate a list of containers that we can filter out by default in
+the containr/docker enumeration tasks.
+"""
+
+import json
+import subprocess
+import sys
+
+if len(sys.argv) < 3:
+  print(
+      f'usage: {sys.argv[0]} <project> <cluster to list> [<zone if other than us-central-f>]'
+  )
+  sys.exit(1)
+
+project = sys.argv[1]
+cluster = sys.argv[2]
+if len(sys.argv) >= 4:
+  zone = sys.argv[3]
+else:
+  zone = 'us-central1-f'
+namespaces = {}
+
+# Authenticate to cluster
+auth_cmd = f'gcloud container clusters get-credentials {cluster} --zone {zone} --project {project}'
+print(f'Authenticating to project {project} cluster {cluster} zone {zone}')
+subprocess.check_call(auth_cmd.split(' '))
+
+# Get pods data
+cmd = f"kubectl get pods -o json -A"
+pods_data = subprocess.check_output(cmd.split(' '))
+pods_data = json.loads(pods_data)
+
+filtered_data = []
+
+for item in pods_data['items']:
+  if not item.get('metadata'):
+    continue
+
+  name = item.get('metadata').get('name')
+  namespace = item.get('metadata').get('namespace')
+
+  if namespace not in namespaces:
+    namespaces[namespace] = []
+
+  for container in item['spec']['containers']:
+    image = container["image"].split('@')[0]
+    image = image.split(':')[0]
+    namespaces[namespace].append(
+        f'Pod Name: {name}, Container Name: {container["name"]} Image: {image}')
+
+print()
+for namespace, containers in namespaces.items():
+  print(f'Namespace: {namespace}')
+  for container_info in containers:
+    print(f'\t{container_info}')

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -1266,11 +1266,15 @@ class ContainerdContainer(Evidence):
   REQUIRED_ATTRIBUTES = ['namespace', 'container_id']
   POSSIBLE_STATES = [EvidenceState.CONTAINER_MOUNTED]
 
-  def __init__(self, namespace=None, container_id=None, *args, **kwargs):
+  def __init__(
+      self, namespace=None, container_id=None, image_name=None,
+      pod_name=None, *args, **kwargs):
     """Initialization of containerd container."""
     super(ContainerdContainer, self).__init__(*args, **kwargs)
     self.namespace = namespace
     self.container_id = container_id
+    self.image_name = image_name if image_name else 'UnknownImageName'
+    self.pod_name = pod_name if pod_name else 'UnknownPodName'
     self._image_path = None
     self._container_fs_path = None
 
@@ -1282,9 +1286,12 @@ class ContainerdContainer(Evidence):
       return self._name
 
     if self.parent_evidence:
-      return ':'.join((self.parent_evidence.name, self.container_id))
+      return ':'.join((
+          self.parent_evidence.name, self.image_name,
+          self.pod_name, self.container_id))
     else:
-      return ':'.join((self.type, self.container_id))
+      return ':'.join((
+          self.type, self.image_name, self.pod_name, self.container_id))
 
   def _preprocess(self, _, required_states):
     if EvidenceState.CONTAINER_MOUNTED in required_states:

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -1267,8 +1267,8 @@ class ContainerdContainer(Evidence):
   POSSIBLE_STATES = [EvidenceState.CONTAINER_MOUNTED]
 
   def __init__(
-      self, namespace=None, container_id=None, image_name=None,
-      pod_name=None, *args, **kwargs):
+      self, namespace=None, container_id=None, image_name=None, pod_name=None,
+      *args, **kwargs):
     """Initialization of containerd container."""
     super(ContainerdContainer, self).__init__(*args, **kwargs)
     self.namespace = namespace
@@ -1287,11 +1287,11 @@ class ContainerdContainer(Evidence):
 
     if self.parent_evidence:
       return ':'.join((
-          self.parent_evidence.name, self.image_name,
-          self.pod_name, self.container_id))
+          self.parent_evidence.name, self.image_name, self.pod_name,
+          self.container_id))
     else:
-      return ':'.join((
-          self.type, self.image_name, self.pod_name, self.container_id))
+      return ':'.join(
+          (self.type, self.image_name, self.pod_name, self.container_id))
 
   def _preprocess(self, _, required_states):
     if EvidenceState.CONTAINER_MOUNTED in required_states:

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -194,7 +194,8 @@ class ContainerdEnumerationTask(TurbiniaTask):
         namespace = container.get('Namespace')
         container_id = container.get('ID')
         if container.get('Labels'):
-          pod_name = container.get('Labels').get(POD_NAME_LABEL, 'UnknownPodName')
+          pod_name = container.get('Labels').get(
+              POD_NAME_LABEL, 'UnknownPodName')
         else:
           pod_name = 'UnknownPodName'
         container_type = container.get('ContainerType') or None

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -189,6 +189,7 @@ class ContainerdEnumerationTask(TurbiniaTask):
           f'Found {len(container_ids)} containers: {", ".join(container_ids)}')
 
       # 2. Add containers as evidences
+      new_evidence = []
       for container in containers:
         namespace = container.get('Namespace')
         container_id = container.get('ID')
@@ -251,6 +252,7 @@ class ContainerdEnumerationTask(TurbiniaTask):
         container_evidence = ContainerdContainer(
             namespace=namespace, container_id=container_id,
             image_name=image_short, pod_name=pod_name)
+        new_evidence.append(container_evidence.name)
 
         result.add_evidence(container_evidence, evidence.config)
         result.log(
@@ -258,10 +260,8 @@ class ContainerdEnumerationTask(TurbiniaTask):
             f'type {container_type}')
 
       summary = (
-          f'Found {len(container_ids)} containers, added '
-          f'{len(filtered_container_list)} (filtered out '
-          f'{len(container_ids) - len(filtered_container_list)}): '
-          f'{", ".join(filtered_container_list)}')
+          f'Found {len(container_ids)} containers, added {len(new_evidence)} '
+          f'(filtered out {len(filtered_container_list)})')
       success = True
       if filtered_container_list:
         report_data.append(

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -44,10 +44,11 @@ class ContainerdEnumerationTask(TurbiniaTask):
       # ['gke.gcr.io/'] will filter out image `gke.gcr.io/event-exporter`.
       #
       # Which k8 namespaces to filter out by default
-      filter_namespaces: ['kube-system'],
-      filter_containers: ['sidecar', 'konnectivity-agent'],
-      # Taken from https://github.com/google/container-explorer/blob/main/supportcontainer.yaml
-      filter_images: [
+      'filter_namespaces': ['kube-system'],
+      'filter_containers': ['sidecar', 'konnectivity-agent'],
+      # Taken from
+      # https://github.com/google/container-explorer/blob/main/supportcontainer.yaml
+      'filter_images': [
           'gcr.io/gke-release-staging/cluster-proportional-autoscaler-amd64',
           'gcr.io/k8s-ingress-image-push/ingress-gce-404-server-with-metrics',
           'gke.gcr.io/cluster-proportional-autoscaler',
@@ -167,7 +168,9 @@ class ContainerdEnumerationTask(TurbiniaTask):
 
     image_path = evidence.mount_path
     if not image_path:
-      summary = f'Evidence {evidence.name}:{evidence.source_path} is not mounted'
+      summary = (
+          f'Evidence {evidence.name}:{evidence.source_path} is not '
+          'mounted')
       result.close(self, success=False, status=summary)
       return result
 
@@ -192,8 +195,8 @@ class ContainerdEnumerationTask(TurbiniaTask):
 
         if not namespace or not container_id:
           result.log(
-              f'Value is empty. namespace={namespace}, container_id={container_id}'
-          )
+              f'Value is empty. namespace={namespace}, '
+              f'container_id={container_id}')
           report_data.append(
               f'Skipping container with empty value namespace ({namespace})'
               f' or container_id ({container_id})')

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -191,8 +191,8 @@ class ContainerdEnumerationTask(TurbiniaTask):
       # 2. Add containers as evidences
       new_evidence = []
       for container in containers:
-        namespace = container.get('Namespace')
-        container_id = container.get('ID')
+        namespace = container.get('Namespace', 'UnknownNamespace')
+        container_id = container.get('ID', 'UnknownContainerID')
         if container.get('Labels'):
           pod_name = container.get('Labels').get(
               POD_NAME_LABEL, 'UnknownPodName')

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -194,12 +194,11 @@ class ContainerdEnumerationTask(TurbiniaTask):
         image = container.get('Image')
 
         if not namespace or not container_id:
-          result.log(
-              f'Value is empty. namespace={namespace}, '
-              f'container_id={container_id}')
-          report_data.append(
+          message = (
               f'Skipping container with empty value namespace ({namespace})'
               f' or container_id ({container_id})')
+          result.log(message)
+          report_data.append(message)
           continue
 
         # Filter out configured namespaces/containers/images
@@ -243,6 +242,10 @@ class ContainerdEnumerationTask(TurbiniaTask):
             namespace=namespace, container_id=container_id)
 
         result.add_evidence(container_evidence, evidence.config)
+        result.log(
+            f'Adding container evidence: id {container_id} '
+            f'name {container_name} type {container_type} image {image}')
+
       summary = (
           f'Found {len(container_ids)} containers: {", ".join(container_ids)}')
       success = True
@@ -251,8 +254,8 @@ class ContainerdEnumerationTask(TurbiniaTask):
             f'Filtered out {len(filtered_container_list)} containers: '
             f'{{", ".join(filtered_container_list)}}')
         report_data.append(
-            'To process filtered containers, adjust the ContainerEnumeration Task '
-            'filter* parameters with a recipe')
+            'To process filtered containers, adjust the ContainerEnumeration '
+            'Task config filter* parameters with a recipe')
     except TurbiniaException as e:
       summary = f'Error enumerating containerd containers: {e}'
       report_data.append(summary)

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -200,8 +200,11 @@ class ContainerdEnumerationTask(TurbiniaTask):
           pod_name = 'UnknownPodName'
         container_type = container.get('ContainerType') or None
         image = container.get('Image')
-        image_short = image.split('@')[0]
-        image_short = image_short.split(':')[0]
+        if image:
+          image_short = image.split('@')[0]
+          image_short = image_short.split(':')[0]
+        else:
+          image_short = 'UnknownImageName'
 
         if not namespace or not container_id:
           message = (

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -161,9 +161,9 @@ class ContainerdEnumerationTask(TurbiniaTask):
     summary = ''
     success = False
     report_data = []
-    filter_namespaces = self.task_conig.get('filter_namespaces')
-    filter_containers = self.task_conig.get('filter_containers')
-    filter_images = self.task_conig.get('filter_images')
+    filter_namespaces = self.task_config.get('filter_namespaces')
+    filter_containers = self.task_config.get('filter_containers')
+    filter_images = self.task_config.get('filter_images')
     filtered_container_list = []
 
     image_path = evidence.mount_path

--- a/turbinia/workers/containerd.py
+++ b/turbinia/workers/containerd.py
@@ -215,7 +215,7 @@ class ContainerdEnumerationTask(TurbiniaTask):
             continue
         if filter_images:
           image_short = image.split('@')[0]
-          image_short = image.split(':')[0]
+          image_short = image_short.split(':')[0]
           if image_short in filter_images:
             message = (
                 f'Filtering out image {image} because image matches filter')
@@ -255,7 +255,7 @@ class ContainerdEnumerationTask(TurbiniaTask):
       if filtered_container_list:
         report_data.append(
             f'Filtered out {len(filtered_container_list)} containers: '
-            f'{{", ".join(filtered_container_list)}}')
+            f'{", ".join(filtered_container_list)}')
         report_data.append(
             f'Container filter lists: Namespaces: {filter_namespaces}, Images: {filter_images}, '
             f'Containers: {filter_containers}')

--- a/turbinia/workers/containerd_test.py
+++ b/turbinia/workers/containerd_test.py
@@ -47,10 +47,12 @@ class ContainerdEnumerationTaskTest(TestTurbiniaTaskBase):
         {
             'Namespace': 'default',
             'ID': 'nginx01',
+            'Image': 'nginx01-image',
         },
         {
             'Namespace': 'default',
             'ID': 'apache01',
+            'Image': 'apache01-image',
         },
     ]
     result = self.task.run(self.evidence, self.result)


### PR DESCRIPTION
### Description of the change

Filters the output of ContainerEnumeration Task to remove any system containers and any containers with names or images that are known to be system related in order to reduce the Evidence/Task count noise with containers that we rarely will need to inspect.

Also:
* Has TASK_CONFIG vars for these filters so we can update them with a recipe
* Adds a  utility to list the namespaces and containers for a given cluster to make it easier to update this list in the future.
* Adds container evidence attributes for pod name and image name and includes them in the image name for readability

### Applicable issues

- fixes #1343 

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
