### PR TITLE
Add Fraken docker build file

### DIFF
--- a/tools/fraken/Dockerfile
+++ b/tools/fraken/Dockerfile
@@ -1,0 +1,60 @@
+# Build: docker build -t fraken -f tools/fraken/Dockerfile .
+# Run: docker run -ti fraken fraken -rules /opt/signature-base -folder /
+# Image: us-docker.pkg.dev/osdfir-registry/turbinia/release/fraken:latest
+
+FROM golang:alpine AS fraken-builder
+RUN apk add --no-cache -t .build-deps \
+  autoconf \
+  automake \
+  bison \
+  build-base \
+  curl \
+  file \
+  file-dev \
+  flex \
+  git \
+  jansson \
+  jansson-dev \
+  jansson-static \
+  libc-dev \
+  libmagic \
+  libmagic-static \
+  libtool \
+  linux-headers \
+  openssl \
+  openssl-dev \
+  openssl-libs-static \
+  py3-setuptools \
+  python3 \
+  python3-dev \
+  sudo
+
+RUN set -x \
+  && echo "Compiling Yara from source..."
+
+# Fetch and compile libyara
+RUN mkdir -p /opt/fraken/yara
+WORKDIR /opt/fraken/yara
+RUN cd /opt/fraken/yara && curl -s -L --retry 5 "$(curl -s -L --retry 5 https://api.github.com/repos/VirusTotal/Yara/releases/latest | sed -n 's/.*"tarball_url": "\(.*\)",.*/\1/p')"  | tar -xz --strip-components=1
+RUN ./bootstrap.sh
+RUN sync
+RUN ./configure --with-crypto \
+  --enable-magic \
+  --enable-cuckoo
+RUN make
+RUN sudo make install
+
+# Compile fraken statically
+COPY tools/fraken/* /opt/fraken/
+RUN cd /opt/fraken && GOOS=linux GOARCH=amd64 go build -a -v -ldflags="-linkmode=external -extldflags=-static" -installsuffix netgo -tags yara_static,osusergo,netgo -o fraken
+
+FROM alpine:3.18.4 AS fraken
+# Install yara rules and fraken binary.
+RUN apk add --no-cache -t .build-deps git
+RUN cd /opt \
+    && git clone https://github.com/Neo23x0/signature-base.git \
+    && find /opt/signature-base -type f -not -iname '*.yar' -not -iname '*.yara' -not -iname 'file-type-signatures.txt' -delete
+COPY turbinia/config/rules/*.yar /opt/signature-base/yara/
+#
+COPY --from=fraken-builder /opt/fraken/fraken /bin/fraken
+CMD ["fraken","-h"]

--- a/tools/fraken/README.md
+++ b/tools/fraken/README.md
@@ -3,18 +3,19 @@ This is a multithreaded Yara scanner.  It supports rules that make use of the ex
 Its main use is as part of Turbinia but it can be compiled and used standalone.
 
 Usage:
-`./<binary> -folder <path to scan> -rules <path to rules>`
+Run fraken from the docker image scanning a local folder
+
+`docker run -v /my/folder/path:/data -ti fraken fraken -rules /opt/signature-base -folder /data`
+
+Instead of a local image you can also use the public image located at 
+`us-docker.pkg.dev/osdfir-registry/turbinia/release/fraken:latest`
 
 Thanks to [Loki](https://github.com/Neo23x0/Loki), [Kraken](https://github.com/botherder/kraken) and [go-yara](https://github.com/hillu/go-yara)
 
-Needs Yara first, i.e:
+Docker build:
+Build the docker image using
 
-```
-sudo apt install gcc automake libtool make go-bindata dh-autoreconf libssl-dev
-wget https://github.com/VirusTotal/yara/archive/refs/tags/v4.2.1.tar.gz
-tar xvzf v4.2.1.tar.gz
-cd yara-4.2.1
-./bootstrap.sh
-./configure
-make && sudo make install && sudo ldconfig
-```
+`docker build -t fraken -f tools/fraken/Dockerfile .`
+
+
+

--- a/tools/fraken/README.md
+++ b/tools/fraken/README.md
@@ -3,6 +3,7 @@ This is a multithreaded Yara scanner.  It supports rules that make use of the ex
 Its main use is as part of Turbinia but it can be compiled and used standalone.
 
 Usage:
+
 Run fraken from the docker image scanning a local folder
 
 `docker run -v /my/folder/path:/data -ti fraken fraken -rules /opt/signature-base -folder /data`
@@ -13,9 +14,22 @@ Instead of a local image you can also use the public image located at
 Thanks to [Loki](https://github.com/Neo23x0/Loki), [Kraken](https://github.com/botherder/kraken) and [go-yara](https://github.com/hillu/go-yara)
 
 Docker build:
-Build the docker image using
 
 `docker build -t fraken -f tools/fraken/Dockerfile .`
 
+Compiling:
 
+Needs Yara first, i.e:
+
+```
+sudo apt install gcc automake libtool make go-bindata dh-autoreconf libssl-dev
+wget https://github.com/VirusTotal/yara/archive/refs/tags/v4.2.1.tar.gz
+tar xvzf v4.2.1.tar.gz
+cd yara-4.2.1
+./bootstrap.sh
+./configure --with-crypto --enable-magic --enable-cuckoo
+make && sudo make install && sudo ldconfig
+
+GOOS=linux GOARCH=amd64 go build -a -v -ldflags="-linkmode=external -extldflags=-static" -installsuffix netgo -tags yara_static,osusergo,netgo -o fraken
+```
 

--- a/tools/fraken/cloudbuild.yaml
+++ b/tools/fraken/cloudbuild.yaml
@@ -1,0 +1,19 @@
+# Google Cloud Build configuration for Turbinia worker release
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "us-docker.pkg.dev/osdfir-registry/turbinia/release/fraken:$TAG_NAME",
+        "-t",
+        "us-docker.pkg.dev/osdfir-registry/turbinia/release/fraken:latest",
+        "-f",
+        "tools/fraken/Dockerfile",
+        ".",
+      ]
+    timeout: 4800s
+timeout: 4800s
+images:
+  - us-docker.pkg.dev/osdfir-registry/turbinia/release/fraken:latest
+  - us-docker.pkg.dev/osdfir-registry/turbinia/release/fraken:$TAG_NAME


### PR DESCRIPTION
### Description of the change

Create a docker build file for Fraken (including cloud build configuration).

### Additional information

This will allow us:
* to run fraken standalone from a docker image
* to improve build simplicity and build speed for the worker (by copying in Fraken from existing image)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
- [x] Documentation updated.
