### PR TITLE
Update report filtering

### DIFF
--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -127,8 +127,10 @@ def get_jobs(ctx: click.Context) -> None:
     'shown in full detail in report output.  Any tasks that have set a '
     'report_priority value equal to or lower than this setting will be '
     'shown in full detail, and tasks with a higher value will only have '
-    'a summary shown.  To see all tasks report output in full detail, '
-    'set --priority_filter=100', is_flag=True, required=False)
+    'a summary shown.  The default is 20 which corresponds to "HIGH_PRIORITY"'
+    'To see all tasks report output in full detail, set --priority_filter=100 '
+    'or to see CRITICAL only set --priority_filter=10', is_flag=True, type=int,
+    default=80, required=False)
 @click.option(
     '--show_all', '-a', help='Shows all fields including saved output paths.',
     is_flag=True, required=False)

--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -130,7 +130,7 @@ def get_jobs(ctx: click.Context) -> None:
     'a summary shown.  The default is 20 which corresponds to "HIGH_PRIORITY"'
     'To see all tasks report output in full detail, set --priority_filter=100 '
     'or to see CRITICAL only set --priority_filter=10', show_default=True,
-    default=80, type=int, required=False)
+    default=20, type=int, required=False)
 @click.option(
     '--show_all', '-a', help='Shows all fields including saved output paths.',
     is_flag=True, required=False)

--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -129,8 +129,8 @@ def get_jobs(ctx: click.Context) -> None:
     'shown in full detail, and tasks with a higher value will only have '
     'a summary shown.  The default is 20 which corresponds to "HIGH_PRIORITY"'
     'To see all tasks report output in full detail, set --priority_filter=100 '
-    'or to see CRITICAL only set --priority_filter=10', is_flag=True, type=int,
-    default=80, required=False)
+    'or to see CRITICAL only set --priority_filter=10', show_default=True,
+    default=80, type=int, required=False)
 @click.option(
     '--show_all', '-a', help='Shows all fields including saved output paths.',
     is_flag=True, required=False)

--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -123,13 +123,20 @@ def get_jobs(ctx: click.Context) -> None:
 @click.pass_context
 @click.argument('request_id')
 @click.option(
-    '--show_all', '-a', help='Shows all field regardless of priority.',
+    '--priority_filter', '-p', help='This sets what report sections are '
+    'shown in full detail in report output.  Any tasks that have set a '
+    'report_priority value equal to or lower than this setting will be '
+    'shown in full detail, and tasks with a higher value will only have '
+    'a summary shown.  To see all tasks report output in full detail, '
+    'set --priority_filter=100', is_flag=True, required=False)
+@click.option(
+    '--show_all', '-a', help='Shows all fields including saved output paths.',
     is_flag=True, required=False)
 @click.option(
     '--json_dump', '-j', help='Generates JSON output.', is_flag=True,
     required=False)
 def get_request(
-    ctx: click.Context, request_id: str, show_all: bool,
+    ctx: click.Context, request_id: str, priority_filter: int, show_all: bool,
     json_dump: bool) -> None:
   """Gets Turbinia request status."""
   client: api_client.ApiClient = ctx.obj.api_client
@@ -145,7 +152,7 @@ def get_request(
       formatter.echo_json(api_response)
     else:
       report = formatter.RequestMarkdownReport(api_response).generate_markdown(
-          show_all=show_all)
+          priority_filter=priority_filter, show_all=show_all)
       click.echo(report)
   except exceptions.ApiException as exception:
     log.error(

--- a/turbinia/api/cli/turbinia_client/helpers/formatter.py
+++ b/turbinia/api/cli/turbinia_client/helpers/formatter.py
@@ -281,6 +281,7 @@ class TaskMarkdownReport(MarkdownReportComponent):
 
     priority = task.get('report_priority') if task.get(
         'report_priority') else MEDIUM_PRIORITY
+    priority_filter = priority_filter if priority_filter else HIGH_PRIORITY
 
     if priority <= CRITICAL_PRIORITY:
       name = f'{task.get("name")} ({"CRITICAL PRIORITY"})'
@@ -364,7 +365,7 @@ class RequestMarkdownReport(MarkdownReportComponent):
         self.components.append(component)
         component.parent = self
 
-  def generate_markdown(self, show_all=False) -> str:
+  def generate_markdown(self, priority_filter=None, show_all=False) -> str:
     """Generates a Markdown version of Requests results."""
     report: list[str] = []
     request_dict: dict = self._request_data
@@ -400,7 +401,9 @@ class RequestMarkdownReport(MarkdownReportComponent):
       log.warning(f'Error formatting the Markdown report: {exception!s}')
 
     for task in self.components:
-      report.append(task.generate_markdown(show_all=show_all, compact=True))
+      report.append(
+          task.generate_markdown(
+              priority_filter=priority_filter, show_all=show_all, compact=True))
 
     self.report = '\n'.join(report)
     return self.report

--- a/turbinia/api/cli/turbinia_client/helpers/formatter.py
+++ b/turbinia/api/cli/turbinia_client/helpers/formatter.py
@@ -363,7 +363,7 @@ class RequestMarkdownReport(MarkdownReportComponent):
     # Generate task list with counts
     for task in unique_tasks:
       if task_counter[task] > 1:
-        filtered_tasks.append(f'{task_counter[task]} x {task}')
+        filtered_tasks.append(f'{task} ({task_counter[task]}x)')
       else:
         filtered_tasks.append(task)
 

--- a/turbinia/api/cli/turbinia_client/helpers/formatter.py
+++ b/turbinia/api/cli/turbinia_client/helpers/formatter.py
@@ -295,7 +295,7 @@ class TaskMarkdownReport(MarkdownReportComponent):
       # Only show Task details if the Task has more priority than the
       # priority_filter
       if priority > priority_filter:
-        report.append(f'{self.heading2(name)}: {task.get('status')!s}')
+        report.append(f'{self.heading2(name)}: {task.get("status")!s}')
       else:
         report.append(self.heading2(name))
         line = f"{self.bold('Evidence:'):s} {task.get('evidence_name')!s}"

--- a/turbinia/api/cli/turbinia_client/helpers/formatter.py
+++ b/turbinia/api/cli/turbinia_client/helpers/formatter.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from click import echo as click_echo
 
+from collections import defaultdict
 import logging
 import json
 import pandas
@@ -345,10 +346,28 @@ class RequestMarkdownReport(MarkdownReportComponent):
     self._request_data: dict = request_data
 
     sorted_tasks = sorted(
-        request_data.get('tasks'), key=lambda x: x['report_priority'])
+        request_data.get('tasks'), key=lambda x:
+        (x['report_priority'], x['name']))
 
     tasks = [TaskMarkdownReport(task) for task in sorted_tasks]
-    self.add_components(tasks)
+    task_counter = defaultdict(int)
+    unique_tasks = []
+    filtered_tasks = []
+
+    # Get unique tasks and task counts
+    for task in tasks:
+      task_counter[task] += 1
+      if task not in unique_tasks:
+        unique_tasks.append(task)
+
+    # Generate task list with counts
+    for task in unique_tasks:
+      if task_counter[task] > 1:
+        filtered_tasks.append(f'{task_counter[task]} x {task}')
+      else:
+        filtered_tasks.append(task)
+
+    self.add_components(filtered_tasks)
 
   def add(self, component: MarkdownReportComponent) -> None:
     if component:


### PR DESCRIPTION
### Description of the change

* Adds `--priority_filter` so we can dynamically change which priorities we want to see full report data for (similar to old `turbiniactl` implementation).  
* Further reduces the details of things with lower priority so only one line is shown for anything with a low priority
* Changes the default priority of details shown from "MEDIUM" to "HIGH"
* Changes `--show_all` from showing all details for all tasks no matter the priority to showing extra saved path fields for the tasks that are higher priority than the priority filter. 
* Sorts tasks by name in addition to priority and aggregates task summaries with the same exact task status

### Applicable issues


### Additional information


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
