### PR TITLE
Add version command and decouple evidence requests

### DIFF
--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -17,9 +17,9 @@
 import os
 import logging
 import click
-import base64
-import mimetypes
 import tarfile
+
+from importlib.metadata import version as importlib_version
 
 from turbinia_api_lib import exceptions
 from turbinia_api_lib import api_client
@@ -274,95 +274,6 @@ def get_task(
         f'when calling get_task_status: {exception.body}')
 
 
-@click.pass_context
-def create_request(ctx: click.Context, *args: int, **kwargs: int) -> None:
-  """Creates and submits a new Turbinia request."""
-  client: api_client.ApiClient = ctx.obj.api_client
-  api_instance = turbinia_requests_api.TurbiniaRequestsApi(client)
-  evidence_name = ctx.command.name
-
-  # Normalize the evidence class name from lowercase to the original name.
-  evidence_name = ctx.obj.normalize_evidence_name(evidence_name)
-  # Build request and request_options objects to send to the API server.
-  request_options = list(ctx.obj.request_options.keys())
-  request = {'evidence': {'type': evidence_name}, 'request_options': {}}
-
-  if 'googlecloud' in evidence_name:
-    api_instance_config = turbinia_configuration_api.TurbiniaConfigurationApi(
-        client)
-    cloud_provider = api_instance_config.read_config()['CLOUD_PROVIDER']
-    if cloud_provider != 'GCP':
-      log.error(
-          f'The evidence type {evidence_name} is Google Cloud only and '
-          f'the configured provider for this Turbinia instance is '
-          f'{cloud_provider}.')
-      return
-
-  for key, value in kwargs.items():
-    # If the value is not empty, add it to the request.
-    if kwargs.get(key):
-      # Check if the key is for evidence or request_options
-      if not key in request_options:
-        request['evidence'][key] = value
-      elif key in ('jobs_allowlist', 'jobs_denylist'):
-        jobs_list = value.split(',')
-        request['request_options'][key] = jobs_list
-      else:
-        request['request_options'][key] = value
-
-  if all(key in request['request_options']
-         for key in ('recipe_name', 'recipe_data')):
-    log.error('You can only provide one of recipe_data or recipe_name')
-    return
-
-  recipe_name = request['request_options'].get('recipe_name')
-  if recipe_name:
-    if not recipe_name.endswith('.yaml'):
-      recipe_name = f'{recipe_name}.yaml'
-    # Fallback path for the recipe would be TURBINIA_CLI_CONFIG_PATH/recipe_name
-    # This is the same path where the client configuration is loaded from.
-    recipe_path_fallback = os.path.expanduser(ctx.obj.config_path)
-    recipe_path_fallback = os.path.join(recipe_path_fallback, recipe_name)
-
-    if os.path.isfile(recipe_name):
-      recipe_path = recipe_name
-    elif os.path.isfile(recipe_path_fallback):
-      recipe_path = recipe_path_fallback
-    else:
-      log.error(f'Unable to load recipe {recipe_name}.')
-      return
-
-    try:
-      with open(recipe_path, 'r', encoding='utf-8') as recipe_file:
-        # Read the file and convert to base64 encoded bytes.
-        recipe_bytes = recipe_file.read().encode('utf-8')
-        recipe_data = base64.b64encode(recipe_bytes)
-    except OSError as exception:
-      log.error(f'Error opening recipe file {recipe_path}: {exception}')
-      return
-    except TypeError as exception:
-      log.error(f'Error converting recipe data to Base64: {exception}')
-      return
-    # We found the recipe file, so we will send it to the API server
-    # via the recipe_data parameter. To do so, we need to pop recipe_name
-    # from the request so that we only have recipe_data.
-    request['request_options'].pop('recipe_name')
-    # recipe_data should be a UTF-8 encoded string.
-    request['request_options']['recipe_data'] = recipe_data.decode('utf-8')
-
-  # Send the request to the API server.
-  try:
-    log.info(f'Sending request: {request}')
-    api_response = api_instance.create_request(request)
-    log.info(f'Received response: {api_response}')
-  except exceptions.ApiException as exception:
-    log.error(
-        f'Received status code {exception.status} '
-        f'when calling create_request: {exception.body}')
-  except (TypeError, exceptions.ApiTypeError) as exception:
-    log.error(f'The request object is invalid. {exception}')
-
-
 @groups.evidence_group.command('summary')
 @click.pass_context
 @click.option(
@@ -514,3 +425,10 @@ def upload_evidence(
         formatter.EvidenceMarkdownReport({}).dict_to_markdown(
             report, 0, format_keys=False))
     click.echo(report)
+
+
+@click.command('version')
+def version():
+  """Returns the turbinia-client package distribution version."""
+  cli_version = importlib_version('turbinia-client')
+  click.echo(f'turbinia-client version {cli_version}')

--- a/turbinia/api/cli/turbinia_client/core/groups.py
+++ b/turbinia/api/cli/turbinia_client/core/groups.py
@@ -15,6 +15,13 @@
 """Turbinia API client command-line tool."""
 
 import click
+import logging
+import sys
+
+from turbinia_api_lib import exceptions
+from turbinia_client.factory import factory
+
+log = logging.getLogger('turbinia')
 
 
 @click.group('config')
@@ -42,6 +49,32 @@ def jobs_group():
   """Get a list of enabled Turbinia jobs."""
 
 
-@click.group('submit')
-def submit_group():
-  """Submit new requests to the Turbinia API server."""
+@click.pass_context
+def setup_submit(ctx: click.Context):
+  try:
+    ctx.obj.evidence_mapping = ctx.obj.get_evidence_arguments()
+    ctx.obj.request_options = ctx.obj.get_request_options()
+
+    # Build all the commands based on responses from the API server.
+    request_commands = factory.CommandFactory.create_dynamic_objects(
+        evidence_mapping=ctx.obj.evidence_mapping,
+        request_options=ctx.obj.request_options)
+    for command in request_commands:
+      submit_group.add_command(command)
+  except exceptions.ApiException as exception:
+    log.error(
+        'Error while attempting to contact the API server during setup: %s',
+        exception)
+    sys.exit(-1)
+
+
+@click.group('submit', chain=True, invoke_without_command=True)
+@click.pass_context
+def submit_group(ctx: click.Context):
+  """Submit new requests to the Turbinia API server.
+  
+  Please run this command without any arguments to view a list
+  of available evidence types.
+  """
+  ctx.invoke(setup_submit)
+  click.echo(submit_group.get_help(ctx))

--- a/turbinia/api/cli/turbinia_client/factory/factory.py
+++ b/turbinia/api/cli/turbinia_client/factory/factory.py
@@ -21,7 +21,6 @@ import logging
 import click
 
 from turbinia_client.helpers import click_helper
-from turbinia_client.core.commands import create_request
 
 T = TypeVar('T', bound='FactoryInterface')
 
@@ -147,7 +146,8 @@ class CommandFactory(FactoryInterface):
           request_options=request_options)
       OptionFactory.append_request_option_objects(params, request_options)
       cmd = CommandFactory.create_object(
-          name=evidence_name_lower, params=params, callback=create_request)
+          name=evidence_name_lower, params=params,
+          callback=click_helper.create_request)
       command_objects.append(cmd)
     return command_objects
 

--- a/turbinia/api/cli/turbinia_client/helpers/click_helper.py
+++ b/turbinia/api/cli/turbinia_client/helpers/click_helper.py
@@ -14,7 +14,19 @@
 # limitations under the License.
 """Turbinia API client command-line tool."""
 
+import os
+import logging
+import click
+import base64
+
 from typing import Tuple, Sequence
+from turbinia_api_lib.api import turbinia_configuration_api
+from turbinia_api_lib.api import turbinia_requests_api
+
+from turbinia_api_lib import exceptions
+from turbinia_api_lib import api_client
+
+log = logging.getLogger('turbinia')
 
 
 def generate_option_parameters(
@@ -23,3 +35,92 @@ def generate_option_parameters(
       name.
   """
   return ((['--' + option_name], option_name), {'required': False, 'type': str})
+
+
+@click.pass_context
+def create_request(ctx: click.Context, *args: int, **kwargs: int) -> None:
+  """Creates and submits a new Turbinia request."""
+  client: api_client.ApiClient = ctx.obj.api_client
+  api_instance = turbinia_requests_api.TurbiniaRequestsApi(client)
+  evidence_name = ctx.command.name
+
+  # Normalize the evidence class name from lowercase to the original name.
+  evidence_name = ctx.obj.normalize_evidence_name(evidence_name)
+  # Build request and request_options objects to send to the API server.
+  request_options = list(ctx.obj.request_options.keys())
+  request = {'evidence': {'type': evidence_name}, 'request_options': {}}
+
+  if 'googlecloud' in evidence_name:
+    api_instance_config = turbinia_configuration_api.TurbiniaConfigurationApi(
+        client)
+    cloud_provider = api_instance_config.read_config()['CLOUD_PROVIDER']
+    if cloud_provider != 'GCP':
+      log.error(
+          f'The evidence type {evidence_name} is Google Cloud only and '
+          f'the configured provider for this Turbinia instance is '
+          f'{cloud_provider}.')
+      return
+
+  for key, value in kwargs.items():
+    # If the value is not empty, add it to the request.
+    if kwargs.get(key):
+      # Check if the key is for evidence or request_options
+      if not key in request_options:
+        request['evidence'][key] = value
+      elif key in ('jobs_allowlist', 'jobs_denylist'):
+        jobs_list = value.split(',')
+        request['request_options'][key] = jobs_list
+      else:
+        request['request_options'][key] = value
+
+  if all(key in request['request_options']
+         for key in ('recipe_name', 'recipe_data')):
+    log.error('You can only provide one of recipe_data or recipe_name')
+    return
+
+  recipe_name = request['request_options'].get('recipe_name')
+  if recipe_name:
+    if not recipe_name.endswith('.yaml'):
+      recipe_name = f'{recipe_name}.yaml'
+    # Fallback path for the recipe would be TURBINIA_CLI_CONFIG_PATH/recipe_name
+    # This is the same path where the client configuration is loaded from.
+    recipe_path_fallback = os.path.expanduser(ctx.obj.config_path)
+    recipe_path_fallback = os.path.join(recipe_path_fallback, recipe_name)
+
+    if os.path.isfile(recipe_name):
+      recipe_path = recipe_name
+    elif os.path.isfile(recipe_path_fallback):
+      recipe_path = recipe_path_fallback
+    else:
+      log.error(f'Unable to load recipe {recipe_name}.')
+      return
+
+    try:
+      with open(recipe_path, 'r', encoding='utf-8') as recipe_file:
+        # Read the file and convert to base64 encoded bytes.
+        recipe_bytes = recipe_file.read().encode('utf-8')
+        recipe_data = base64.b64encode(recipe_bytes)
+    except OSError as exception:
+      log.error(f'Error opening recipe file {recipe_path}: {exception}')
+      return
+    except TypeError as exception:
+      log.error(f'Error converting recipe data to Base64: {exception}')
+      return
+    # We found the recipe file, so we will send it to the API server
+    # via the recipe_data parameter. To do so, we need to pop recipe_name
+    # from the request so that we only have recipe_data.
+    request['request_options'].pop('recipe_name')
+    # recipe_data should be a UTF-8 encoded string.
+    request['request_options']['recipe_data'] = recipe_data.decode('utf-8')
+
+  # Send the request to the API server.
+  try:
+    log.info(f'Sending request: {request}')
+    api_response = api_instance.create_request(request)
+    log.info(f'Received response: {api_response}')
+  except exceptions.ApiException as exception:
+    log.error(
+        f'Received status code {exception.status} '
+        f'when calling create_request: {exception.body}')
+  except (TypeError, exceptions.ApiTypeError) as exception:
+    log.error(f'The request object is invalid. {exception}')

--- a/turbinia/api/cli/turbinia_client/turbiniacli.py
+++ b/turbinia/api/cli/turbinia_client/turbiniacli.py
@@ -98,14 +98,6 @@ class TurbiniaCli:
     log.info(
         f'Using configuration instance name -> {self.config_instance:s}'
         f' with host {self.api_server_address:s}:{self.api_server_port:d}')
-    try:
-      self.evidence_mapping = self.get_evidence_arguments()
-      self.request_options = self.get_request_options()
-    except turbinia_api_lib.ApiException as exception:
-      log.error(
-          'Error while attempting to contact the API server during setup: %s',
-          exception)
-      sys.exit(-1)
 
   @property
   def api_client(self):

--- a/turbinia/api/cli/turbinia_client/turbiniacli_tool.py
+++ b/turbinia/api/cli/turbinia_client/turbiniacli_tool.py
@@ -23,7 +23,7 @@ from urllib3 import exceptions as urllib3_exceptions
 
 from turbinia_client.turbiniacli import TurbiniaCli
 from turbinia_client.core import groups
-from turbinia_client.factory import factory
+from turbinia_client.core.commands import version
 
 _LOGGER_FORMAT = '%(asctime)s %(levelname)s %(name)s - %(message)s'
 logging.basicConfig(format=_LOGGER_FORMAT, level=logging.INFO)
@@ -79,13 +79,6 @@ def cli(ctx: click.Context, config_instance: str, config_path: str) -> None:
   # Set up the tool based on the configuration file parameters.
   ctx.obj.setup()
 
-  # Build all the commands based on responses from the API server.
-  request_commands = factory.CommandFactory.create_dynamic_objects(
-      evidence_mapping=ctx.obj.evidence_mapping,
-      request_options=ctx.obj.request_options)
-  for command in request_commands:
-    groups.submit_group.add_command(command)
-
 
 def main():
   """Initialize the cli application."""
@@ -97,7 +90,7 @@ def main():
   cli.add_command(groups.jobs_group)
   cli.add_command(groups.result_group)
   cli.add_command(groups.status_group)
-
+  cli.add_command(version)
   try:
     cli.main()
   except (ConnectionRefusedError, urllib3_exceptions.MaxRetryError,


### PR DESCRIPTION
### Description of the change

This PR adds a new "version" command to display the tool's version. It also implements changes to decouple API requests that retrieve evidence types to build the list of "submit" subcommands. This means that those API requests are only sent when running "submit" or one of its subcommands.

The ```create_request``` method was moved from the ```commands``` module to the ```click_helper``` module since it's not a command.

The evidence mapping API requests and ```CommandFactory``` methods that create dynamic click Commands are now invoked only when calling the ```submit``` command. Click can then "chain" the subcommands as they are generated during runtime.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1213 
- fixes #1352 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
