### PR TITLE
Bulk extractor upgrade

### DIFF
--- a/turbinia/jobs/bulk_extractor.py
+++ b/turbinia/jobs/bulk_extractor.py
@@ -17,6 +17,8 @@
 from __future__ import unicode_literals
 
 from turbinia.evidence import GoogleCloudDisk
+from turbinia.evidence import Directory
+from turbinia.evidence import CompressedDirectory
 from turbinia.evidence import GoogleCloudDiskRawEmbedded
 from turbinia.evidence import RawDisk
 from turbinia.evidence import EwfDisk

--- a/turbinia/jobs/bulk_extractor.py
+++ b/turbinia/jobs/bulk_extractor.py
@@ -35,7 +35,7 @@ class BulkExtractorJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-      RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, EwfDisk
+      RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, EwfDisk, Directory, CompressedDirectory
   ]
   evidence_output = [BulkExtractorOutput]
 

--- a/turbinia/jobs/bulk_extractor.py
+++ b/turbinia/jobs/bulk_extractor.py
@@ -37,7 +37,8 @@ class BulkExtractorJob(interface.TurbiniaJob):
 
   # The types of evidence that this Job will process
   evidence_input = [
-      RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, EwfDisk, Directory, CompressedDirectory
+      RawDisk, GoogleCloudDisk, GoogleCloudDiskRawEmbedded, EwfDisk, Directory,
+      CompressedDirectory
   ]
   evidence_output = [BulkExtractorOutput]
 

--- a/turbinia/workers/bulk_extractor.py
+++ b/turbinia/workers/bulk_extractor.py
@@ -193,7 +193,7 @@ class BulkExtractorTask(TurbiniaTask):
           if f.tag == 'feature_file':
             name = next(feature_iter)
             count = next(feature_iter)
-            findings.append(fmt.bullet(f'{name.text}:{count.text}'))
+            findings.append(fmt.bullet(f'{name.text}: {count.text}'))
             features_count += int(count.text)
       else:
         findings.append(fmt.heading5("There are no findings to report."))

--- a/turbinia/workers/bulk_extractor.py
+++ b/turbinia/workers/bulk_extractor.py
@@ -76,7 +76,7 @@ class BulkExtractorTask(TurbiniaTask):
       bulk_extractor_args = None
 
     if self.task_config.get('regex_pattern_files'):
-      regex_pattern_files = [pattern_file_path for pattern_file_path in self.task_config.get('regex_pattern_files')]
+      regex_pattern_files = self.task_config.get('regex_pattern_files')
       result.log(f"Regex Files detected.")
     else:
       regex_pattern_files = None
@@ -107,6 +107,7 @@ class BulkExtractorTask(TurbiniaTask):
       output_evidence.text_data = report
       result.report_data = output_evidence.text_data
 
+      # Write report to file
       with open(report_path, 'wb') as fh:
         fh.write(output_evidence.text_data.encode('utf-8'))
 
@@ -189,15 +190,18 @@ class BulkExtractorTask(TurbiniaTask):
       scanner_results = []
       if feature_files is not None:
         findings.append(fmt.heading5('Scanner Results\n'))
-        for name, count in zip(self.xml.findall(".//feature_file/name"), self.xml.findall(".//feature_file/count")):
+        for name, count in zip(self.xml.findall(".//feature_file/name"),
+                               self.xml.findall(".//feature_file/count")):
           scanner_results.append({"Name": name.text, "Count": count.text})
           features_count += int(count.text)
-        sorted_scanner_results = sorted(scanner_results, key=lambda x: x["Count"], reverse=True)
+        sorted_scanner_results = sorted(
+            scanner_results, key=lambda x: x["Count"], reverse=True)
         columns = scanner_results[0].keys()
         findings.append(" | ".join(columns))
         findings.append(" | ".join(["---"] * len(columns)))
         for scanner_result in sorted_scanner_results:
-          findings.append(" | ".join(str(scanner_result[column]) for column in columns))
+          findings.append(
+              " | ".join(str(scanner_result[column]) for column in columns))
       else:
         findings.append(fmt.heading5("There are no findings to report."))
     except AttributeError as exception:

--- a/turbinia/workers/bulk_extractor.py
+++ b/turbinia/workers/bulk_extractor.py
@@ -184,17 +184,20 @@ class BulkExtractorTask(TurbiniaTask):
               f"Elapsed Time: {self.check_xml_attrib('report/elapsed_seconds')}"
           ))
 
-      # Retrieve results from each of the scanner runs
+      # Retrieve results from each of the scanner runs and display in table
       feature_files = self.xml.find(".//feature_files")
+      scanner_results = []
       if feature_files is not None:
-        feature_iter = feature_files.iter()
-        findings.append(fmt.heading5('Scanner Results'))
-        for f in feature_iter:
-          if f.tag == 'feature_file':
-            name = next(feature_iter)
-            count = next(feature_iter)
-            findings.append(fmt.bullet(f'{name.text}: {count.text}'))
-            features_count += int(count.text)
+        findings.append(fmt.heading5('Scanner Results\n'))
+        for name, count in zip(self.xml.findall(".//feature_file/name"), self.xml.findall(".//feature_file/count")):
+          scanner_results.append({"Name": name.text, "Count": count.text})
+          features_count += int(count.text)
+        sorted_scanner_results = sorted(scanner_results, key=lambda x: x["Count"], reverse=True)
+        columns = scanner_results[0].keys()
+        findings.append(" | ".join(columns))
+        findings.append(" | ".join(["---"] * len(columns)))
+        for scanner_result in sorted_scanner_results:
+          findings.append(" | ".join(str(scanner_result[column]) for column in columns))
       else:
         findings.append(fmt.heading5("There are no findings to report."))
     except AttributeError as exception:

--- a/turbinia/workers/bulk_extractor.py
+++ b/turbinia/workers/bulk_extractor.py
@@ -185,7 +185,7 @@ class BulkExtractorTask(TurbiniaTask):
           ))
 
       # Retrieve results from each of the scanner runs
-      feature_files = self.xml.find('feature_files')
+      feature_files = self.xml.find(".//feature_files")
       if feature_files is not None:
         feature_iter = feature_files.iter()
         findings.append(fmt.heading5('Scanner Results'))


### PR DESCRIPTION
### Description of the change
Even though the Issue resolved by this pull request (#1263) was initially about the `Strings`-Job, it came clear, that 
`bulk-extractor` is able to to all desired work. Therefore in accordance with the discussion on the issue, several changes were made to the `bulk-extractor`-wrapper.

This pull request therefore changes a couple of things regarding the `bulk-extractor` in turbinia. The following list gives an overview:
- Adding new `evidence` types: It now supports `Directory` and `CompressedDirectory` as well. In both cases the `R`-Flag is used to scan the evidence recursively.
- Adding a new `TASK_CONFIG`-Parameter: `regex_pattern_files` lets you list one or many files that include regular expressions separated by newline. This does not break the possibility to pass other parameters to `bulk-extractor` using `bulk_extractor_args` including other regex-pattern-files passed directly to the tool. These are then passed to the `bulk-extractor` using the `F`-Flag and results are listed in `find.txt`
- Writing a Report-File: The existing function `generate_summary_report` already generates a report. This report is now written to file in the output-directory.

An example recipe e.g. would be a yaml file with the following content:
```yaml
globals:
  jobs_allowlist:
   - BulkExtractorJob

plaso_base:
  task: "BulkExtractorTask"
  regex_pattern_files: [
  "/evidence/regex_pattern_file"
  ]
```
An example file in path  `/evidence/regex_pattern_file` would look e.g. like this:
```
[a-fA-F0-9]{64}
\b(?:\d{1,3}\.){3}\d{1,3}\b
```

### Applicable issues

- resolves #1263

### Additional information

Apart from extending the functionality of the bulk-extractor this pull request includes code that creates an 
enhanced report. This includes writing the report to file at the end and displaying the hits as table instead of a bulleted list.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.
- [X] Documentation updated.
- [X] Applied Google Python Style Guide 
