### PR TITLE
Speedup e2e docker image builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "Turbinia Development Container TEST",
+	"name": "Turbinia Development Container",
 	"build": {
 		"dockerfile": "../docker/vscode/Dockerfile"
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,17 +4,13 @@
 	"build": {
 		"dockerfile": "../docker/vscode/Dockerfile"
 	},
-	"runArgs": [
-		"--privileged"
-	],
+	"runArgs": [ "--privileged" ],
 	// copy launch profiles to .vscode
 	"postCreateCommand": "mkdir -p .vscode && cp docker/vscode/vscode-launch.json .vscode/launch.json",
 	// start redis-server after subsequent start of the devcontainer
 	"postStartCommand": "/etc/init.d/redis-server start",
 	// Set *default* container specific settings.json values on container create.
-	"mounts": [
-		"source=/dev,target=/dev,type=bind"
-	],
+	"mounts": ["source=/dev,target=/dev,type=bind"],
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"terminal.integrated.env.linux": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,20 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
-	"name": "Turbinia Development Container",
+	"name": "Turbinia Development Container TEST",
 	"build": {
 		"dockerfile": "../docker/vscode/Dockerfile"
 	},
-	"runArgs": [ "--privileged" ],
+	"runArgs": [
+		"--privileged"
+	],
 	// copy launch profiles to .vscode
 	"postCreateCommand": "mkdir -p .vscode && cp docker/vscode/vscode-launch.json .vscode/launch.json",
 	// start redis-server after subsequent start of the devcontainer
 	"postStartCommand": "/etc/init.d/redis-server start",
 	// Set *default* container specific settings.json values on container create.
-	"mounts": ["source=/dev,target=/dev,type=bind"],
+	"mounts": [
+		"source=/dev,target=/dev,type=bind"
+	],
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"terminal.integrated.env.linux": {

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,12 +27,24 @@ jobs:
           tags: turbinia-api-server-dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      # - name: Build Turbinia API server Docker image
-      #   run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server-dev:latest -t turbinia-api-server-dev -f docker/api_server/Dockerfile .
-      # - name: Build Turbinia server Docker image
-      #   run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server-dev:latest -t turbinia-server-dev -f docker/server/Dockerfile .
-      # - name: Build Turbinia worker Docker image
-      #   run: docker build --build-arg PPA_TRACK=${{ matrix.gift_ppa_track }} --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker-dev:latest -t turbinia-worker-dev -f docker/worker/Dockerfile .
+      - name: Build Turbinia Server Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/server/Dockerfile
+          context: .
+          load: true
+          tags: turbinia-server-dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Build Turbinia Worker Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/worker/Dockerfile
+          context: .
+          load: true
+          tags: turbinia-worker-dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Prepare Turbinia configuration
         run: |
           mkdir ./conf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,19 +14,25 @@ jobs:
           - docker_base_image: "ubuntu:22.04"
             gift_ppa_track: "stable"
     steps:
-      - uses: actions/checkout@v2
-      - name: Pull docker images for cache
-        run: |
-          docker pull ${{ matrix.docker_base_image }}
-          docker pull us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server-dev:latest
-          docker pull us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server-dev:latest
-          docker pull us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker-dev:latest
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build Turbinia API server Docker image
-        run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server-dev:latest -t turbinia-api-server-dev -f docker/api_server/Dockerfile .
-      - name: Build Turbinia server Docker image
-        run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server-dev:latest -t turbinia-server-dev -f docker/server/Dockerfile .
-      - name: Build Turbinia worker Docker image
-        run: docker build --build-arg PPA_TRACK=${{ matrix.gift_ppa_track }} --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker-dev:latest -t turbinia-worker-dev -f docker/worker/Dockerfile .
+        uses: docker/build-push-action@v5
+          with:
+            file: docker/api-server/Dockerfile
+            context: .
+            load: true
+            tags: turbinia-api-server-dev
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
+      # - name: Build Turbinia API server Docker image
+      #   run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server-dev:latest -t turbinia-api-server-dev -f docker/api_server/Dockerfile .
+      # - name: Build Turbinia server Docker image
+      #   run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server-dev:latest -t turbinia-server-dev -f docker/server/Dockerfile .
+      # - name: Build Turbinia worker Docker image
+      #   run: docker build --build-arg PPA_TRACK=${{ matrix.gift_ppa_track }} --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker-dev:latest -t turbinia-worker-dev -f docker/worker/Dockerfile .
       - name: Prepare Turbinia configuration
         run: |
           mkdir ./conf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,8 +19,8 @@ jobs:
           context: .
           load: true
           tags: turbinia-api-server-dev
-          # cache-from: type=gha,scope=api-server
-          # cache-to: type=gha,mode=max,scope=api-server
+          cache-from: type=gha,scope=api-server
+          cache-to: type=gha,mode=max,scope=api-server
       - name: Build Turbinia Server Docker image
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,13 +20,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build Turbinia API server Docker image
         uses: docker/build-push-action@v5
-          with:
-            file: docker/api-server/Dockerfile
-            context: .
-            load: true
-            tags: turbinia-api-server-dev
-            cache-from: type=gha
-            cache-to: type=gha,mode=max
+        with:
+          file: docker/api-server/Dockerfile
+          context: .
+          load: true
+          tags: turbinia-api-server-dev
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       # - name: Build Turbinia API server Docker image
       #   run: docker build --cache-from=${{ matrix.docker_base_image }},us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server-dev:latest -t turbinia-api-server-dev -f docker/api_server/Dockerfile .
       # - name: Build Turbinia server Docker image

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,13 +6,7 @@ jobs:
   e2e-test:
     name: Run local stack e2e test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - docker_base_image: "ubuntu:22.04"
-            gift_ppa_track: "staging"
-          - docker_base_image: "ubuntu:22.04"
-            gift_ppa_track: "stable"
+
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,8 +19,8 @@ jobs:
           context: .
           load: true
           tags: turbinia-api-server-dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=api-server
+          cache-to: type=gha,mode=max,scope=api-server
       - name: Build Turbinia Server Docker image
         uses: docker/build-push-action@v5
         with:
@@ -28,17 +28,17 @@ jobs:
           context: .
           load: true
           tags: turbinia-server-dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-      - name: Build Turbinia Worker Docker image
-        uses: docker/build-push-action@v5
-        with:
-          file: docker/worker/Dockerfile
-          context: .
-          load: true
-          tags: turbinia-worker-dev
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
+      # - name: Build Turbinia Worker Docker image
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     file: docker/worker/Dockerfile
+      #     context: .
+      #     load: true
+      #     tags: turbinia-worker-dev
+      #     cache-from: type=gha,scope=worker
+      #     cache-to: type=gha,mode=max,scope=worker
       - name: Prepare Turbinia configuration
         run: |
           mkdir ./conf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,8 +19,8 @@ jobs:
           context: .
           load: true
           tags: turbinia-api-server-dev
-          cache-from: type=gha,scope=api-server
-          cache-to: type=gha,mode=max,scope=api-server
+          # cache-from: type=gha,scope=api-server
+          # cache-to: type=gha,mode=max,scope=api-server
       - name: Build Turbinia Server Docker image
         uses: docker/build-push-action@v5
         with:
@@ -30,15 +30,15 @@ jobs:
           tags: turbinia-server-dev
           cache-from: type=gha,scope=server
           cache-to: type=gha,mode=max,scope=server
-      # - name: Buid Turbinia Worker Docker image
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     file: docker/worker/Dockerfile
-      #     context: .
-      #     load: true
-      #     tags: turbinia-worker-dev
-      #     cache-from: type=gha,scope=worker
-      #     cache-to: type=gha,mode=max,scope=worker
+      - name: Buid Turbinia Worker Docker image
+        uses: docker/build-push-action@v5
+        with:
+          file: docker/worker/Dockerfile
+          context: .
+          load: true
+          tags: turbinia-worker-dev
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
       - name: Prepare Turbinia configuration
         run: |
           mkdir ./conf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build Turbinia API server Docker image
         uses: docker/build-push-action@v5
         with:
-          file: docker/api-server/Dockerfile
+          file: docker/api_server/Dockerfile
           context: .
           load: true
           tags: turbinia-api-server-dev

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,13 @@ jobs:
   e2e-test:
     name: Run local stack e2e test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - docker_base_image: "ubuntu:22.04"
+            gift_ppa_track: "staging"
+          - docker_base_image: "ubuntu:22.04"
+            gift_ppa_track: "stable"
 
     steps:
       - name: checkout
@@ -35,6 +42,8 @@ jobs:
         with:
           file: docker/worker/Dockerfile
           context: .
+          build-args: |
+            "PPA_TRACK=${{ matrix.gift_ppa_track }}"
           load: true
           tags: turbinia-worker-dev
           cache-from: type=gha,scope=worker

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
           tags: turbinia-server-dev
           cache-from: type=gha,scope=server
           cache-to: type=gha,mode=max,scope=server
-      # - name: Build Turbinia Worker Docker image
+      # - name: Buid Turbinia Worker Docker image
       #   uses: docker/build-push-action@v5
       #   with:
       #     file: docker/worker/Dockerfile


### PR DESCRIPTION
### Description of the change

Speedup the e2e docker image builds. By changing the build tools from a simple docker build to using Buildkit in combination with Github Actions Caching there is a greater change of hitting the docker layer cache on subsequent builds for the docker images in the e2e test. 

See below link where the build times for api-server, server and worker were brought down to 29, 27 and 54 seconds.
https://github.com/hacktobeer/turbinia/actions/runs/6795148691/job/18472715886

Note: The cache hits are not guaranteed and depend on the changes made in the PR!


### Additional information

Github Actions Cache -> https://docs.docker.com/build/cache/backends/gha/
Buildkit -> https://docs.docker.com/build/buildkit/

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
- [NA] Unit tests added.
- [NA] Documentation updated.
