### PR TITLE
Fix unique tasks and sort/filtering in report output

### DIFF
--- a/turbinia/api/cli/turbinia_client/core/commands.py
+++ b/turbinia/api/cli/turbinia_client/core/commands.py
@@ -275,7 +275,7 @@ def get_task(
       formatter.echo_json(api_response)
     else:
       report = formatter.TaskMarkdownReport(api_response).generate_markdown(
-          show_all=show_all)
+          show_all=show_all, priority_filter=100)
       click.echo(report)
   except exceptions.ApiException as exception:
     log.error(

--- a/turbinia/api/cli/turbinia_client/helpers/formatter.py
+++ b/turbinia/api/cli/turbinia_client/helpers/formatter.py
@@ -442,7 +442,9 @@ class SummaryMarkdownReport(MarkdownReportComponent):
     if not requests_status_list:
       return '## No requests found.'
 
-    for request_dict in requests_status_list:
+    sorted_requests = sorted(
+        requests_status_list, key=lambda x: x['last_task_update_time'])
+    for request_dict in sorted_requests:
       request_report = RequestMarkdownReport(request_dict).generate_markdown()
       report.append(request_report)
 


### PR DESCRIPTION
### Description of the change

* Fixes unique task summary counts  so we can remove duplicate task outputs in the report to make it more succinct.
* Also sort request summary tasks output by last update time.
* Also set default priority filter for task status requests so all details are shown.

### Applicable issues

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
