### PR TITLE
Change to turbinia-worker-dev as it has latest changes

### DIFF
--- a/docker/vscode/Dockerfile
+++ b/docker/vscode/Dockerfile
@@ -1,5 +1,5 @@
 # We take the latest Turbinia worker release as a base image to make sure dependencies are already installed
-FROM us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-unit-tests:latest
+FROM us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker-dev:latest
 
 USER root
 


### PR DESCRIPTION
<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please add links for any issues that are related to this PR.
 -->

### Description of the change

Anyone trying to use vscode devcontainer will run into issues with worker deps missing. Changing back to `turbinia-worker-dev` as thats working and is the most up to date

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x ] All tests were successful.

