### PR TITLE
Add retry port-forward connection and logic to wait until request is populated

### DIFF
--- a/turbinia/e2e/run-e2e-gke.sh
+++ b/turbinia/e2e/run-e2e-gke.sh
@@ -113,20 +113,20 @@ then
   # Grab the Task ID
   tasks=$(echo $task_status | jq -r '.[] | .id')
   FAILED=1
-  for t in $tasks
+  for task in $tasks
   do
-    echo "Failed Task ID: $t"
-    turbinia-client status task $t
+    echo "Failed Task ID: $task"
+    turbinia-client status task $task
   done
   # Grab Turbinia worker logs from the server pod
   server=$(kubectl get pods -o name  | grep turbinia-server)
   workers=$(echo $task_status | jq -r '.[] | .worker_name')
-  for w in $workers
+  for worker in $workers
   do
-    wlogs=$(kubectl exec $server -- find /mnt/turbiniavolume/logs -path "*$w*")
+    wlogs=$(kubectl exec $server -- find /mnt/turbiniavolume/logs -path "*$worker*")
     if [ -n $wlogs ] && [ -n  $server ]
     then
-      echo "Grabbing logs for Turbinia worker $w"
+      echo "Grabbing logs for Turbinia worker $worker"
       kubectl exec $server -- cat $wlogs 
     fi
   done

--- a/turbinia/e2e/run-e2e-gke.sh
+++ b/turbinia/e2e/run-e2e-gke.sh
@@ -65,6 +65,7 @@ if [ $? != "0" ]
 then
   echo "Connection to the Turbinia service failed. Retrying k8s port-forward..."
   kubectl --namespace default port-forward service/$RELEASE-turbinia 8000:8000  > /dev/null 2>&1 &
+  sleep 5
 fi
 
 # Exit on any failures after this point


### PR DESCRIPTION
### Description of the change

Fixes an issue where port-forward connection wasn't able to establish after a first connection (happens very little and at random) so it retries the connection before considering the test failed

Also fixes request needing some time to populated on Turbinia server from when it was first submitted + minor nits.

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.

