### PR TITLE
Updated the "Using Docker for Job execution" documentation

### DIFF
--- a/docs/user/using-docker.md
+++ b/docs/user/using-docker.md
@@ -6,9 +6,9 @@ Turbinia supports the use of Docker by allowing a Task to execute its command th
 ## Enabling Docker usage
 In order to enable this feature, please take the following steps. 
 1. Install the Docker daemon on the Worker's host machine. Please visit the Docker website for the [Installation Guide](https://docs.docker.com/install/).
-2. In the `turbina.conf` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
-3. Review the `DEPENDENCIES` flag in the `turbina.conf` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the name of the Docker image. 
-4. Save the `turbina.conf` configuration file then restart all Workers for the changes to take into effect. 
+2. In the `turbinia.conf` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
+3. Review the `DEPENDENCIES` flag in the `turbinia.conf` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the name of the Docker image. 
+4. Save the `turbinia.conf` configuration file then restart all Workers for the changes to take into effect. 
 5. When the Workers start, they will perform dependency checks to ensure that the binaries required by the Job are installed in the Container, and if that check passes, it will execute those in the configured Docker Container. 
 6. If you no longer would like to use the Docker image, set the `docker_image` value back to `None`.
 
@@ -24,7 +24,7 @@ The following section provides an example of the steps mentioned above for the P
     REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
     log2timeline/plaso                              latest              9c22665bff50        4 days ago          314MB
     ```
-3. Open up the `turbina.conf` configuration file then set the attribute `DOCKER_ENABLED` to `True`. 
+3. Open up the `turbinia.conf` configuration file then set the attribute `DOCKER_ENABLED` to `True`. 
 4. Identify the `DEPENDENCIES` attribute and look for the Job `PlasoJob`, then replace the `docker_image` value with the identified `REPOSITORY`. 
     ```python
     {

--- a/docs/user/using-docker.md
+++ b/docs/user/using-docker.md
@@ -6,9 +6,9 @@ Turbinia supports the use of Docker by allowing a Task to execute its command th
 ## Enabling Docker usage
 In order to enable this feature, please take the following steps. 
 1. Install the Docker daemon on the Worker's host machine. Please visit the Docker website for the [Installation Guide](https://docs.docker.com/install/).
-2. In the `.turbiniarc` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
-3. Review the `DEPENDENCIES` flag in the `.turbiniarc` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the `image_id` of the Docker image. 
-4. Save the `.turbiniarc` configuration file then restart all Workers for the changes to take into effect. 
+2. In the `turbina.conf` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
+3. Review the `DEPENDENCIES` flag in the `turbina.conf` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the name of the Docker image. 
+4. Save the `turbina.conf` configuration file then restart all Workers for the changes to take into effect. 
 5. When the Workers start, they will perform dependency checks to ensure that the binaries required by the Job are installed in the Container, and if that check passes, it will execute those in the configured Docker Container. 
 6. If you no longer would like to use the Docker image, set the `docker_image` value back to `None`.
 
@@ -16,21 +16,21 @@ In order to enable this feature, please take the following steps.
 The following section provides an example of the steps mentioned above for the Plaso Job by using the Docker CLI to retrieve the required information.
 1. Retrieve the latest Plaso Docker image either locally or through a preconfigured registry containing the image.
     * ` docker pull log2timeline/plaso`
-2. Identify the  `image_id` for the retrieved image. 
+2. Identify the  name for the retrieved image. 
     * `docker image ls`  
 
-    Then copy the value listed under the column `IMAGE ID`.
+    Then copy the value listed under the column `REPOSITORY`.
     ```
     REPOSITORY                                      TAG                 IMAGE ID            CREATED             SIZE
     log2timeline/plaso                              latest              9c22665bff50        4 days ago          314MB
     ```
-3. Open up the `.turbiniarc` configuration file then set the attribute `DOCKER_ENABLED` to `True`. 
-4. Identify the `DEPENDENCIES` attribute and look for the Job `PlasoJob`, then replace the `docker_image` value with the identified `IMAGE ID`. 
+3. Open up the `turbina.conf` configuration file then set the attribute `DOCKER_ENABLED` to `True`. 
+4. Identify the `DEPENDENCIES` attribute and look for the Job `PlasoJob`, then replace the `docker_image` value with the identified `REPOSITORY`. 
     ```python
     {
         'job': 'PlasoJob'
         'programs': ['log2timeline.py'],
-        'docker_image': '9c22665bff50' 
+        'docker_image': 'log2timeline/plaso' 
     }
     ```
 5. Save the configuration file, then restart the turbinia Worker.

--- a/docs/user/using-docker.md
+++ b/docs/user/using-docker.md
@@ -5,12 +5,11 @@ Turbinia supports the use of Docker by allowing a Task to execute its command th
 
 ## Enabling Docker usage
 In order to enable this feature, please take the following steps. 
-1. Install the Docker daemon on the Worker's host machine. Please visit the Docker website for the [Installation Guide](https://docs.docker.com/install/).
-2. In the `turbinia.conf` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
-3. Review the `DEPENDENCIES` flag in the `turbinia.conf` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the name of the Docker image. 
-4. Save the `turbinia.conf` configuration file then restart all Workers for the changes to take into effect. 
-5. When the Workers start, they will perform dependency checks to ensure that the binaries required by the Job are installed in the Container, and if that check passes, it will execute those in the configured Docker Container. 
-6. If you no longer would like to use the Docker image, set the `docker_image` value back to `None`.
+1. In the `turbinia.conf` configuration file, set the `DOCKER_ENABLED` flag to `True` to enable the usage of Docker. 
+2. Review the `DEPENDENCIES` flag in the `turbinia.conf` configuration file and identify which Job you would like to execute a Docker container for. Once identified, replace the value for `docker_image` with the name of the Docker image. 
+3. Save the `turbinia.conf` configuration file then restart all Workers for the changes to take into effect. 
+4. When the Workers start, they will perform dependency checks to ensure that the binaries required by the Job are installed in the Container, and if that check passes, it will execute those in the configured Docker Container. 
+5. If you no longer would like to use the Docker image, set the `docker_image` value back to `None`.
 
 ## Example using Plaso
 The following section provides an example of the steps mentioned above for the Plaso Job by using the Docker CLI to retrieve the required information.
@@ -33,6 +32,8 @@ The following section provides an example of the steps mentioned above for the P
         'docker_image': 'log2timeline/plaso' 
     }
     ```
+> **Note:** You can also provide the docker image name with a tag to pin the programs used in jobs to a certain version. In the example above `log2timeline/plaso` can also be specified as `log2timeline/plaso:latest`. This way the tools can be updated and after that the tag is changed in the configuration file which eliminates the need for redeploying or re-installing anything.   
+    
 5. Save the configuration file, then restart the turbinia Worker.
     * `sudo systemctl restart turbinia@psqworker.service`
 6. If the dependency check succeeds, once a Worker receives a Docker configured Task, the Task will execute its external command through the Docker Container instead and pass the associated data back to the Worker for further processing. 


### PR DESCRIPTION
The documentation article "Using Docker for Job execution" was updated so it reflects the code in line 124 `turbinia/turbinia/lib /docker_manager.py`.

<!--
 Thank you for contributing! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe what the change does.
 - Please run any tests that can exercise your modified code.
 - Please add links for any issues that are related to this PR.
 -->

### Description of the change

The changes update the documentation article *Using Docker for Job execution* so that it reflects the code in [docker_manager.py#L111](https://github.com/google/turbinia/blob/master/turbinia/lib/docker_manager.py#L111). 

The following errors occur when using the `IMAGE ID` instead of the `REPOSITORY` value:

```python3
2024-01-11 12:26:30 [WARNING] DOCKER_ENABLED=True is set in the config, but there is an error checking for the docker daemon: {0:s}
Traceback (most recent call last):
  File "/home/turbinia/turbinia/worker.py", line 198, in __init__
    check_docker_dependencies(dependencies)
  File "/home/turbinia/turbinia/worker.py", line 91, in check_docker_dependencies
    raise TurbiniaException(
turbinia.TurbiniaException: Docker image 399a772c8145 does not exist for the job psortjob. Please update the config with the correct image name

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/turbinia/turbinia/turbiniactl.py", line 1015, in main
    process_args(sys.argv[1:])
  File "/home/turbinia/turbinia/turbiniactl.py", line 694, in process_args
    worker = TurbiniaCeleryWorker(
  File "/home/turbinia/turbinia/worker.py", line 242, in __init__
    super(TurbiniaCeleryWorker, self).__init__(*args, **kwargs)
  File "/home/turbinia/turbinia/worker.py", line 202, in __init__
    ).format(str(exception))
AttributeError: 'NoneType' object has no attribute 'format'
```

Since the function `image_exists(self, image_id)` [docker_manager.py#L111](https://github.com/google/turbinia/blob/master/turbinia/lib/docker_manager.py#L111) doesn't use the image id but rather the image name, the documentation needed to be updated.

Changed the "Using Docker for Job execution" article in the documentation. The documentation know explains that the image name is required. Also the name of the configuration file was changed to `turbinia.conf`.

### Applicable issues

- None

### Additional information

- None

### Checklist

- [x] All tests were successful.
- [ ] Unit tests added.
- [x] Documentation updated.
