### PR TITLE
Add workaround for pinfo non-json warning output

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -1070,6 +1070,8 @@ class PlasoFile(Evidence):
       log.info(f'Running pinfo.py to validate PlasoFile {self.local_path}')
       command = subprocess.run(cmd, capture_output=True, check=True)
       storage_counters_json = command.stdout.decode('utf-8').strip()
+      # pinfo.py might print warnings (non-json) so we only need to last line of output
+      storage_counters_json = storage_counters_json.splitlines()[-1]
       storage_counters = json.loads(storage_counters_json)
       total_file_events = storage_counters.get('storage_counters', {}).get(
           'parsers', {}).get('total', 0)


### PR DESCRIPTION

### Description of the change

Make sure we only use the relevant json output of pinfo.py

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1417 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
