### PR TITLE
Rewrite pinfo.py call

### DIFF
--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -1067,6 +1067,7 @@ class PlasoFile(Evidence):
           pinfo._CalculateStorageCounters(  # pylint: disable=protected-access
               storage_reader
           )
+      )
       total_file_events = storage_counters.get("parsers", {}).get("total")
       if not total_file_events:
         raise TurbiniaException(


### PR DESCRIPTION
### Description of the change
Rewrite the call to pinfo.py from a sys call to a pinfo lib call to prevent issues with parsing the json output.

### Applicable issues

- fixes #

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
