### PR TITLE
Remove Celery task_acks_late

### DIFF
--- a/turbinia/tcelery.py
+++ b/turbinia/tcelery.py
@@ -56,7 +56,6 @@ class TurbiniaCelery:
         broker_connection_retry_on_startup=True,
         task_default_queue=config.INSTANCE_ID,
         accept_content=['json'],
-        task_acks_late=True,
         worker_cancel_long_running_tasks_on_connection_loss=True,
         worker_concurrency=1,
         worker_prefetch_multiplier=1,


### PR DESCRIPTION
### Description of the change

This is to disable implicit retries by Celery because it causes duplicate tasks that the task manager does not deal with appropriately when a task has timed out because the task stub has already been removed, which means that new Jobs do not get created based on the output evidence from the retried task.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
