### PR TITLE
Update fs timeline dependency path

### DIFF
--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -190,7 +190,7 @@ DEPENDENCIES = [{
     'timeout': 1200
 }, {
     'job': 'FileSystemTimelineJob',
-    'programs': ['list_file_entries'],
+    'programs': ['list_file_entries.py'],
     'docker_image': None,
     'timeout': 1800
 }, {


### PR DESCRIPTION
### Description of the change

list_file_entries.py still has the file extension in the latest version of Plaso (20240308). 

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
