### PR TITLE
Add back list_file_entries file extension

### DIFF
--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -190,7 +190,7 @@ DEPENDENCIES = [{
     'timeout': 1200
 }, {
     'job': 'FileSystemTimelineJob',
-    'programs': ['list_file_entries.py'],
+    'programs': ['list_file_entries'],
     'docker_image': None,
     'timeout': 1800
 }, {


### PR DESCRIPTION
### Description of the change

Revert #1475 which added the extension to match the worker build for the previous release, but this dependency has been updated in the latest build so needs to be added back.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
