### PR TITLE
WIP: Add AWS EBS disk evidence type and processor

### DIFF
--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -24,8 +24,7 @@
 # separate when running with the same Cloud projects or backend servers.
 INSTANCE_ID = 'turbinia-instance1'
 
-# Which Cloud provider to use. Valid options are 'Local' and 'GCP'. Use 'GCP'
-# for GCP or hybrid installations, and 'Local' for local installations.
+# Which Cloud provider to use. Valid options are 'Local', 'GCP' or 'AWS'.
 CLOUD_PROVIDER = 'Local'
 
 # Task manager only supports 'Celery'.

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -920,23 +920,20 @@ class DiskPartition(Evidence):
 
 
 class AwsEbsVolume(Evidence):
-  """Evidence object for an AWS EC2 EBS Disk.
+  """Evidence object for an AWS EBS Disk.
 
   Attributes:
-    project: The cloud project name this disk is associated with.
     zone: The geographic zone.
     disk_name: The cloud disk name.
   """
 
-  REQUIRED_ATTRIBUTES = ['volume_id', 'project', 'zone']
+  REQUIRED_ATTRIBUTES = ['volume_id', 'zone']
   POSSIBLE_STATES = [EvidenceState.ATTACHED, EvidenceState.MOUNTED]
 
   def __init__(
-      self, project=None, zone=None, volume_id=None, mount_partition=1, *args,
-      **kwargs):
-    """Initialization for Google Cloud Disk."""
+      self, zone=None, volume_id=None, mount_partition=1, *args, **kwargs):
+    """Initialization for AWS EBS Disk."""
     super(AwsEbsVolume, self).__init__(*args, **kwargs)
-    self.project = project
     self.zone = zone
     self.volume_id = volume_id
     self.mount_partition = mount_partition
@@ -951,14 +948,9 @@ class AwsEbsVolume(Evidence):
     if self._name:
       return self._name
     else:
-      return ':'.join((self.type, self.project, self.disk_name))
+      return ':'.join((self.type, self.disk_name))
 
   def _preprocess(self, _, required_states):
-    # The GoogleCloudDisk should never need to be mounted unless it has child
-    # evidence (GoogleCloudDiskRawEmbedded). In all other cases, the
-    # DiskPartition evidence will be used. In this case we're breaking the
-    # evidence layer isolation and having the child evidence manage the
-    # mounting and unmounting.
     if EvidenceState.ATTACHED in required_states:
       self.device_path, partition_paths = aws.PreprocessAttachDisk(
           self.disk_name)

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -42,6 +42,8 @@ from datetime import datetime
 config.LoadConfig()
 if config.CLOUD_PROVIDER.lower() == 'gcp':
   from turbinia.processors import google_cloud
+elif config.CLOUD_PROVIDER.lower() == 'aws':
+  from turbinia.processors import aws
 
 log = logging.getLogger(__name__)
 
@@ -917,7 +919,7 @@ class DiskPartition(Evidence):
         self.state[EvidenceState.ATTACHED] = False
 
 
-class AwsEbsDisk(Evidence):
+class AwsEbsVolume(Evidence):
   """Evidence object for an AWS EC2 EBS Disk.
 
   Attributes:
@@ -926,17 +928,17 @@ class AwsEbsDisk(Evidence):
     disk_name: The cloud disk name.
   """
 
-  REQUIRED_ATTRIBUTES = ['disk_name', 'project', 'zone']
+  REQUIRED_ATTRIBUTES = ['volume_id', 'project', 'zone']
   POSSIBLE_STATES = [EvidenceState.ATTACHED, EvidenceState.MOUNTED]
 
   def __init__(
-      self, project=None, zone=None, disk_name=None, mount_partition=1, *args,
+      self, project=None, zone=None, volume_id=None, mount_partition=1, *args,
       **kwargs):
     """Initialization for Google Cloud Disk."""
-    super(GoogleCloudDisk, self).__init__(*args, **kwargs)
+    super(AwsEbsVolume, self).__init__(*args, **kwargs)
     self.project = project
     self.zone = zone
-    self.disk_name = disk_name
+    self.volume_id = volume_id
     self.mount_partition = mount_partition
     self.partition_paths = None
     self.cloud_only = True

--- a/turbinia/lib/utils.py
+++ b/turbinia/lib/utils.py
@@ -173,6 +173,21 @@ def get_exe_path(filename):
   return binary
 
 
+def is_block_device(path):
+  """Checks path to determine whether it is a block device.
+
+  Args:
+      path: String of path to check.
+
+  Returns:
+      Bool indicating success.
+  """
+  if not os.path.exists(path):
+    return False
+  mode = os.stat(path).st_mode
+  return stat.S_ISBLK(mode)
+
+
 def bruteforce_password_hashes(
     password_hashes, tmp_dir, timeout=300, extra_args=''):
   """Bruteforce password hashes using Hashcat or john.


### PR DESCRIPTION
WIP

### Description of the change

Adds a new evidence type for AWS EBS disks and the related pre/post-processors so we can attach and mount these disks.

### Applicable issues

Fixes #1318 

### Additional information

Only certain disk types are compatible with multi-attach so this first iteration will only support those types, and for other disk types we'll only be able to support a single worker for now.  In future PRs we'll try to come up with a method to process these disks, possibly by making a copy of the disk with a disk type that supports multi-attach.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
