### PR TITLE
Remove Prometheus registry setup

### DIFF
--- a/turbinia/worker_test.py
+++ b/turbinia/worker_test.py
@@ -31,6 +31,8 @@ from turbinia.jobs import manager
 from turbinia.jobs import manager_test
 from turbinia import TurbiniaException
 
+from prometheus_client import REGISTRY
+
 
 class TestTurbiniaCeleryWorker(unittest.TestCase):
   """Test Turbinia Celery Worker class."""
@@ -49,6 +51,12 @@ class TestTurbiniaCeleryWorker(unittest.TestCase):
 
     if 'turbinia-test' in self.tmp_dir:
       shutil.rmtree(self.tmp_dir)
+    self.unregisterMetrics()
+
+  def unregisterMetrics(self):
+    """Unset all the metrics to avoid duplicated timeseries error."""
+    for collector, names in tuple(REGISTRY._collector_to_names.items()):
+      REGISTRY.unregister(collector)
 
   @mock.patch('turbinia.client.task_manager.CeleryTaskManager._backend_setup')
   @mock.patch('turbinia.lib.docker_manager.DockerManager')

--- a/turbinia/worker_test.py
+++ b/turbinia/worker_test.py
@@ -51,12 +51,6 @@ class TestTurbiniaCeleryWorker(unittest.TestCase):
 
     if 'turbinia-test' in self.tmp_dir:
       shutil.rmtree(self.tmp_dir)
-    self.unregisterMetrics()
-
-  def unregisterMetrics(self):
-    """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY._collector_to_names.items()):
-      REGISTRY.unregister(collector)
 
   @mock.patch('turbinia.client.task_manager.CeleryTaskManager._backend_setup')
   @mock.patch('turbinia.lib.docker_manager.DockerManager')

--- a/turbinia/worker_test.py
+++ b/turbinia/worker_test.py
@@ -55,7 +55,7 @@ class TestTurbiniaCeleryWorker(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY._collector_to_names.items()):
+    for collector, names in tuple(REGISTRY.get_names()):
       REGISTRY.unregister(collector)
 
   @mock.patch('turbinia.client.task_manager.CeleryTaskManager._backend_setup')

--- a/turbinia/worker_test.py
+++ b/turbinia/worker_test.py
@@ -55,7 +55,7 @@ class TestTurbiniaCeleryWorker(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY.get_names()):
+    for collector, names in tuple(REGISTRY._get_names()):
       REGISTRY.unregister(collector)
 
   @mock.patch('turbinia.client.task_manager.CeleryTaskManager._backend_setup')

--- a/turbinia/worker_test.py
+++ b/turbinia/worker_test.py
@@ -55,7 +55,7 @@ class TestTurbiniaCeleryWorker(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY._get_names()):
+    for collector, names in tuple(REGISTRY._collector_to_names.items()):
       REGISTRY.unregister(collector)
 
   @mock.patch('turbinia.client.task_manager.CeleryTaskManager._backend_setup')

--- a/turbinia/worker_test.py
+++ b/turbinia/worker_test.py
@@ -31,8 +31,6 @@ from turbinia.jobs import manager
 from turbinia.jobs import manager_test
 from turbinia import TurbiniaException
 
-from prometheus_client import REGISTRY
-
 
 class TestTurbiniaCeleryWorker(unittest.TestCase):
   """Test Turbinia Celery Worker class."""

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -35,7 +35,7 @@ import traceback
 import uuid
 import filelock
 
-from prometheus_client import CollectorRegistry, Counter, Histogram
+from prometheus_client import Counter, Histogram
 from turbinia import __version__, config
 from turbinia.config import DATETIME_FORMAT
 from turbinia.evidence import evidence_decode
@@ -59,30 +59,25 @@ REPORT_MAXSIZE = int(1048572 * 0.75)
 
 log = logging.getLogger(__name__)
 
-registry = CollectorRegistry()
 turbinia_worker_exception_failure = Counter(
     'turbinia_worker_exception_failure',
-    'Total number Tasks failed due to uncaught exception', registry=registry)
+    'Total number Tasks failed due to uncaught exception')
 turbinia_worker_tasks_started_total = Counter(
     'turbinia_worker_tasks_started_total',
-    'Total number of started worker tasks', registry=registry)
+    'Total number of started worker tasks')
 turbinia_worker_tasks_completed_total = Counter(
     'turbinia_worker_tasks_completed_total',
-    'Total number of completed worker tasks', registry=registry)
+    'Total number of completed worker tasks')
 turbinia_worker_tasks_queued_total = Counter(
-    'turbinia_worker_tasks_queued_total', 'Total number of queued worker tasks',
-    registry=registry)
+    'turbinia_worker_tasks_queued_total', 'Total number of queued worker tasks')
 turbinia_worker_tasks_failed_total = Counter(
-    'turbinia_worker_tasks_failed_total', 'Total number of failed worker tasks',
-    registry=registry)
+    'turbinia_worker_tasks_failed_total', 'Total number of failed worker tasks')
 turbinia_worker_tasks_timeout_total = Counter(
     'turbinia_worker_tasks_timeout_total',
-    'Total number of worker tasks timed out during dependency execution.',
-    registry=registry)
+    'Total number of worker tasks timed out during dependency execution.')
 turbinia_worker_tasks_timeout_celery_soft = Counter(
     'turbinia_worker_tasks_timeout_celery_soft',
-    'Total number of Tasks timed out due to Celery soft timeout',
-    registry=registry)
+    'Total number of Tasks timed out due to Celery soft timeout')
 
 
 class Priority(IntEnum):

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from datetime import timedelta
 from enum import IntEnum
 
+from itertools import chain
 import json
 import logging
 import os
@@ -48,6 +49,7 @@ from turbinia import TurbiniaException
 from turbinia import log_and_report
 
 from celery.exceptions import SoftTimeLimitExceeded
+from prometheus_client import REGISTRY
 
 METRICS = {}
 # Set the maximum size that the report can be before truncating it.  This is a
@@ -59,25 +61,30 @@ REPORT_MAXSIZE = int(1048572 * 0.75)
 
 log = logging.getLogger(__name__)
 
-turbinia_worker_exception_failure = Counter(
-    'turbinia_worker_exception_failure',
-    'Total number Tasks failed due to uncaught exception')
-turbinia_worker_tasks_started_total = Counter(
-    'turbinia_worker_tasks_started_total',
-    'Total number of started worker tasks')
-turbinia_worker_tasks_completed_total = Counter(
-    'turbinia_worker_tasks_completed_total',
-    'Total number of completed worker tasks')
-turbinia_worker_tasks_queued_total = Counter(
-    'turbinia_worker_tasks_queued_total', 'Total number of queued worker tasks')
-turbinia_worker_tasks_failed_total = Counter(
-    'turbinia_worker_tasks_failed_total', 'Total number of failed worker tasks')
-turbinia_worker_tasks_timeout_total = Counter(
-    'turbinia_worker_tasks_timeout_total',
-    'Total number of worker tasks timed out during dependency execution.')
-turbinia_worker_tasks_timeout_celery_soft = Counter(
-    'turbinia_worker_tasks_timeout_celery_soft',
-    'Total number of Tasks timed out due to Celery soft timeout')
+# Prevent re-registering metrics if module is loaded multiple times.
+metric_names = list(chain.from_iterable(REGISTRY._collector_to_names.values()))
+if 'turbinia_worker_exception_failure' not in metric_names:
+  turbinia_worker_exception_failure = Counter(
+      'turbinia_worker_exception_failure',
+      'Total number Tasks failed due to uncaught exception')
+  turbinia_worker_tasks_started_total = Counter(
+      'turbinia_worker_tasks_started_total',
+      'Total number of started worker tasks')
+  turbinia_worker_tasks_completed_total = Counter(
+      'turbinia_worker_tasks_completed_total',
+      'Total number of completed worker tasks')
+  turbinia_worker_tasks_queued_total = Counter(
+      'turbinia_worker_tasks_queued_total',
+      'Total number of queued worker tasks')
+  turbinia_worker_tasks_failed_total = Counter(
+      'turbinia_worker_tasks_failed_total',
+      'Total number of failed worker tasks')
+  turbinia_worker_tasks_timeout_total = Counter(
+      'turbinia_worker_tasks_timeout_total',
+      'Total number of worker tasks timed out during dependency execution.')
+  turbinia_worker_tasks_timeout_celery_soft = Counter(
+      'turbinia_worker_tasks_timeout_celery_soft',
+      'Total number of Tasks timed out due to Celery soft timeout')
 
 
 class Priority(IntEnum):

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -87,6 +87,7 @@ class TestTurbiniaTaskBase(unittest.TestCase):
         os.rmdir(directory)
 
     os.rmdir(self.base_output_dir)
+    self.unregisterMetrics()
 
   def setResults(
       self, setup=None, run=None, validate_result=None, mock_run=True):
@@ -149,7 +150,6 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
   def testTurbiniaTaskRunWrapper(self):
     """Test that the run wrapper executes task run."""
-    self.unregisterMetrics()
     self.setResults()
     self.result.closed = True
     new_result = self.task.run_wrapper(self.evidence.__dict__)
@@ -160,7 +160,6 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
   def testTurbiniaTaskRunWrapperAutoClose(self):
     """Test that the run wrapper closes the task."""
-    self.unregisterMetrics()
     self.setResults()
     new_result = self.task.run_wrapper(self.evidence.__dict__)
     new_result = TurbiniaTaskResult.deserialize(new_result)
@@ -170,7 +169,6 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
   @mock.patch('turbinia.state_manager.get_state_manager')
   def testTurbiniaTaskRunWrapperBadResult(self, _):
     """Test that the run wrapper recovers from run returning bad result."""
-    self.unregisterMetrics()
     bad_result = 'Not a TurbiniaTaskResult'
     checked_result = TurbiniaTaskResult(base_output_dir=self.base_output_dir)
     checked_result.setup(self.task)
@@ -184,7 +182,6 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
   def testTurbiniaTaskJobUnavailable(self):
     """Test that the run wrapper can fail if the job doesn't exist."""
-    self.unregisterMetrics()
     self.setResults()
     self.task.job_name = 'non_exist'
     canary_status = (
@@ -196,7 +193,6 @@ class TestTurbiniaTask(TestTurbiniaTaskBase):
 
   def testTurbiniaTaskRunWrapperExceptionThrown(self):
     """Test that the run wrapper recovers from run throwing an exception."""
-    self.unregisterMetrics()
     self.setResults()
     self.task.run = mock.MagicMock(side_effect=TurbiniaException)
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -119,7 +119,7 @@ class TestTurbiniaTaskBase(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY._collector_to_names.items()):
+    for collector, names in tuple(REGISTRY.get_names()):
       REGISTRY.unregister(collector)
 
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -119,7 +119,7 @@ class TestTurbiniaTaskBase(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY.get_names()):
+    for collector, names in tuple(REGISTRY._get_names()):
       REGISTRY.unregister(collector)
 
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -119,8 +119,7 @@ class TestTurbiniaTaskBase(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY._collector_to_names.items()):
-      print(collector, names)
+    for collector, _ in tuple(REGISTRY._collector_to_names.items()):
       REGISTRY.unregister(collector)
 
 

--- a/turbinia/workers/workers_test.py
+++ b/turbinia/workers/workers_test.py
@@ -119,7 +119,8 @@ class TestTurbiniaTaskBase(unittest.TestCase):
 
   def unregisterMetrics(self):
     """Unset all the metrics to avoid duplicated timeseries error."""
-    for collector, names in tuple(REGISTRY._get_names()):
+    for collector, names in tuple(REGISTRY._collector_to_names.items()):
+      print(collector, names)
       REGISTRY.unregister(collector)
 
 


### PR DESCRIPTION
### Description of the change

Removes the registry setup for Prometheus as this causes the application metrics not to show up.  This also makes sure that we only initialize worker metrics once (otherwise we get duplicate timeseries errors from prometheus_client) and unregisters all metrics in worker task tearDown() instead of individual tests.

### Applicable issues

### Additional information

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ x] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
