### PR TITLE
LLMAnalyser UTF-8 decode input error

### DIFF
--- a/turbinia/workers/analysis/llm_analyzer.py
+++ b/turbinia/workers/analysis/llm_analyzer.py
@@ -89,7 +89,9 @@ class LLMAnalyzerTask(workers.TurbiniaTask):
       TurbiniaTaskResult object.
     """
 
-    result.log(f"Running LLMAnalyzerTask task on {evidence.artifact_name}")
+    result.log(
+        f"Running LLMAnalyzerTask task on {evidence.artifact_name} {evidence.local_path}"
+    )
     # Where to store the resulting output file.
     output_file_name = f"{evidence.artifact_name}-llm_analysis.txt"
     output_file_path = os.path.join(self.output_dir, output_file_name)
@@ -106,8 +108,10 @@ class LLMAnalyzerTask(workers.TurbiniaTask):
     try:
       with open_function(evidence.local_path, "rb") as input_file:
         artifact_content = input_file.read().decode("utf-8")
-    except UnicodeDecodeError as e:
-      result.log(f"Artifact {evidence.local_path} not UTF-8 encoded")
+    except UnicodeDecodeError:
+      result.log(
+          f"UnicodeDecodeError: Artifact {evidence.local_path} not UTF-8 encoded"
+      )
 
     if not artifact_content:
       result.log(

--- a/turbinia/workers/analysis/llm_analyzer.py
+++ b/turbinia/workers/analysis/llm_analyzer.py
@@ -103,12 +103,15 @@ class LLMAnalyzerTask(workers.TurbiniaTask):
       open_function = gzip.open
 
     # Read the input file
-    with open_function(evidence.local_path, "rb") as input_file:
-      artifact_content = input_file.read().decode("utf-8")
+    try:
+      with open_function(evidence.local_path, "rb") as input_file:
+        artifact_content = input_file.read().decode("utf-8")
+    except UnicodeDecodeError as e:
+      result.log(f"Artifact {evidence.local_path} not UTF-8 encoded")
 
     if not artifact_content:
-      result.log(f"Artifact {evidence.artifact_name} has empty content")
-      raise ValueError(f"Artifact {evidence.artifact_name} has empty content")
+      result.log(f"Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded")
+      raise ValueError(f"Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded")
     (report, priority, summary) = self.llm_analyze_artifact(
         artifact_content, evidence.artifact_name)
     output_evidence.text_data = report

--- a/turbinia/workers/analysis/llm_analyzer.py
+++ b/turbinia/workers/analysis/llm_analyzer.py
@@ -110,8 +110,12 @@ class LLMAnalyzerTask(workers.TurbiniaTask):
       result.log(f"Artifact {evidence.local_path} not UTF-8 encoded")
 
     if not artifact_content:
-      result.log(f"Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded")
-      raise ValueError(f"Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded")
+      result.log(
+          f"Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded"
+      )
+      raise ValueError(
+          f"Artifact {evidence.artifact_name} has empty content or not UTF-8 encoded"
+      )
     (report, priority, summary) = self.llm_analyze_artifact(
         artifact_content, evidence.artifact_name)
     output_evidence.text_data = report


### PR DESCRIPTION
### Description of the change

The LLM Analyser should fail nicely with non-UTF-8 input. Sometimes the artifact extractions yields non parseble input to the analyser. This PR catches that and logs it.

### Applicable issues
None

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
