### PR TITLE
Add API endpoint download.output

### DIFF
--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -484,18 +484,18 @@ class testTurbiniaAPIServer(unittest.TestCase):
     result = json.loads(result.content)
     self.assertEqual(expected_result, result)
 
-  def testDownloadEvidenceNotFound(self):
-    """Test downloading non existent evidence file path."""
+  def testDownloadNotFound(self):
+    """Test downloading non existent file path."""
     file_path = pathname2url('/non-existing/path with space/does-not-exist.txt')
-    response = self.client.get(f'/api/evidence/download/{file_path}')
+    response = self.client.get(f'/api/download/output/{file_path}')
     self.assertEqual(response.status_code, 404)
 
-  def testDownloadEvidence(self):
-    """Test downloading evidence file path."""
+  def testDownload(self):
+    """Test downloading file path."""
     turbinia_config.OUTPUT_DIR = str(
         os.path.dirname(os.path.realpath(__file__)))
     file_path = pathname2url(f'{turbinia_config.OUTPUT_DIR}/api_server_test.py')
-    response = self.client.get(f'/api/evidence/download/{file_path}')
+    response = self.client.get(f'/api/download/output/{file_path}')
     self.assertEqual(response.status_code, 200)
 
   @mock.patch('turbinia.api.routes.evidence.redis_manager.get_evidence_data')

--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -24,6 +24,7 @@ import json
 import os
 import fakeredis
 import mock
+from urllib.request import pathname2url
 
 from fastapi.testclient import TestClient
 
@@ -481,6 +482,21 @@ class testTurbiniaAPIServer(unittest.TestCase):
     result = self.client.get('/api/jobs')
     result = json.loads(result.content)
     self.assertEqual(expected_result, result)
+
+  def testDownloadEvidenceNotFound(self):
+    """Test downloading non existent evidence file path."""
+    file_path = pathname2url('/non-existing/path with space/does-not-exist.txt')
+    response = self.client.get(f'/api/evidence/download/{file_path}')
+    self.assertEqual(response.status_code, 404)
+
+  def testDownloadEvidence(self):
+    """Test downloading evidence file path."""
+    # set OUTPUT_DIR to current folder
+    turbinia_config.OUTPUT_DIR = os.path.dirname(os.path.realpath(__file__)) 
+    # set file_path to filename of current test script
+    file_path = pathname2url(os.path.basename(__file__))
+    response = self.client.get(f'/api/evidence/download/{file_path}')
+    self.assertEqual(response.status_code, 200)
 
   @mock.patch('turbinia.api.routes.evidence.redis_manager.get_evidence_data')
   def testGetEvidence(self, testGetEvidence):

--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -24,7 +24,6 @@ import json
 import os
 import fakeredis
 import mock
-from urllib.request import pathname2url
 
 from fastapi.testclient import TestClient
 

--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -485,7 +485,7 @@ class testTurbiniaAPIServer(unittest.TestCase):
 
   def testDownloadNotFound(self):
     """Test downloading non existent file path."""
-    file_path = pathname2url('/non-existing/path with space/does-not-exist.txt')
+    file_path = '/non-existing/path with space/does-not-exist.txt'
     response = self.client.get(f'/api/download/output/{file_path}')
     self.assertEqual(response.status_code, 404)
 
@@ -493,7 +493,7 @@ class testTurbiniaAPIServer(unittest.TestCase):
     """Test downloading file path."""
     turbinia_config.OUTPUT_DIR = str(
         os.path.dirname(os.path.realpath(__file__)))
-    file_path = pathname2url(f'{turbinia_config.OUTPUT_DIR}/api_server_test.py')
+    file_path = f'{turbinia_config.OUTPUT_DIR}/api_server_test.py'
     response = self.client.get(f'/api/download/output/{file_path}')
     self.assertEqual(response.status_code, 200)
 

--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -22,6 +22,7 @@ import datetime
 import unittest
 import json
 import os
+import pathlib
 import fakeredis
 import mock
 from urllib.request import pathname2url
@@ -491,10 +492,9 @@ class testTurbiniaAPIServer(unittest.TestCase):
 
   def testDownloadEvidence(self):
     """Test downloading evidence file path."""
-    # set OUTPUT_DIR to current folder
-    turbinia_config.OUTPUT_DIR = os.path.dirname(os.path.realpath(__file__)) 
-    # set file_path to filename of current test script
-    file_path = pathname2url(os.path.basename(__file__))
+    turbinia_config.OUTPUT_DIR = str(
+        os.path.dirname(os.path.realpath(__file__)))
+    file_path = pathname2url(f'{turbinia_config.OUTPUT_DIR}/api_server_test.py')
     response = self.client.get(f'/api/evidence/download/{file_path}')
     self.assertEqual(response.status_code, 200)
 

--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -483,14 +483,14 @@ class testTurbiniaAPIServer(unittest.TestCase):
     result = json.loads(result.content)
     self.assertEqual(expected_result, result)
 
-  def testDownloadNotFound(self):
-    """Test downloading non existent file path."""
+  def testDownloadOutputNotFound(self):
+    """Test downloading non existent output file path."""
     file_path = '/non-existing/path with space/does-not-exist.txt'
     response = self.client.get(f'/api/download/output/{file_path}')
     self.assertEqual(response.status_code, 404)
 
-  def testDownload(self):
-    """Test downloading file path."""
+  def testDownloadOutput(self):
+    """Test downloading output file path."""
     turbinia_config.OUTPUT_DIR = str(
         os.path.dirname(os.path.realpath(__file__)))
     file_path = f'{turbinia_config.OUTPUT_DIR}/api_server_test.py'

--- a/turbinia/api/api_server_test.py
+++ b/turbinia/api/api_server_test.py
@@ -22,7 +22,6 @@ import datetime
 import unittest
 import json
 import os
-import pathlib
 import fakeredis
 import mock
 from urllib.request import pathname2url

--- a/turbinia/api/openapi.yaml
+++ b/turbinia/api/openapi.yaml
@@ -217,11 +217,11 @@ paths:
         summary: Download Configuration
         tags:
         - Turbinia Configuration
-  /api/evidence/download/{file_path}:
+  /api/download/{file_path}:
     get:
-      description: "Download evidence by path.\n\nRaises:\nHTTPException: if another\
+      description: "Download by path.\n\nRaises:\nHTTPException: if another\
         \ exception is caught."
-      operationId: download_evidence
+      operationId: download_file_path
       parameters:
       - in: path
         name: file_path

--- a/turbinia/api/openapi.yaml
+++ b/turbinia/api/openapi.yaml
@@ -217,6 +217,35 @@ paths:
         summary: Download Configuration
         tags:
         - Turbinia Configuration
+  /api/evidence/download/{file_path}:
+    get:
+      description: "Download evidence by path.\n\nRaises:\nHTTPException: if another\
+        \ exception is caught."
+      operationId: download_evidence
+      parameters:
+      - in: path
+        name: file_path
+        required: true
+        schema:
+          title: File Path
+          type: string
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Task Report
+      tags:
+      - Turbinia Tasks
   /api/evidence/query:
     get:
       description: "Queries evidence in Redis that have the specified attribute value.\n\

--- a/turbinia/api/openapi.yaml
+++ b/turbinia/api/openapi.yaml
@@ -217,7 +217,7 @@ paths:
         summary: Download Configuration
         tags:
         - Turbinia Configuration
-  /api/download/{file_path}:
+  /api/download/output/{file_path}:
     get:
       description: "Download by path.\n\nRaises:\nHTTPException: if another\
         \ exception is caught."

--- a/turbinia/api/openapi.yaml
+++ b/turbinia/api/openapi.yaml
@@ -221,7 +221,7 @@ paths:
     get:
       description: "Download by path.\n\nRaises:\nHTTPException: if another\
         \ exception is caught."
-      operationId: download_file_path
+      operationId: download_output_path
       parameters:
       - in: path
         name: file_path

--- a/turbinia/api/routes/download.py
+++ b/turbinia/api/routes/download.py
@@ -26,6 +26,7 @@ from turbinia import config as turbinia_config
 log = logging.getLogger(__name__)
 router = APIRouter(prefix='/download', tags=['Turbinia Download'])
 
+
 @router.get('/output/{file_path:path}')
 async def download_file_path(request: Request, file_path):
   """Downloads evidence file path.
@@ -45,6 +46,3 @@ async def download_file_path(request: Request, file_path):
 
   raise HTTPException(
       status_code=404, detail='Access denied or file not found!')
-
-
-

--- a/turbinia/api/routes/download.py
+++ b/turbinia/api/routes/download.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2022 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Turbinia API - Download router"""
+
+import logging
+import pathlib
+
+from fastapi import HTTPException, APIRouter
+from fastapi.responses import FileResponse
+from fastapi.requests import Request
+
+from turbinia import config as turbinia_config
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix='/download', tags=['Turbinia Download'])
+
+@router.get('/output/{file_path:path}')
+async def download_file_path(request: Request, file_path):
+  """Downloads evidence file path.
+  
+  Args:
+    file_path (str): Path to file.
+  """
+
+  # clean path to prevent path traversals
+  # check if path is below the configured output folder
+  # check if exists and is file
+  print('start')
+  config_output_dir = pathlib.Path(turbinia_config.OUTPUT_DIR)
+  requested_file = pathlib.Path(file_path).resolve()
+  if requested_file.is_relative_to(
+      config_output_dir) and requested_file.is_file():
+    return FileResponse(requested_file)
+
+  raise HTTPException(
+      status_code=404, detail='Access denied or file not found!')
+
+
+

--- a/turbinia/api/routes/download.py
+++ b/turbinia/api/routes/download.py
@@ -37,7 +37,6 @@ async def download_file_path(request: Request, file_path):
   # clean path to prevent path traversals
   # check if path is below the configured output folder
   # check if exists and is file
-  print('start')
   config_output_dir = pathlib.Path(turbinia_config.OUTPUT_DIR)
   requested_file = pathlib.Path(file_path).resolve()
   if requested_file.is_relative_to(

--- a/turbinia/api/routes/download.py
+++ b/turbinia/api/routes/download.py
@@ -23,7 +23,7 @@ from fastapi.requests import Request
 
 from turbinia import config as turbinia_config
 
-log = logging.getLogger(__name__)
+#log = logging.getLogger(__name__)
 router = APIRouter(prefix='/download', tags=['Turbinia Download'])
 
 

--- a/turbinia/api/routes/download.py
+++ b/turbinia/api/routes/download.py
@@ -28,8 +28,8 @@ router = APIRouter(prefix='/download', tags=['Turbinia Download'])
 
 
 @router.get('/output/{file_path:path}')
-async def download_file_path(request: Request, file_path):
-  """Downloads evidence file path.
+async def download_output_path(request: Request, file_path):
+  """Downloads output file path.
   
   Args:
     file_path (str): Path to file.

--- a/turbinia/api/routes/evidence.py
+++ b/turbinia/api/routes/evidence.py
@@ -112,6 +112,7 @@ async def upload_file(
       file_info['hash'] = sha_hash.hexdigest()
   return file_info
 
+
 @router.get('/download/{file_path:path}')
 async def download_evidence(request: Request, file_path):
   """Downloads evidence file path.
@@ -125,13 +126,13 @@ async def download_evidence(request: Request, file_path):
   # check if file exists
   configured_output_path = turbinia_config.OUTPUT_DIR
   abspath = os.path.abspath(file_path)
-  if configured_output_path != os.path.commonpath((configured_output_path, abspath)) or not os.path.isfile(abspath):
+  if configured_output_path != os.path.commonpath(
+      (configured_output_path, abspath)) or not os.path.isfile(abspath):
     raise HTTPException(
         status_code=404,
         detail='File path: access denied or file does not exist')
 
   return FileResponse(file_path)
-
 
 
 @router.get('/types')

--- a/turbinia/api/routes/evidence.py
+++ b/turbinia/api/routes/evidence.py
@@ -129,7 +129,7 @@ async def download_evidence(request: Request, file_path):
   requested_file = pathlib.Path(file_path).resolve()
   if requested_file.is_relative_to(
       config_output_dir) and requested_file.is_file():
-    return FileResponse(file_path)
+    return FileResponse(requested_file)
 
   raise HTTPException(
       status_code=404, detail='Access denied or file not found!')

--- a/turbinia/api/routes/evidence.py
+++ b/turbinia/api/routes/evidence.py
@@ -17,12 +17,11 @@
 import hashlib
 import logging
 import os
-import pathlib
 
 from datetime import datetime
 from fastapi import HTTPException, APIRouter, UploadFile, Query, Form
 from fastapi.requests import Request
-from fastapi.responses import JSONResponse, FileResponse
+from fastapi.responses import JSONResponse
 from typing import List, Annotated
 
 from turbinia import evidence
@@ -112,27 +111,6 @@ async def upload_file(
     if calculate_hash:
       file_info['hash'] = sha_hash.hexdigest()
   return file_info
-
-
-@router.get('/download/{file_path:path}')
-async def download_evidence(request: Request, file_path):
-  """Downloads evidence file path.
-  
-  Args:
-    file_path (str): Path to file.
-  """
-
-  # clean path to prevent path traversals
-  # check if path is below the configured output folder
-  # check if exists and is file
-  config_output_dir = pathlib.Path(turbinia_config.OUTPUT_DIR)
-  requested_file = pathlib.Path(file_path).resolve()
-  if requested_file.is_relative_to(
-      config_output_dir) and requested_file.is_file():
-    return FileResponse(requested_file)
-
-  raise HTTPException(
-      status_code=404, detail='Access denied or file not found!')
 
 
 @router.get('/types')

--- a/turbinia/api/routes/evidence.py
+++ b/turbinia/api/routes/evidence.py
@@ -21,7 +21,7 @@ import os
 from datetime import datetime
 from fastapi import HTTPException, APIRouter, UploadFile, Query, Form
 from fastapi.requests import Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
 from typing import List, Annotated
 
 from turbinia import evidence
@@ -111,6 +111,27 @@ async def upload_file(
     if calculate_hash:
       file_info['hash'] = sha_hash.hexdigest()
   return file_info
+
+@router.get('/download/{file_path:path}')
+async def download_evidence(request: Request, file_path):
+  """Downloads evidence file path.
+  
+  Args:
+    file_path (str): Path to file.
+  """
+
+  # clean path to prevent path traversals
+  # check if path is below the configured output folder
+  # check if file exists
+  configured_output_path = turbinia_config.OUTPUT_DIR
+  abspath = os.path.abspath(file_path)
+  if configured_output_path != os.path.commonpath((configured_output_path, abspath)) or not os.path.isfile(abspath):
+    raise HTTPException(
+        status_code=404,
+        detail='File path: access denied or file does not exist')
+
+  return FileResponse(file_path)
+
 
 
 @router.get('/types')

--- a/turbinia/api/routes/router.py
+++ b/turbinia/api/routes/router.py
@@ -18,6 +18,7 @@ import logging
 from fastapi import APIRouter
 
 from turbinia.api.routes import config
+from turbinia.api.routes import download
 from turbinia.api.routes import evidence
 from turbinia.api.routes import jobs
 from turbinia.api.routes import logs
@@ -32,6 +33,7 @@ api_router = APIRouter(prefix='/api')
 
 # Register all API endpoints.
 api_router.include_router(config.router)
+api_router.include_router(download.router)
 api_router.include_router(evidence.router)
 api_router.include_router(jobs.router)
 api_router.include_router(logs.router)


### PR DESCRIPTION
### Description of the change
Add an API endpoint to download a Turbinia output file `/api/download/output/{file_path}`. 
<!-- Describe what the change does. --

### Applicable issues
None
<!-- Enter any applicable Issues here (You can reference an issue using #) -->

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
- [x] Unit tests added.
- [ ] Documentation updated.
