### PR TITLE
Add WebUI dev documentation and skaffold fix.

### DIFF
--- a/docs/developer/develop-minikube.md
+++ b/docs/developer/develop-minikube.md
@@ -181,6 +181,9 @@ Try our Turbinia minikube development 101 Codelab [here](turbinia-codelab-analys
 #### Debugging API Server
 You can enable debugging by uncommenting the API Server `build` and `setValueTemplates` sections in the `skaffold.yaml` file.
 
+#### Developing and debuggin the WebUI
+The WebUI is developed with Vue and build using node/npm. This means there is no easy way to debug this in the container. We suggest developing with a local running WebUI using `npm run dev` in the `web/` folder. This will spinup a development web server for the WebUI that will talk to the API server managed by skaffold.
+
 #### Google Cloud Code tools not found (minikube, skaffold, kubectl)
 The extension will add the PATH automatically to your config. But if you have a different or custom shell configuration this may fail. Add the path manually to your PATH.
 * Linux: `$HOME/.cache/cloud-code/installer/google-cloud-sdk/bin`

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -40,8 +40,11 @@ build:
     #       TURBINIA_DEBUG: 1
     #       TURBINIA_DEBUG_PORT: 30000
     #   sync:
-    #     infer:
-    #     - turbinia/**
+    #     manual:
+    #     - src: turbinia/**
+    #       dest: .
+    #     - src: web/**
+    #       dest: .
 
 deploy:
   statusCheckDeadlineSeconds: 90

--- a/web/README.md
+++ b/web/README.md
@@ -9,7 +9,7 @@ npm install
 ### Compiles and hot-reloads for development
 
 ```text
-npm run serve
+npm run dev
 ```
 
 ### Compiles and minifies for production


### PR DESCRIPTION
### Description of the change

As the WebUI is build in Vue and we put a minified build in the API server it is not possible to debug this in the containers. This PR:
* adds a paragraph to the dev documentation on how to develop for the WebUI
* changes the skaffold config to prevent rebuilds of the api-server container when developing on the WebUI
* fixes the web README as `npm run serve` does not work as there is no `serve` profile.

<!-- Describe what the change does. -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [x] Documentation updated.
