### PR TITLE
Handle Celery tasks with REVOKED status

### DIFF
--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -70,7 +70,7 @@ REQUIRED_VARS = [
     'API_EVIDENCE_UPLOAD_DIR',
     'API_MAX_UPLOAD_SIZE',
     'WEBUI_PATH',
-    'CELERY_EXPIRATION_TIME'
+    'CELERY_TASK_EXPIRATION_TIME'
 ]
 
 # Optional config vars.  Some may be mandatory depending on the configuration

--- a/turbinia/config/__init__.py
+++ b/turbinia/config/__init__.py
@@ -69,7 +69,8 @@ REQUIRED_VARS = [
     'API_UPLOAD_CHUNK_SIZE',
     'API_EVIDENCE_UPLOAD_DIR',
     'API_MAX_UPLOAD_SIZE',
-    'WEBUI_PATH'
+    'WEBUI_PATH',
+    'CELERY_EXPIRATION_TIME'
 ]
 
 # Optional config vars.  Some may be mandatory depending on the configuration

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -319,6 +319,11 @@ CELERY_BROKER = f'redis://{REDIS_HOST}'
 # Storage for task results/status
 CELERY_BACKEND = f'redis://{REDIS_HOST}'
 
+# Task expiration (in seconds). Tasks will be revoked
+# after the expiration time elapses. Revoked tasks will not
+# be processed by Turbinia workers
+CELERY_EXPIRATION_TIME = 86400  # 24 hours
+
 # Can be the same as CELERY_BROKER
 KOMBU_BROKER = CELERY_BROKER
 

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -322,7 +322,7 @@ CELERY_BACKEND = f'redis://{REDIS_HOST}'
 # Task expiration (in seconds). Tasks will be revoked
 # after the expiration time elapses. Revoked tasks will not
 # be processed by Turbinia workers
-CELERY_EXPIRATION_TIME = 86400  # 24 hours
+CELERY_TASK_EXPIRATION_TIME = 86400  # 24 hours
 
 # Can be the same as CELERY_BROKER
 KOMBU_BROKER = CELERY_BROKER

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -690,7 +690,6 @@ class CeleryTaskManager(BaseTaskManager):
       elif celery_task.status == celery_states.PENDING:
         task.status = 'pending'
         log.debug(f'Task {celery_task.id:s} status pending.')
-
       elif celery_task.status == celery_states.REVOKED:
         message = (
             f'Celery task {celery_task.id:s} associated with Turbinia '

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -692,10 +692,10 @@ class CeleryTaskManager(BaseTaskManager):
         message = (
             f'Celery task {celery_task.id:s} associated with Turbinia '
             f'task {task.id} was revoked. This could be caused if the task is '
-            f'not started before the CELERY_EXPIRATION_TIME or if the user '
-            f'forces the task to be revoked. Task will not be processed.')
+            f'not started before the CELERY_TASK_EXPIRATION_TIME or if the '
+            f'task is manually revoked. Task will not be processed.')
         log.warning(message)
-        task = self.timeout_task(task, config.CELERY_EXPIRATION_TIME)
+        task = self.timeout_task(task, config.CELERY_TASK_EXPIRATION_TIME)
         task.result.status = message
         completed_tasks.append(task)
       else:
@@ -778,4 +778,4 @@ class CeleryTaskManager(BaseTaskManager):
     task.stub = self.celery_runner.apply_async(
         (task.serialize(), evidence_.serialize()), retry=False,
         soft_time_limit=celery_soft_timeout, time_limit=celery_hard_timeout,
-        expires=config.CELERY_EXPIRATION_TIME)
+        expires=config.CELERY_TASK_EXPIRATION_TIME)

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -697,7 +697,6 @@ class CeleryTaskManager(BaseTaskManager):
         log.warning(message)
         task = self.timeout_task(task, config.CELERY_EXPIRATION_TIME)
         task.result.status = message
-        task.result.close(self, success=False, status=message)
         completed_tasks.append(task)
       else:
         check_timeout = True

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -1097,7 +1097,8 @@ class TurbiniaTask:
         self._evidence_config = evidence.config
         self.task_config = self.get_task_recipe(evidence.config)
         self.worker_start_time = datetime.now()
-        self.update_task_status(self, 'running')
+        updated_status = f'{self.id} is running on worker {self.worker_name}'
+        self.update_task_status(self, updated_status)
         self.result = self.run(evidence, self.result)
 
       # pylint: disable=broad-except

--- a/web/src/components/TaskList.vue
+++ b/web/src/components/TaskList.vue
@@ -14,8 +14,7 @@ limitations under the License.
 <template>
   <div>
     <v-list density="compact">
-      <v-empty-state v-if="taskList.length === 0"
-        text="No Tasks are available. Try adjusting your filters.">
+      <v-empty-state v-if="taskList.length === 0" text="No Tasks are available. Try adjusting your filters.">
       </v-empty-state>
       <v-virtual-scroll :items="taskList" :item-height="40" :height="400" v-else>
         <template v-slot:default="{ item }">
@@ -41,7 +40,7 @@ limitations under the License.
               </v-list-item-action>
             </div>
             <v-list-item :max-width="800">
-              {{ item.task_name }} {{ $filters.truncate(item.task_status, 128, '...') }}
+              {{ item.task_name }}: {{ $filters.truncate(item.task_status, 384, '...') }}
             </v-list-item>
           </v-list-item>
           <v-divider> </v-divider>
@@ -77,26 +76,26 @@ export default {
             let taskStatusTemp = task_dict.status
             // As pending status requests show as null or pending
             if (taskStatusTemp === null || taskStatusTemp === "pending") {
-              taskStatusTemp = 'pending on server.'
+              taskStatusTemp = 'is pending on server.'
             }
             if (this.filterJobs.length > 0) {
               let jobName = task_dict.job_name.toLowerCase()
-              if ( this.radioFilter && !this.filterJobs.includes(jobName)) {
+              if (this.radioFilter && !this.filterJobs.includes(jobName)) {
                 continue;
-              } else if ( !this.radioFilter && this.filterJobs.includes(jobName)) {
+              } else if (!this.radioFilter && this.filterJobs.includes(jobName)) {
                 continue
               }
             }
             let taskListTemp = {
-                job_name: task_dict.job_name,
-                task_name: task_dict.name,
-                task_id: task_dict.id,
-                task_status: taskStatusTemp,
-                task_success: task_dict.successful,
-                evidence_name: task_dict.evidence_name,
-                evidence_id: task_dict.evidence_id,
-                evidence_size: task_dict.evidence_size,
-              }
+              job_name: task_dict.job_name,
+              task_name: task_dict.name,
+              task_id: task_dict.id,
+              task_status: taskStatusTemp,
+              task_success: task_dict.successful,
+              evidence_name: task_dict.evidence_name,
+              evidence_id: task_dict.evidence_id,
+              evidence_size: task_dict.evidence_size,
+            }
             // When Failed filter chip is applied
             if (task_dict.successful === false && this.filterFailed) {
               taskList.push(taskListTemp)


### PR DESCRIPTION
### Description of the change

This PR adds logic to handle tasks that are revoked by Celery due to exceeding the task expiration time.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1539 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] All tests were successful.
- [ ] Unit tests added.
- [ ] Documentation updated.
