### PR TITLE
Add ppa_track build arg to cloud build config

### DIFF
--- a/docker/worker/cloudbuild.yaml
+++ b/docker/worker/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
         "-t",
         "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:$TAG_NAME",
         "-t",
-        "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:latest",
+        "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:${_LATEST}",
         "--build-arg",
         "PPA_TRACK=${_PPA_TRACK}",
         "-f",
@@ -17,5 +17,5 @@ steps:
     timeout: 4800s
 timeout: 4800s
 images:
-  - us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:latest
+  - us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:${_LATEST}
   - us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:$TAG_NAME

--- a/docker/worker/cloudbuild.yaml
+++ b/docker/worker/cloudbuild.yaml
@@ -8,6 +8,8 @@ steps:
         "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:$TAG_NAME",
         "-t",
         "us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker:latest",
+        "--build-arg",
+        "PPA_TRACK=${_PPA_TRACK}",
         "-f",
         "docker/worker/Dockerfile",
         ".",


### PR DESCRIPTION
### Description of the change
Adds the PPA_TRACK build argument to the Cloud Build configuration file to build Turbinia worker versions with software from different GIFT PPA tracks.

### Applicable issues



### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
- [x] Unit tests added.
- [ ] Documentation updated.
