### PR TITLE
Various updates to task management

### DIFF
--- a/docker/local/local-config.sed
+++ b/docker/local/local-config.sed
@@ -1,5 +1,5 @@
 s/CELERY_BROKER = .*/CELERY_BROKER = 'redis:\/\/redis'/g
-s/CELERY_BACKEND = .*/CELERY_BACKEND = 'redis:\/\/redis'/g
+s/CELERY_BACKEND = .*/CELERY_BACKEND = 'redis:\/\/redis\/1'/g
 s/REDIS_HOST = .*/REDIS_HOST = 'redis'/g
 s/PROMETHEUS_ENABLED = .*/PROMETHEUS_ENABLED = False/g
 s/STATE_MANAGER = .*/STATE_MANAGER = 'Redis'/g

--- a/turbinia/api/cli/turbinia_client/core/groups.py
+++ b/turbinia/api/cli/turbinia_client/core/groups.py
@@ -87,4 +87,3 @@ def submit_group(ctx: click.Context):
   of available evidence types.
   """
   ctx.invoke(setup_submit)
-  click.echo(submit_group.get_help(ctx))

--- a/turbinia/config/turbinia_config_tmpl.py
+++ b/turbinia/config/turbinia_config_tmpl.py
@@ -317,7 +317,7 @@ REDIS_DB = '0'
 CELERY_BROKER = f'redis://{REDIS_HOST}'
 
 # Storage for task results/status
-CELERY_BACKEND = f'redis://{REDIS_HOST}'
+CELERY_BACKEND = f'redis://{REDIS_HOST}/1'
 
 # Task expiration (in seconds). Tasks will be revoked
 # after the expiration time elapses. Revoked tasks will not

--- a/turbinia/evidence.py
+++ b/turbinia/evidence.py
@@ -533,7 +533,7 @@ class Evidence:
       if self.resource_tracked:
         # Track resource and task id in state file
         log.debug(
-            'Evidence {0:s} is resource tracked. Acquiring filelock for'
+            'Evidence {0:s} is resource tracked. Acquiring filelock for '
             'preprocessing'.format(self.name))
         with filelock.FileLock(config.RESOURCE_FILE_LOCK):
           resource_manager.PreprocessResourceState(self.resource_id, task_id)
@@ -565,7 +565,7 @@ class Evidence:
 
     if self.resource_tracked:
       log.debug(
-          'Evidence: {0:s} is resource tracked. Acquiring filelock for '
+          'Evidence {0:s} is resource tracked. Acquiring filelock for '
           'postprocessing.'.format(self.name))
       with filelock.FileLock(config.RESOURCE_FILE_LOCK):
         # Run postprocess to either remove task_id or resource_id.

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -616,7 +616,8 @@ class RedisStateManager(BaseStateManager):
       request_status = 'successful'
     elif len(request_data['task_ids']) == len(request_data['failed_tasks']):
       request_status = 'failed'
-    elif len(request_data['running_tasks']) > 0:
+    elif len(request_data['running_tasks']) > 0 or len(
+        request_data['queued_tasks']) > 0:
       request_status = 'running'
     elif len(request_data['failed_tasks']) > 0 and all_tasks_finished:
       request_status = 'completed_with_errors'

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -292,10 +292,11 @@ class RedisStateManager(BaseStateManager):
           self.redis_client.add_to_list(request_key, 'failed_tasks', task.id)
           statuses_to_remove.remove('failed_tasks')
       task_status = self.redis_client.get_attribute(task_key, 'status')
-      if task_status == 'running':
+      if task_status and 'running' in task_status:
         self.redis_client.add_to_list(request_key, 'running_tasks', task.id)
         statuses_to_remove.remove('running_tasks')
-      elif task_status is None or task_status == 'queued':
+      elif (task_status is None or task_status == 'queued' or
+            task_status == 'pending'):
         self.redis_client.add_to_list(request_key, 'queued_tasks', task.id)
         statuses_to_remove.remove('queued_tasks')
       for status_name in statuses_to_remove:

--- a/turbinia/state_manager.py
+++ b/turbinia/state_manager.py
@@ -292,7 +292,7 @@ class RedisStateManager(BaseStateManager):
           self.redis_client.add_to_list(request_key, 'failed_tasks', task.id)
           statuses_to_remove.remove('failed_tasks')
       task_status = self.redis_client.get_attribute(task_key, 'status')
-      if task_status and 'running' in task_status:
+      if task_status and 'Task is running' in task_status:
         self.redis_client.add_to_list(request_key, 'running_tasks', task.id)
         statuses_to_remove.remove('running_tasks')
       elif (task_status is None or task_status == 'queued' or

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -713,7 +713,11 @@ class CeleryTaskManager(BaseTaskManager):
       elif celery_task.status == celery_states.PENDING:
         task.status = 'pending'
         check_timeout = True
-        log.debug(f'Task {celery_task.id:s} status pending.')
+        log.debug(f'Task {celery_task.id:s} is pending.')
+      elif celery_task.status == celery_states.RECEIVED:
+        task.status = 'queued'
+        check_timeout = True
+        log.debug(f'Task {celery_task.id:s} is queued.')
       elif celery_task.status == celery_states.REVOKED:
         message = (
             f'Celery task {celery_task.id:s} associated with Turbinia '

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -700,8 +700,8 @@ class CeleryTaskManager(BaseTaskManager):
         log.debug(f'Task {task.stub.task_id:s} not yet created.')
         check_timeout = True
       elif celery_task.status == celery_states.STARTED:
+        # Task status will be set to running when the worker executes run_wrapper()
         log.debug(f'Task {celery_task.id:s} not finished.')
-        # set status here too
         check_timeout = True
       elif celery_task.status == celery_states.FAILURE:
         log.warning(f'Task {celery_task.id:s} failed.')
@@ -712,7 +712,6 @@ class CeleryTaskManager(BaseTaskManager):
         completed_tasks.append(task)
       elif celery_task.status == celery_states.PENDING:
         task.status = 'pending'
-        # set status here too
         check_timeout = True
         log.debug(f'Task {celery_task.id:s} status pending.')
       elif celery_task.status == celery_states.REVOKED:

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -518,11 +518,6 @@ class BaseTaskManager:
           f'from {task_result.worker_name} executed with status '
           f'[{task_result.status}]')
 
-    task_key = self.state_manager.redis_client.build_key_name(
-        'task', task_result.id)
-    self.state_manager.redis_client.set_attribute(
-        task_key, 'successful', 'false')
-
     if not isinstance(task_result.evidence, list):
       log.warning(
           f'Task {task_result.task_id} {task_result.task_name} '

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -628,7 +628,6 @@ class BaseTaskManager:
     Returns:
       TurbiniaTask: The updated Task.
     """
-    
     result = workers.TurbiniaTaskResult(
         request_id=task.request_id, no_output_manager=True,
         no_state_manager=True)

--- a/turbinia/task_manager.py
+++ b/turbinia/task_manager.py
@@ -620,6 +620,15 @@ class BaseTaskManager:
       time.sleep(config.SLEEP_TIME)
 
   def close_failed_task(self, task):
+    """Sets status and result data for failed Task.
+
+    Args:
+      task(TurbiniaTask): The Task that will be closed.
+
+    Returns:
+      TurbiniaTask: The updated Task.
+    """
+    
     result = workers.TurbiniaTaskResult(
         request_id=task.request_id, no_output_manager=True,
         no_state_manager=True)

--- a/turbinia/tcelery.py
+++ b/turbinia/tcelery.py
@@ -56,7 +56,6 @@ class TurbiniaCelery:
         worker_cancel_long_running_tasks_on_connection_loss=True,
         worker_concurrency=1,
         worker_prefetch_multiplier=1,
-        task_acks_late=True,  # ack task after execution
         task_reject_on_worker_lost=True,  # Re-queue task if celery worker abruptly exists
         worker_deduplicate_successful_tasks=True)  # avoid task duplication
 

--- a/turbinia/tcelery.py
+++ b/turbinia/tcelery.py
@@ -56,7 +56,9 @@ class TurbiniaCelery:
         worker_cancel_long_running_tasks_on_connection_loss=True,
         worker_concurrency=1,
         worker_prefetch_multiplier=1,
-    )
+        task_acks_late=True,  # ack task after execution
+        task_reject_on_worker_lost=True,  # Re-queue task if celery worker abruptly exists
+        worker_deduplicate_successful_tasks=True)  # avoid task duplication
 
 
 class TurbiniaKombu(TurbiniaMessageBase):

--- a/turbinia/tcelery.py
+++ b/turbinia/tcelery.py
@@ -50,14 +50,18 @@ class TurbiniaCelery:
     self.app = celery.Celery(
         'turbinia', broker=config.CELERY_BROKER, backend=config.CELERY_BACKEND)
     self.app.conf.update(
-        broker_connection_retry_on_startup=True,
-        task_default_queue=config.INSTANCE_ID,
         accept_content=['json'],
+        broker_connection_retry_on_startup=True,
+        # Store Celery task results metadata
+        result_backend=config.CELERY_BACKEND,
+        task_default_queue=config.INSTANCE_ID,
+        # Re-queue task if Celery worker abruptly exists
+        task_reject_on_worker_lost=True,
         worker_cancel_long_running_tasks_on_connection_loss=True,
         worker_concurrency=1,
         worker_prefetch_multiplier=1,
-        task_reject_on_worker_lost=True,  # Re-queue task if celery worker abruptly exists
-        worker_deduplicate_successful_tasks=True)  # avoid task duplication
+        # Avoid task duplication
+        worker_deduplicate_successful_tasks=True)
 
 
 class TurbiniaKombu(TurbiniaMessageBase):

--- a/turbinia/worker.py
+++ b/turbinia/worker.py
@@ -27,7 +27,6 @@ from turbinia import TurbiniaException
 from turbinia import job_utils
 from turbinia.lib import docker_manager
 from turbinia.jobs import manager as job_manager
-from turbinia.tcelery import TurbiniaCelery
 
 config.LoadConfig()
 task_manager_type = config.TASK_MANAGER.lower()
@@ -249,7 +248,6 @@ class TurbiniaCeleryWorker(TurbiniaWorkerBase):
     # no apparent benefit from having this enabled at the moment.
     self.worker.task(task_utils.task_runner, name='task_runner')
     argv = [
-        'worker', '--loglevel=info', '--concurrency=1', '--without-gossip',
-        '--without-mingle'
+        'worker', '--loglevel=info', '--concurrency=1', '--without-gossip', '-E'
     ]
     self.worker.start(argv)

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -454,7 +454,7 @@ class TurbiniaTask:
   STORED_ATTRIBUTES = [
       'id', 'job_id', 'job_name', 'start_time', 'last_update', 'name',
       'evidence_name', 'evidence_id', 'request_id', 'requester', 'group_name',
-      'reason', 'group_id'
+      'reason', 'group_id', 'celery_id'
   ]
 
   # The list of evidence states that are required by a Task in order to run.
@@ -482,6 +482,7 @@ class TurbiniaTask:
       self.base_output_dir = config.OUTPUT_DIR
 
     self.id = uuid.uuid4().hex
+    self.celery_id = None
     self.is_finalize_task = False
     self.job_id = None
     self.job_name = None
@@ -507,7 +508,6 @@ class TurbiniaTask:
     self.group_name = group_name
     self.reason = reason
     self.group_id = group_id
-    self.worker_name = platform.node()
 
   def serialize(self):
     """Converts the TurbiniaTask object into a serializable dict.
@@ -1097,7 +1097,13 @@ class TurbiniaTask:
         self._evidence_config = evidence.config
         self.task_config = self.get_task_recipe(evidence.config)
         self.worker_start_time = datetime.now()
-        updated_status = f'{self.id} is running on worker {self.worker_name}'
+        # Update task status so we know which worker the task executed on.
+        worker_name = platform.node()
+        updated_status = f'Task is running on {worker_name}'
+        task_key = self.state_manager.redis_client.build_key_name(
+            'task', self.id)
+        self.state_manager.redis_client.set_attribute(
+            task_key, 'worker_name', json.dumps(worker_name))
         self.update_task_status(self, updated_status)
         self.result = self.run(evidence, self.result)
 
@@ -1194,9 +1200,8 @@ class TurbiniaTask:
       status (str): Brief word or phrase for Task state. If not supplied, the
           existing Task status will be used.
     """
-    if status:
-      task.status = 'Task {0!s} is {1!s} on {2!s}'.format(
-          self.name, status, self.worker_name)
+    if not status:
+      return
     if not self.state_manager:
       self.state_manager = state_manager.get_state_manager()
     if self.state_manager:

--- a/turbinia/workers/__init__.py
+++ b/turbinia/workers/__init__.py
@@ -1043,7 +1043,14 @@ class TurbiniaTask:
     try:
       evidence = evidence_decode(evidence)
       self.result = self.setup(evidence)
+      # Call update_task_status to update status
+      # We cannot call update_task() here since it will clobber previously
+      # stored data by the Turbinia server when the task was created, which is
+      # not present in the TurbiniaTask object the worker currently has in its
+      # runtime.
       self.update_task_status(self, 'queued')
+      # Beucase of the same reason, we perform a single attribute update
+      # for the worker name.
       task_key = self.state_manager.redis_client.build_key_name('task', self.id)
       self.state_manager.redis_client.set_attribute(
           task_key, 'worker_name', json.dumps(worker_name))

--- a/turbinia/workers/dfdewey.py
+++ b/turbinia/workers/dfdewey.py
@@ -91,7 +91,7 @@ class DfdeweyTask(TurbiniaTask):
         result.log(status_summary)
     else:
       status_summary = (
-          'Not running dfDewey. Case was not provided in task config.')
+          'dfDewey will not execute. Case was not provided in task config.')
       result.log(status_summary)
 
     result.close(self, success=success, status=status_summary)

--- a/turbinia/workers/fsstat.py
+++ b/turbinia/workers/fsstat.py
@@ -45,7 +45,7 @@ class FsstatTask(TurbiniaTask):
     # Since fsstat does not support some filesystems, we won't run it when we
     # know the partition is not supported.
     elif evidence.path_spec.type_indicator in ("APFS", "XFS"):
-      message = 'Not running fsstat since partition is not supported'
+      message = 'Not processing since partition is not supported'
       result.log(message)
       result.close(self, success=True, status=message)
     else:

--- a/web/src/components/RequestDetails.vue
+++ b/web/src/components/RequestDetails.vue
@@ -41,11 +41,15 @@ limitations under the License.
     </v-alert>
     <v-alert v-else-if="requestDetails.status === 'running'" type="info" prominent>
       Request <strong>{{ requestDetails.request_id }}</strong> has <strong>{{ requestDetails.task_count -
-          requestDetails.successful_tasks - requestDetails.failed_tasks }}</strong> Tasks remaining.
+        requestDetails.successful_tasks - requestDetails.failed_tasks }}</strong> Tasks remaining.
     </v-alert>
     <v-alert v-else-if="requestDetails.status === 'completed_with_errors'" type="warning" prominent>
       Request <strong>{{ requestDetails.request_id }}</strong> completed with <strong>{{ requestDetails.failed_tasks
         }}</strong> failed Tasks.
+    </v-alert>
+    <v-alert v-else-if="requestDetails.status === 'pending'" type="info" prominent>
+      Request <strong>{{ requestDetails.request_id }}</strong> has <strong>{{ requestDetails.queued_tasks
+       }}</strong> Tasks pending.
     </v-alert>
     <v-alert v-else type="error" prominent>
       Request <strong>{{ requestDetails.request_id }}</strong> was not successful.

--- a/web/src/components/RequestList.vue
+++ b/web/src/components/RequestList.vue
@@ -17,14 +17,14 @@ limitations under the License.
       <div class="text-center pa-4">
         <v-dialog v-model="openDialog" width="auto">
           <v-card max-width="400" prepend-icon="mdi-filter-menu"
-            text="You may filter by Job Name either including or excluding Jobs."
-            title="Filter by Job Name">
+            text="You may filter by Job Name either including or excluding Jobs." title="Filter by Job Name">
             <v-form @submit.prevent>
               <v-radio-group v-model="radioFilter">
                 <v-radio label="Including Jobs" :value="true"></v-radio>
                 <v-radio label="Excluding Jobs" :value="false"></v-radio>
               </v-radio-group>
-              <v-select clearable chips label="Select" :items="this.availableJobs" v-model="filterJobs" multiple></v-select>
+              <v-select clearable chips label="Select" :items="this.availableJobs" v-model="filterJobs"
+                multiple></v-select>
             </v-form>
             <template v-slot:actions>
               <v-btn type="submit" @click="filterSelectedJobs" class="ms-auto" text="Submit"></v-btn>
@@ -38,7 +38,8 @@ limitations under the License.
       <template v-slot:append>
         <v-tooltip right>
           <template v-slot:activator="{ props }">
-            <v-btn icon="mdi-refresh" color="blue lighten-2" @click="getRequestList()" v-bind="props" class="justify-left">
+            <v-btn icon="mdi-refresh" color="blue lighten-2" @click="getRequestList()" v-bind="props"
+              class="justify-left">
             </v-btn>
           </template>
           Refresh Request List
@@ -65,7 +66,7 @@ limitations under the License.
             <v-tooltip location="top">
               <template v-slot:activator="{ props }">
                 <v-chip v-bind="props" text="Failed" filter @click="this.filterFailed = !this.filterFailed">
-                </v-chip> 
+                </v-chip>
               </template>
               Filter by failed Tasks
             </v-tooltip>
@@ -73,7 +74,7 @@ limitations under the License.
           <v-tooltip location="right">
             <template v-slot:activator="{ props }">
               <v-btn v-bind="props" variant="text" icon="mdi-filter" @click="openDialog = true"
-              selected-class="activated" :class="{ activated: jobFilterActive == true }">
+                selected-class="activated" :class="{ activated: jobFilterActive == true }">
               </v-btn>
             </template>
             Filter by Job Name
@@ -85,9 +86,9 @@ limitations under the License.
         item-value="request_id" :footer-props="{ itemsPerPageOptions: [10, 20, 40, -1] }" :loading="isLoading"
         :sort-by="sortBy" multi-sort show-expand hover>
         <template v-slot:[`item.request_id`]="{ item }">
-          <v-btn variant="text" :ripple="true" :key="item.request_id" 
-          @click="getRequestDetails(item.request_id) + selectActiveRow(item.request_id)"
-          selected-class="activated" :class="{ activated: isActiveRow == item.request_id }">
+          <v-btn variant="text" :ripple="true" :key="item.request_id"
+            @click="getRequestDetails(item.request_id) + selectActiveRow(item.request_id)" selected-class="activated"
+            :class="{ activated: isActiveRow == item.request_id }">
             {{ item.request_id }}
           </v-btn>
         </template>
@@ -127,9 +128,11 @@ limitations under the License.
         <template v-slot:expanded-row="{ columns, item }">
           <tr>
             <td :colspan="columns.length">
-              <task-list :request-id="item.request_id" :key="this.filterJobs + this.filterRunning + this.filterFailed + this.filterSuccess"
-              :filterRunning="this.filterRunning" :filterFailed="this.filterFailed" :filterSuccess="this.filterSuccess" :filterJobs="this.filterJobs" 
-              :radioFilter="this.radioFilter" :isActiveRow="this.isActiveRow"> 
+              <task-list :request-id="item.request_id"
+                :key="this.filterJobs + this.filterRunning + this.filterFailed + this.filterSuccess"
+                :filterRunning="this.filterRunning" :filterFailed="this.filterFailed"
+                :filterSuccess="this.filterSuccess" :filterJobs="this.filterJobs" :radioFilter="this.radioFilter"
+                :isActiveRow="this.isActiveRow">
               </task-list>
             </td>
           </tr>
@@ -160,8 +163,8 @@ export default {
       headers: [
         { title: '', key: 'data-table-expand', width: '1%' },
         { title: 'Request', key: 'request_id', width: '15%' },
-        { title: 'Last Task Update Time', key: 'last_task_update_time', width:'20%' },
-        { title: 'Evidence Name', key: 'evidence_name', width: '25%'},
+        { title: 'Last Task Update Time', key: 'last_task_update_time', width: '20%' },
+        { title: 'Evidence Name', key: 'evidence_name', width: '25%' },
         { title: 'Requester', key: 'requester', width: '12%' },
         { title: 'Reason', key: 'request_id_reason', width: '10%' },
         { title: 'Status', key: 'status', width: '10%' },
@@ -189,7 +192,7 @@ export default {
           let requestSummary = []
           let data = response.data['requests_status']
           for (const req in data) {
-            let outstanding_perc = Math.round(
+            let outstanding_perc = Math.floor(
               ((data[req].failed_tasks + data[req].successful_tasks) / data[req].task_count) * 100
             )
             let reason = null
@@ -235,28 +238,28 @@ export default {
           console.error(e)
         })
     },
-   getAvailableJobs: function() {
-    ApiClient.getAvailableJobs()
-      .then((response) => {
-        let available = response.data
-        this.availableJobs = available.sort()
-      })
-      .catch((e) => {
-        console.error(e)
-      })
-   },
-   filterSelectedJobs: function() {
-    if (this.filterJobs.length > 0) {
-      this.jobFilterActive = true
-    } else {
-      this.jobFilterActive = false
+    getAvailableJobs: function () {
+      ApiClient.getAvailableJobs()
+        .then((response) => {
+          let available = response.data
+          this.availableJobs = available.sort()
+        })
+        .catch((e) => {
+          console.error(e)
+        })
+    },
+    filterSelectedJobs: function () {
+      if (this.filterJobs.length > 0) {
+        this.jobFilterActive = true
+      } else {
+        this.jobFilterActive = false
+      }
+      this.openDialog = false
+    },
+    selectActiveRow: function (id) {
+      // Accepts Request ID or Task ID
+      this.isActiveRow = id
     }
-    this.openDialog = false
-   },
-   selectActiveRow: function(id) {
-    // Accepts Request ID or Task ID
-    this.isActiveRow = id
-   }
   },
   mounted() {
     this.getRequestList()
@@ -266,9 +269,7 @@ export default {
 </script>
 
 <style scoped>
-
 .activated {
   background-color: rgba(128, 128, 128, 0.4);
 }
-
 </style>

--- a/web/src/components/TaskDetails.vue
+++ b/web/src/components/TaskDetails.vue
@@ -164,6 +164,9 @@ limitations under the License.
             <div v-if="taskDetails.successful">
               {{ taskDetails.successful }}
             </div>
+            <div v-else-if="taskDetails.successful == false">
+              False
+            </div>
             <div v-else>N/A</div>
           </v-list-item>
           <v-list-item title="Run Time:">

--- a/web/src/components/TaskDetails.vue
+++ b/web/src/components/TaskDetails.vue
@@ -40,7 +40,10 @@ limitations under the License.
       {{ taskDetails.status }}
     </v-alert>
     <v-alert v-else-if="taskDetails.successful === null" type="info" prominent>
-      {{ taskDetails.status }}
+      <div v-if="taskDetails.status">
+        {{ taskDetails.status }}
+      </div>
+      <div v-else>Task {{ taskDetails.id }} is pending</div>
     </v-alert>
     <v-alert v-else type="error" prominent>
       {{ taskDetails.status }}
@@ -60,6 +63,12 @@ limitations under the License.
           <v-list-item title="Request ID:">
             <div v-if="taskDetails.request_id">
               {{ taskDetails.request_id }}
+            </div>
+            <div v-else>N/A</div>
+          </v-list-item>
+          <v-list-item title="Celery ID:">
+            <div v-if="taskDetails.celery_id">
+              {{ taskDetails.celery_id }}
             </div>
             <div v-else>N/A</div>
           </v-list-item>
@@ -107,10 +116,10 @@ limitations under the License.
                 </template>
               </v-tooltip>
             </template>
-            <v-snackbar v-model="evidenceSnackbar" color="primary" location="top" height="55" timeout="2000"> 
+            <v-snackbar v-model="evidenceSnackbar" color="primary" location="top" height="55" timeout="2000">
               Evidence output is downloading...
             </v-snackbar>
-            <v-snackbar v-model="notCopyable" color="red" location="top" height="55" timeout="2000"> 
+            <v-snackbar v-model="notCopyable" color="red" location="top" height="55" timeout="2000">
               Evidence type is not supported for downloading.
             </v-snackbar>
             <div v-if="taskDetails.evidence_name">
@@ -140,7 +149,8 @@ limitations under the License.
             <template v-if="taskDetails.worker_name" v-slot:append>
               <v-tooltip location="top" text="Download Worker Logs (defaults to most recent 500 entries)">
                 <template v-slot:activator="{ props: tooltip }">
-                  <v-btn icon="mdi-database-outline" v-bind="tooltip" @click="downloadWorkerLogs(taskDetails.worker_name)">
+                  <v-btn icon="mdi-database-outline" v-bind="tooltip"
+                    @click="downloadWorkerLogs(taskDetails.worker_name)">
                   </v-btn>
                 </template>
               </v-tooltip>

--- a/web/src/components/TaskList.vue
+++ b/web/src/components/TaskList.vue
@@ -78,6 +78,9 @@ export default {
             if (taskStatusTemp === null || taskStatusTemp === "pending") {
               taskStatusTemp = 'is pending on server.'
             }
+            else if (taskStatusTemp == "queued") {
+              taskStatusTemp = 'is queued for execution.'
+            }
             if (this.filterJobs.length > 0) {
               let jobName = task_dict.job_name.toLowerCase()
               if (this.radioFilter && !this.filterJobs.includes(jobName)) {

--- a/web/src/components/TaskList.vue
+++ b/web/src/components/TaskList.vue
@@ -40,7 +40,7 @@ limitations under the License.
               </v-list-item-action>
             </div>
             <v-list-item :max-width="800">
-              {{ item.task_name }}: {{ $filters.truncate(item.task_status, 384, '...') }}
+              {{ item.task_name }} {{ $filters.truncate(item.task_status, 384, '...') }}
             </v-list-item>
           </v-list-item>
           <v-divider> </v-divider>


### PR DESCRIPTION
### Description of the change

This PR
- Fixes an issue in which task status is not properly tracked, which caused request status to never fully complete.
- Adds a ```result_backend``` configuration option for Celery in order to persist celery task metadata in Redis.
- Adds a ```worker_deduplicate_successful_tasks``` configuration option to Celery to avoid duplicate messages of successful tasks.
- Adds a ```task_reject_on_worker_lost``` configuration option to Celery so tasks can be re-queued if a worker abruptly exists (e.g. SIGTERM/SIGKILL signal sent from GKE or OS process to celery worker)
- Adds a ```celery_id``` attribute to Turbinia tasks for traceability between Turbinia and Celery tasks.
- Enables ```Celery mingle``` in the configuration to be able to handle revoked tasks between workers and worker clock synchronization.
- adds some additional exception handling when queueing tasks.
- adds some minor UI enhancements.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #1556 
- fixes an issue with task state tracking

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.
- [X] Unit tests added.
- [X] Documentation updated.
