### PR TITLE
Add local docker compose debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,21 @@
             ]
         },
         {
+            "name": "Attach debugpy API Server",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port":30000
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/home/turbinia"
+                }
+            ]
+        },
+        {
             "name": "Turbinia API Client",
             "type": "debugpy",
             "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Attach to Worker",
+            "name": "Attach debugpy Worker",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port":10000
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/home/turbinia"
+                }
+            ]
+        },
+        {
+            "name": "Attach debugpy Server",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port":20000
+            },
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "/home/turbinia"
+                }
+            ]
+        },
+        {
+            "name": "Attach k8s Worker",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "language": "Python",
@@ -14,7 +44,7 @@
             "remoteRoot": "/home/turbinia"
         },
         {
-            "name": "Attach to Server",
+            "name": "Attach k8s Server",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "language": "Python",
@@ -26,7 +56,7 @@
             "remoteRoot": "/home/turbinia"
         },
         {
-            "name": "Attach to API Server",
+            "name": "Attach k8s API Server",
             "type": "cloudcode.kubernetes",
             "request": "attach",
             "language": "Python",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,15 @@
             ]
         },
         {
+            "name": "Turbinia API Client",
+            "type": "debugpy",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "program": "turbinia/api/cli/turbinia_client/turbiniacli_tool.py",
+            "args": "${input:apiClientCommand}",
+            "console": "integratedTerminal",
+        },
+        {
             "name": "Attach k8s Worker",
             "type": "cloudcode.kubernetes",
             "request": "attach",
@@ -67,5 +76,13 @@
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/home/turbinia"
         }
-    ]
+    ],
+    "inputs": [
+    {
+      "id": "apiClientCommand",
+      "type": "promptString",
+      "description": "API Client Command",
+      "default": "config list"
+    }
+  ]
 }

--- a/docker/api_server/Dockerfile.dockerignore
+++ b/docker/api_server/Dockerfile.dockerignore
@@ -15,3 +15,6 @@ build
 __pycache__
 .cache
 turbinia.egg-info
+conf/
+redis-data/
+evidence/

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -25,6 +25,8 @@ services:
             - LC_ALL=C.UTF-8
             - LANG=C.UTF-8
             - TURBINIA_EXTRA_ARGS=${TURBINIA_EXTRA_ARGS}
+        ports:
+            - 20000:20000
 
     turbinia-api-server:
         #image: "turbinia-api-server-dev" # Use this for local development and comment out below line
@@ -41,6 +43,8 @@ services:
             - TURBINIA_EXTRA_ARGS=${TURBINIA_EXTRA_ARGS}
         expose:
             - "8000"
+        ports:
+            - 30000:30000
 
     turbinia-worker:
         #image: "turbinia-worker-dev" # Use this for local development and comment out below line
@@ -56,6 +60,8 @@ services:
             - LC_ALL=C.UTF-8
             - LANG=C.UTF-8
             - TURBINIA_EXTRA_ARGS=${TURBINIA_EXTRA_ARGS}
+        ports:
+            - 10000:10000
 
     # Uncomment below in case you want to run a second worker on the same host.
     #  turbinia-worker2:

--- a/docker/local/docker-compose.yml
+++ b/docker/local/docker-compose.yml
@@ -26,7 +26,7 @@ services:
             - LANG=C.UTF-8
             - TURBINIA_EXTRA_ARGS=${TURBINIA_EXTRA_ARGS}
         ports:
-            - 20000:20000
+            - 127.0.0.1:20000:20000
 
     turbinia-api-server:
         #image: "turbinia-api-server-dev" # Use this for local development and comment out below line
@@ -44,7 +44,8 @@ services:
         expose:
             - "8000"
         ports:
-            - 30000:30000
+            - 127.0.0.1:30000:30000
+            - 127.0.0.1:8000:8000
 
     turbinia-worker:
         #image: "turbinia-worker-dev" # Use this for local development and comment out below line
@@ -61,7 +62,7 @@ services:
             - LANG=C.UTF-8
             - TURBINIA_EXTRA_ARGS=${TURBINIA_EXTRA_ARGS}
         ports:
-            - 10000:10000
+            - 127.0.0.1:10000:10000
 
     # Uncomment below in case you want to run a second worker on the same host.
     #  turbinia-worker2:

--- a/docker/local/setup.sh
+++ b/docker/local/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+mkdir redis-data
+mkdir evidence
+mkdir conf
+chmod 777 conf evidence redis-data
+sed -f docker/local/local-config.sed turbinia/config/turbinia_config_tmpl.py > conf/turbinia.conf

--- a/docker/server/Dockerfile.dockerignore
+++ b/docker/server/Dockerfile.dockerignore
@@ -16,3 +16,6 @@ charts
 __pycache__
 .cache
 turbinia.egg-info
+conf/
+redis-data/
+evidence/

--- a/docker/worker/Dockerfile.dockerignore
+++ b/docker/worker/Dockerfile.dockerignore
@@ -16,3 +16,6 @@ charts
 __pycache__
 .cache
 turbinia.egg-info
+conf/
+redis-data/
+evidence/


### PR DESCRIPTION
### Description of the change

Add local docker compose debugging settings and vscode launch configurations. This allows for local docker compose debugging of worker and server in vscode.

Extra:
- add local runtime folders to docker ignore files.
- add helper setup.sh to setup local docker compose folders.

### Applicable issues

None


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] All tests were successful.
- [x] Unit tests added.
- [ ] Documentation updated.
