### PR TITLE
Don't force password hash algo

### DIFF
--- a/turbinia/workers/analysis/linux_acct.py
+++ b/turbinia/workers/analysis/linux_acct.py
@@ -129,9 +129,8 @@ class LinuxAccountAnalysisTask(TurbiniaTask):
     summary = 'No weak passwords found'
     priority = Priority.LOW
 
-    # 1800 is "sha512crypt $6$, SHA512 (Unix)"
     weak_passwords = bruteforce_password_hashes(
-        shadow, tmp_dir=self.tmp_dir, timeout=timeout, extra_args='-m 1800')
+        shadow, tmp_dir=self.tmp_dir, timeout=timeout)
 
     if weak_passwords:
       priority = Priority.CRITICAL


### PR DESCRIPTION
We assumed the password would always be `$6$` but we recently encountered `$1$` so let's let Hashcat autodetect