### PR TITLE
Return nil error in Fraken inner loop

### DIFF
--- a/tools/fraken/main.go
+++ b/tools/fraken/main.go
@@ -353,7 +353,7 @@ func filesystemScan(wait chan struct{}, c chan *Detection, minimumScore int) {
 	err := filepath.Walk(*scanPathFlag, func(filePath string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
 			log.Printf("Error walking dir %v: %v\n", filePath, err)
-			return err
+			return nil
 		}
 		if !fileInfo.Mode().IsRegular() {
 			return nil


### PR DESCRIPTION
Returning a non-nil value errors out too early
