### PR TITLE
Fix yara update logic

### DIFF
--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -66,7 +66,7 @@ class YaraAnalysisTask(TurbiniaTask):
     log.debug('Updating Yara rules')
     for repo, path in rules.items():
       try:
-        repository = git.Repo(path)
+        repository = git.Repo.clone_fome(repo, path)
         origin = repository.remotes.origin
         origin.pull(ff=True, depth=1)
         log.info('Successfully updated rules from %s in %s', repo, path)

--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -70,6 +70,9 @@ class YaraAnalysisTask(TurbiniaTask):
         origin = repository.remotes.origin
         origin.pull(ff=True, depth=1)
         log.info('Successfully updated rules from %s in %s', repo, path)
+      except git.exc.GitCommandError as e:
+        log.error('Error cloning Yara rules: {0!s}'.format(e))
+        return False
       except git.exc.InvalidGitRepositoryError as e:
         log.error(
             'InvalidGitRepositoryError updating rules in %s: %s', path, str(e),

--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -64,6 +64,8 @@ class YaraAnalysisTask(TurbiniaTask):
       rules = self.RULES
 
     log.debug('Updating Yara rules')
+    update_success = True
+
     for repo, path in rules.items():
       log.info('Processing Yara rules for: {0:s}'.format(repo))
 
@@ -75,25 +77,29 @@ class YaraAnalysisTask(TurbiniaTask):
           log.info('Yara rules cloned successfully.')
         except git.exc.GitCommandError as e:
           log.error('Error cloning Yara rules from {0:s}: {1!s}'.format(repo, e))
-          continue  # Skip to git pull if this one fails
+	  update_success = False
+          continue  # Skip to next repo
       else:
         try:
           repository = git.Repo(path)
           origin = repository.remotes.origin
           origin.pull(ff=True, depth=1)
           log.info('Successfully updated rules from %s in %s', repo, path)
-          except git.exc.InvalidGitRepositoryError as e:
-            log.error(
-                'InvalidGitRepositoryError updating rules in %s: %s', path, str(e),
+        except git.exc.InvalidGitRepositoryError as e:
+          log.error(
+              'InvalidGitRepositoryError updating rules in %s: %s', path, str(e),
                 exc_info=True)
-            return False
-          except Exception as e:
-            log.error(
-                'Unknown error updating rules in %s: %s', path, str(e),
-                exc_info=True)
-            return False
+	  update_success = False
+	except git.exc.GitCommandError as e:
+          log.error('Error pulling Yara rules in {0:s}: {1!s}'.format(path, e))
+          update_success = False
+        except Exception as e:
+          log.error(
+              'Unknown error updating rules in %s: %s', path, str(e),
+              exc_info=True)
+	  update_success = False
 
-    return True
+    return update_success 
 
   def run(self, evidence, result):
     """Run the Yara worker.

--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -77,7 +77,7 @@ class YaraAnalysisTask(TurbiniaTask):
           log.info('Yara rules cloned successfully.')
         except git.exc.GitCommandError as e:
           log.error('Error cloning Yara rules from {0:s}: {1!s}'.format(repo, e))
-	  update_success = False
+          update_success = False
           continue  # Skip to next repo
       else:
         try:
@@ -88,18 +88,18 @@ class YaraAnalysisTask(TurbiniaTask):
         except git.exc.InvalidGitRepositoryError as e:
           log.error(
               'InvalidGitRepositoryError updating rules in %s: %s', path, str(e),
-                exc_info=True)
-	  update_success = False
-	except git.exc.GitCommandError as e:
+              exc_info=True)
+          update_success = False
+        except git.exc.GitCommandError as e:
           log.error('Error pulling Yara rules in {0:s}: {1!s}'.format(path, e))
           update_success = False
         except Exception as e:
           log.error(
               'Unknown error updating rules in %s: %s', path, str(e),
               exc_info=True)
-	  update_success = False
+          update_success = False
 
-    return update_success 
+    return update_success
 
   def run(self, evidence, result):
     """Run the Yara worker.

--- a/turbinia/workers/analysis/yara.py
+++ b/turbinia/workers/analysis/yara.py
@@ -71,12 +71,14 @@ class YaraAnalysisTask(TurbiniaTask):
 
       # If dir not exists, git clone; else git pull
       if not os.path.exists(path):
-        log.info('Rules directory {0:s} does not exist. Cloning...'.format(path))
+        log.info(
+            'Rules directory {0:s} does not exist. Cloning...'.format(path))
         try:
           git.Repo.clone_from(repo, path)
           log.info('Yara rules cloned successfully.')
         except git.exc.GitCommandError as e:
-          log.error('Error cloning Yara rules from {0:s}: {1!s}'.format(repo, e))
+          log.error(
+              'Error cloning Yara rules from {0:s}: {1!s}'.format(repo, e))
           update_success = False
           continue  # Skip to next repo
       else:
@@ -87,8 +89,8 @@ class YaraAnalysisTask(TurbiniaTask):
           log.info('Successfully updated rules from %s in %s', repo, path)
         except git.exc.InvalidGitRepositoryError as e:
           log.error(
-              'InvalidGitRepositoryError updating rules in %s: %s', path, str(e),
-              exc_info=True)
+              'InvalidGitRepositoryError updating rules in %s: %s', path,
+              str(e), exc_info=True)
           update_success = False
         except git.exc.GitCommandError as e:
           log.error('Error pulling Yara rules in {0:s}: {1!s}'.format(path, e))


### PR DESCRIPTION
### Description of the change
This PR updates the _update_rules logic to handle edge cases. It fixes Yara rule pull updates, which currently fail to update when this function is run on a non-git directory.

- Added a check: If the rules directory does not exist, use `git.clone` to fetch it.
- Added error handling: Catches `InvalidGitRepositoryError` to prevent crashes if the directory exists but is not a git repo.
- Improved logging for these scenarios.

### Applicable issues

N/A

### Additional information

Nay

### Checklist

- [] All tests were successful.; couldn't find `pip install -r dfvfs_requirements.txt` that _may_ have included **[No] module named 'coverage'**