### PR TITLE
fix: harden input validation in recipe loading and evidence upload

### DIFF
--- a/turbinia/api/routes/evidence.py
+++ b/turbinia/api/routes/evidence.py
@@ -17,6 +17,7 @@
 import hashlib
 import logging
 import os
+import re
 
 from datetime import datetime
 from fastapi import HTTPException, APIRouter, UploadFile, Query, Form
@@ -64,6 +65,11 @@ async def get_file_path(file_name: str, ticket_id: str) -> str:
   try:
     if not safe_file_name(file_name):
       raise TurbiniaException(f'File name {file_name} is not safe')
+    # Validate ticket_id to prevent path traversal
+    if not re.match(r'^[a-zA-Z0-9_-]+$', ticket_id):
+      raise TurbiniaException(
+          f'Invalid ticket_id: {ticket_id}. '
+          'Only alphanumeric characters, hyphens, and underscores are allowed.')
     file_name_without_ext, file_extension = os.path.splitext(file_name)
     current_time = datetime.now().strftime(turbinia_config.DATETIME_FORMAT)
     new_name = f'{file_name_without_ext}_{current_time}{file_extension}'

--- a/turbinia/lib/recipe_helpers.py
+++ b/turbinia/lib/recipe_helpers.py
@@ -23,8 +23,7 @@ import os
 import tempfile
 
 from yaml.parser import ParserError as yaml_error
-from yaml import Loader
-from yaml import load
+from yaml import safe_load
 from turbinia import TurbiniaException, config
 from turbinia.lib.file_helpers import file_to_str
 from turbinia.lib.file_helpers import file_to_list
@@ -90,7 +89,7 @@ def load_recipe_from_file(recipe_file, validate=True):
     log.info(f'Loading recipe file from {recipe_file:s}')
     with open(recipe_file, 'r', encoding='utf-8') as r_file:
       recipe_file_contents = r_file.read()
-      recipe_dict = load(recipe_file_contents, Loader=Loader)
+      recipe_dict = safe_load(recipe_file_contents)
       if validate:
         success, _ = validate_recipe(recipe_dict)
         if success:
@@ -209,6 +208,10 @@ def get_recipe_path_from_name(recipe_name):
     str: a recipe's file system path.
   """
   recipe_path = ''
+  # Sanitize recipe_name to prevent path traversal
+  recipe_name = os.path.basename(recipe_name)
+  if not recipe_name:
+    raise TurbiniaException('Invalid recipe name.')
   if not recipe_name.endswith('.yaml'):
     recipe_name = recipe_name + '.yaml'
 


### PR DESCRIPTION
## Summary

- Use yaml.safe_load() instead of yaml.load(Loader=Loader) in recipe_helpers.py
- Sanitize recipe_name input in get_recipe_path_from_name()
- Validate ticket_id format in evidence upload get_file_path()

These changes add defensive input validation to prevent potential misuse of user-supplied parameters.