### PR TITLE
Avoid shell execution in forensic workers

### DIFF
--- a/turbinia/workers/grep.py
+++ b/turbinia/workers/grep.py
@@ -49,7 +49,9 @@ class GrepTask(TurbiniaTask):
     output_file_path = os.path.join(self.output_dir, f'{base_name:s}.filtered')
 
     output_evidence = FilteredTextFile(source_path=output_file_path)
-    cmd = ['grep', '-E', '-b', '-n', '-f', patterns_file_path, evidence.local_path]
+    cmd = [
+        'grep', '-E', '-b', '-n', '-f', patterns_file_path, evidence.local_path
+    ]
 
     result.log(f'Running [{cmd!s}]')
     ret, result = self.execute(

--- a/turbinia/workers/grep.py
+++ b/turbinia/workers/grep.py
@@ -49,13 +49,15 @@ class GrepTask(TurbiniaTask):
     output_file_path = os.path.join(self.output_dir, f'{base_name:s}.filtered')
 
     output_evidence = FilteredTextFile(source_path=output_file_path)
-    cmd = 'grep -E -b -n -f {0:s} {1:s} > {2:s}'.format(
-        patterns_file_path, evidence.local_path, output_file_path)
+    cmd = [
+        'grep', '-E', '-b', '-n', '-f', patterns_file_path,
+        evidence.local_path
+    ]
 
-    result.log(f'Running [{cmd:s}]')
+    result.log(f'Running [{cmd!s}]')
     ret, result = self.execute(
-        cmd, result, new_evidence=[output_evidence], shell=True,
-        success_codes=[0, 1])
+        cmd, result, new_evidence=[output_evidence],
+        stdout_file=output_file_path, success_codes=[0, 1])
 
     # Grep returns 0 on success and 1 if no results are found.
     if ret == 0:

--- a/turbinia/workers/grep.py
+++ b/turbinia/workers/grep.py
@@ -49,10 +49,7 @@ class GrepTask(TurbiniaTask):
     output_file_path = os.path.join(self.output_dir, f'{base_name:s}.filtered')
 
     output_evidence = FilteredTextFile(source_path=output_file_path)
-    cmd = [
-        'grep', '-E', '-b', '-n', '-f', patterns_file_path,
-        evidence.local_path
-    ]
+    cmd = ['grep', '-E', '-b', '-n', '-f', patterns_file_path, evidence.local_path]
 
     result.log(f'Running [{cmd!s}]')
     ret, result = self.execute(

--- a/turbinia/workers/grep_test.py
+++ b/turbinia/workers/grep_test.py
@@ -33,8 +33,7 @@ class GrepTaskTest(unittest.TestCase):
       task.output_dir = output_dir
       task.task_config = {'filter_patterns': ['needle']}
       evidence = SimpleNamespace(
-          local_path=os.path.join(output_dir, 'input;touch'),
-          name='input')
+          local_path=os.path.join(output_dir, 'input;touch'), name='input')
       result = mock.MagicMock()
       task.execute = mock.MagicMock(return_value=(0, result))
 

--- a/turbinia/workers/grep_test.py
+++ b/turbinia/workers/grep_test.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the Grep worker."""
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+import mock
+
+from turbinia.workers import grep
+
+
+class GrepTaskTest(unittest.TestCase):
+  """Tests for GrepTask."""
+
+  def testGrepRunDoesNotUseShell(self):
+    """Test grep passes paths as argv entries instead of shell text."""
+    with tempfile.TemporaryDirectory() as output_dir:
+      task = grep.GrepTask(base_output_dir=output_dir)
+      task.output_dir = output_dir
+      task.task_config = {'filter_patterns': ['needle']}
+      evidence = SimpleNamespace(
+          local_path=os.path.join(output_dir, 'input;touch'),
+          name='input')
+      result = mock.MagicMock()
+      task.execute = mock.MagicMock(return_value=(0, result))
+
+      task.run(evidence, result)
+
+      cmd = task.execute.call_args.args[0]
+      kwargs = task.execute.call_args.kwargs
+      self.assertIsInstance(cmd, list)
+      self.assertIn(evidence.local_path, cmd)
+      self.assertNotIn('shell', kwargs)
+      self.assertTrue(kwargs['stdout_file'].endswith('.filtered'))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/turbinia/workers/photorec.py
+++ b/turbinia/workers/photorec.py
@@ -56,13 +56,12 @@ class PhotorecTask(TurbiniaTask):
       else:
         cmd.append(evidence.local_path)
       cmd.append('options,paranoid,keep_corrupted_file,search')
-      cmd = ' '.join(cmd)
       # Add a log line to the result that will be returned.
-      result.log(f'Running photorec as [{cmd:s}]')
+      result.log(f'Running photorec as [{cmd!s}]')
       # Actually execute the binary
       self.execute(
           cmd, result, log_files=[photorec_log], new_evidence=[output_evidence],
-          shell=True)
+      )
       status = ''
       if os.path.exists(output_evidence.local_path):
         output_evidence.compress()

--- a/turbinia/workers/photorec.py
+++ b/turbinia/workers/photorec.py
@@ -60,7 +60,10 @@ class PhotorecTask(TurbiniaTask):
       result.log(f'Running photorec as [{cmd!s}]')
       # Actually execute the binary
       self.execute(
-          cmd, result, log_files=[photorec_log], new_evidence=[output_evidence],
+          cmd,
+          result,
+          log_files=[photorec_log],
+          new_evidence=[output_evidence],
       )
       status = ''
       if os.path.exists(output_evidence.local_path):

--- a/turbinia/workers/photorec_command_test.py
+++ b/turbinia/workers/photorec_command_test.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Command construction tests for the Photorec worker."""
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+import mock
+
+from turbinia.workers import photorec
+
+
+class PhotorecCommandTest(unittest.TestCase):
+  """Tests for PhotorecTask command construction."""
+
+  def testPhotorecRunDoesNotUseShell(self):
+    """Test photorec passes evidence paths as argv entries."""
+    with tempfile.TemporaryDirectory() as output_dir:
+      task = photorec.PhotorecTask(base_output_dir=output_dir)
+      task.output_dir = output_dir
+      evidence = SimpleNamespace(
+          device_path=os.path.join(output_dir, 'disk;touch'), local_path=None)
+      result = mock.MagicMock()
+      task.execute = mock.MagicMock(return_value=(0, result))
+
+      task.run(evidence, result)
+
+      cmd = task.execute.call_args.args[0]
+      kwargs = task.execute.call_args.kwargs
+      self.assertIsInstance(cmd, list)
+      self.assertIn(evidence.device_path, cmd)
+      self.assertNotIn('shell', kwargs)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/turbinia/workers/strings.py
+++ b/turbinia/workers/strings.py
@@ -43,12 +43,13 @@ class StringsAsciiTask(TurbiniaTask):
     output_evidence = TextFile(source_path=output_file_path)
 
     # Generate the command we want to run.
-    cmd = f'strings -a -t d {evidence.device_path:s} > {output_file_path:s}'
+    cmd = ['strings', '-a', '-t', 'd', evidence.device_path]
     # Add a log line to the result that will be returned.
-    result.log(f'Running strings as [{cmd:s}]')
+    result.log(f'Running strings as [{cmd!s}]')
     # Actually execute the binary
     self.execute(
-        cmd, result, new_evidence=[output_evidence], close=True, shell=True)
+        cmd, result, new_evidence=[output_evidence], close=True,
+        stdout_file=output_file_path)
 
     return result
 
@@ -75,11 +76,12 @@ class StringsUnicodeTask(TurbiniaTask):
     output_evidence = TextFile(source_path=output_file_path)
 
     # Generate the command we want to run.
-    cmd = f'strings -a -t d -e l {evidence.device_path:s} > {output_file_path:s}'
+    cmd = ['strings', '-a', '-t', 'd', '-e', 'l', evidence.device_path]
     # Add a log line to the result that will be returned.
-    result.log(f'Running strings as [{cmd:s}]')
+    result.log(f'Running strings as [{cmd!s}]')
     # Actually execute the binary
     self.execute(
-        cmd, result, new_evidence=[output_evidence], close=True, shell=True)
+        cmd, result, new_evidence=[output_evidence], close=True,
+        stdout_file=output_file_path)
 
     return result

--- a/turbinia/workers/strings_test.py
+++ b/turbinia/workers/strings_test.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the strings workers."""
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+import mock
+
+from turbinia.workers import strings
+
+
+class StringsTaskTest(unittest.TestCase):
+  """Tests for strings tasks."""
+
+  def testAsciiRunDoesNotUseShell(self):
+    """Test ascii strings passes paths as argv entries."""
+    with tempfile.TemporaryDirectory() as output_dir:
+      task = strings.StringsAsciiTask(base_output_dir=output_dir)
+      task.output_dir = output_dir
+      evidence = SimpleNamespace(
+          device_path=os.path.join(output_dir, 'disk;touch'))
+      result = mock.MagicMock()
+      task.execute = mock.MagicMock(return_value=(0, result))
+
+      task.run(evidence, result)
+
+      cmd = task.execute.call_args.args[0]
+      kwargs = task.execute.call_args.kwargs
+      self.assertIsInstance(cmd, list)
+      self.assertIn(evidence.device_path, cmd)
+      self.assertNotIn('shell', kwargs)
+      self.assertTrue(kwargs['stdout_file'].endswith('.ascii'))
+
+  def testUnicodeRunDoesNotUseShell(self):
+    """Test unicode strings passes paths as argv entries."""
+    with tempfile.TemporaryDirectory() as output_dir:
+      task = strings.StringsUnicodeTask(base_output_dir=output_dir)
+      task.output_dir = output_dir
+      evidence = SimpleNamespace(
+          device_path=os.path.join(output_dir, 'disk;touch'))
+      result = mock.MagicMock()
+      task.execute = mock.MagicMock(return_value=(0, result))
+
+      task.run(evidence, result)
+
+      cmd = task.execute.call_args.args[0]
+      kwargs = task.execute.call_args.kwargs
+      self.assertIsInstance(cmd, list)
+      self.assertIn(evidence.device_path, cmd)
+      self.assertNotIn('shell', kwargs)
+      self.assertTrue(kwargs['stdout_file'].endswith('.uni'))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
## Summary
- pass grep, strings, and photorec commands as argv lists instead of shell strings
- write grep/strings output through stdout_file instead of shell redirection
- add command-construction tests for paths containing shell metacharacters

Closes #1629.

## Testing
- `python -m pytest turbinia/workers/grep_test.py turbinia/workers/strings_test.py turbinia/workers/photorec_command_test.py -q`
- `python -m py_compile turbinia/workers/grep.py turbinia/workers/strings.py turbinia/workers/photorec.py`
- `git diff --check`