### PR TITLE
Move Turbinia and dfDewey helm charts to Turbinia repo for archiving purposes

### DIFF
--- a/k8s/dfdewey/.helmignore
+++ b/k8s/dfdewey/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/dfdewey/Chart.lock
+++ b/k8s/dfdewey/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 14.3.1
+- name: opensearch
+  repository: https://opensearch-project.github.io/helm-charts/
+  version: 2.18.0
+digest: sha256:5a62d8c85755de1ff7e46cb3b75749a9b04f901fb6da3b469340c525627f2f1f
+generated: "2024-03-14T13:41:14.447320047+11:00"

--- a/k8s/dfdewey/Chart.yaml
+++ b/k8s/dfdewey/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: dfdewey
+version: 1.0.0
+description: A Helm chart for dfDewey datastore Kubernetes deployments.
+keywords:
+- dfdewey
+- dfir
+- processing
+- indexing
+- security
+home: "https://github.com/google/dfdewey"
+dependencies:
+- name: postgresql
+  version: 14.3.1
+  repository: https://charts.bitnami.com/bitnami
+- name: opensearch
+  version: 2.18.0
+  repository: https://opensearch-project.github.io/helm-charts/
+maintainers:
+  - name: Open Source DFIR
+    email: osdfir-maintainers@googlegroups.com
+    url: https://github.com/google/osdfir-infrastructure
+sources:
+- https://github.com/google/osdfir-infrastructure
+icon: https://user-images.githubusercontent.com/52063018/101560727-fc827900-3a17-11eb-93a1-f2a0589b6b6b.png
+appVersion: "latest"
+annotations:
+  category: Security
+  licenses: Apache-2.0

--- a/k8s/dfdewey/LICENSE
+++ b/k8s/dfdewey/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/k8s/dfdewey/README.md
+++ b/k8s/dfdewey/README.md
@@ -1,0 +1,127 @@
+<!--- app-name: dfDewey -->
+# dfDewey Datastore Helm Chart
+
+dfDewey is an open-source digital forensics tool for string extraction, indexing, and searching.
+
+[dfDewey Source Code](https://github.com/google/dfdewey)
+
+[Chart Source Code](https://github.com/google/osdfir-infrastructure)
+
+## TL;DR
+
+```console
+helm repo add osdfir-charts https://google.github.io/osdfir-infrastructure/
+helm install my-release osdfir-charts/dfdewey
+```
+
+> **Tip**: To quickly get started with a local cluster, see [minikube install docs](https://minikube.sigs.k8s.io/docs/start/).
+
+## Introduction
+
+This chart bootstraps a [dfDewey datastore](https://github.com/google/dfdewey) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+* Kubernetes 1.19+
+* Helm 3.2.0+
+* PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+The first step is to add the repo and then update to pick up any new changes.
+
+```console
+helm repo add osdfir-charts https://google.github.io/osdfir-infrastructure/
+helm repo update
+```
+
+To install the chart, specify any release name of your choice. For example, using `my-release` as the release name, run:
+
+```console
+helm install my-release osdfir-charts/dfdewey
+```
+
+The command deploys the dfDewey datastores on the Kubernetes cluster in the default configuration. See [Installating for Production](#installing-for-production)
+for a recommended production installation.
+
+## Installing for Production
+
+Pull the chart locally then cd into `/dfdewey` and review the `values-production.yaml` file for a list of values that will be used for production.
+
+```console
+helm pull osdfir-charts/dfdewey --untar
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete a Helm deployment with a release name of `my-release`:
+
+```console
+helm uninstall my-release
+```
+
+> **Tip**: Please update based on the release name chosen. You can list all releases using `helm list`
+
+The command removes all the Kubernetes components except for Persistent Volumes (PVC) associated with the chart and deletes the release.
+
+To delete the PVC's associated with a release name of `my-release`:
+
+```console
+kubectl delete pvc -l release=my-release
+```
+
+> **Note**: Deleting the PVC's will delete any data in the dfDewey datastores as well. Please be cautious before doing it.
+
+## Parameters
+
+### Global parameters
+
+| Name                            | Description                                                                                                             | Value   |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------- |
+| `global.timesketch.enabled`     | Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)                              | `false` |
+| `global.timesketch.servicePort` | Timesketch service port (overrides `timesketch.service.port`)                                                           | `nil`   |
+| `global.turbinia.enabled`       | Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart)                            | `false` |
+| `global.turbinia.servicePort`   | Turbinia API service port (overrides `turbinia.service.port`)                                                           | `nil`   |
+| `global.dfdewey.enabled`        | Enables the dfDewey datastore deployment (only used within the main OSDFIR Infrastructure and the Turbinia Helm charts) | `false` |
+| `global.yeti.enabled`           | Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)                                    | `false` |
+| `global.yeti.servicePort`       | Yeti API service port (overrides `yeti.api.service.port`)                                                               | `nil`   |
+| `global.existingPVC`            | Existing claim for Turbinia persistent volume (overrides `persistent.name`)                                             | `""`    |
+| `global.storageClass`           | StorageClass for the Turbinia persistent volume (overrides `persistent.storageClass`)                                   | `""`    |
+
+### Third Party Configuration
+
+
+### Postgresql Configuration Parameters
+
+| Name                                           | Description                                                                        | Value                |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------- |
+| `postgresql.enabled`                           | Enables the Postgresql deployment                                                  | `true`               |
+| `postgresql.nameOverride`                      | String to partially override common.names.fullname template                        | `dfdewey-postgresql` |
+| `postgresql.auth.username`                     | Name for a custom user to create                                                   | `dfdewey`            |
+| `postgresql.auth.password`                     | Password for the custom user to create. Ignored if auth.existingSecret is provided | `password`           |
+| `postgresql.auth.database`                     | Name for a custom database to create                                               | `dfdewey`            |
+| `postgresql.primary.persistence.size`          | PostgreSQL Persistent Volume size                                                  | `8Gi`                |
+| `postgresql.primary.resources.requests.cpu`    | Requested cpu for the PostgreSQL Primary containers                                | `250m`               |
+| `postgresql.primary.resources.requests.memory` | Requested memory for the PostgreSQL Primary containers                             | `256Mi`              |
+| `postgresql.primary.resources.limits`          | Resource limits for the PostgreSQL Primary containers                              | `{}`                 |
+
+### Opensearch Configuration Parameters
+
+| Name                                   | Description                                                                         | Value                                                                                               |
+| -------------------------------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `opensearch.enabled`                   | Enables the Opensearch deployment                                                   | `true`                                                                                              |
+| `opensearch.nameOverride`              | Overrides the clusterName when used in the naming of resources                      | `dfdewey-opensearch`                                                                                |
+| `opensearch.masterService`             | The service name used to connect to the masters                                     | `dfdewey-opensearch`                                                                                |
+| `opensearch.singleNode`                | Replicas will be forced to 1                                                        | `true`                                                                                              |
+| `opensearch.sysctlInit.enabled`        | Sets optimal sysctl's through privileged initContainer                              | `true`                                                                                              |
+| `opensearch.opensearchJavaOpts`        | Sets the size of the Opensearch Java heap                                           | `-Xms512m -Xmx512m`                                                                                 |
+| `opensearch.config.opensearch.yml`     | Opensearch configuration file. Can be appended for additional configuration options | `{"opensearch.yml":"discovery:\n  type: single-node\nplugins:\n  security:\n    disabled: true\n"}` |
+| `opensearch.extraEnvs[0].name`         | Environment variable to set the initial admin password                              | `OPENSEARCH_INITIAL_ADMIN_PASSWORD`                                                                 |
+| `opensearch.extraEnvs[0].value`        | The initial admin password                                                          | `KyfwJExU2!2MvU6j`                                                                                  |
+| `opensearch.extraEnvs[1].name`         | Environment variable to disable Opensearch Demo config                              | `DISABLE_INSTALL_DEMO_CONFIG`                                                                       |
+| `opensearch.extraEnvs[1].value`        | Disables Opensearch Demo config                                                     | `true`                                                                                              |
+| `opensearch.extraEnvs[2].name`         | Environment variable to disable Opensearch Security plugin given that               | `DISABLE_SECURITY_PLUGIN`                                                                           |
+| `opensearch.extraEnvs[2].value`        | Disables Opensearch Security plugin                                                 | `true`                                                                                              |
+| `opensearch.persistence.size`          | Opensearch Persistent Volume size                                                   | `2Gi`                                                                                               |
+| `opensearch.resources.requests.cpu`    | Requested cpu for the Opensearch containers                                         | `250m`                                                                                              |
+| `opensearch.resources.requests.memory` | Requested memory for the Opensearch containers                                      | `512Mi`                                                                                             |

--- a/k8s/dfdewey/templates/_helpers.tpl
+++ b/k8s/dfdewey/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dfdewey.name" -}}
+{{- default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "dfdewey.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name "dfdewey" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dfdewey.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/k8s/dfdewey/values-production.yaml
+++ b/k8s/dfdewey/values-production.yaml
@@ -1,0 +1,119 @@
+## dfDewey Helm Chart
+## This Helm chart is for deploying dfDewey alongside Turbinia to a Kubernetes environment
+##
+## @section Third Party Configuration
+## This section contains all the main configuration for third party dependencies
+## dfDewey requires to run
+##
+## @section Postgresql Configuration Parameters
+## IMPORTANT: Postgresql is deployed with Auth enabled by default
+##
+postgresql:
+  ## @param postgresql.enabled Enables the Postgresql deployment
+  ##
+  enabled: true
+  ## @param postgresql.nameOverride String to partially override common.names.fullname template
+  ##
+  nameOverride: dfdewey-postgresql
+  ## PostgreSQL Authentication parameters
+  ##
+  auth:
+    ## @param postgresql.auth.username Name for a custom user to create
+    ##
+    username: "dfdewey"
+    ## @param postgresql.auth.password Password for the custom user to create. Ignored if auth.existingSecret is provided
+    ##
+    password: "password"
+    ## @param postgresql.auth.database Name for a custom database to create
+    ##
+    database: "dfdewey"
+  ## PostgreSQL Primary configuration parameters
+  ##
+  primary:
+    ## PostgreSQL Primary persistence configuration
+    ##
+    persistence:
+      ## @param postgresql.primary.persistence.size PostgreSQL Persistent Volume size
+      ##
+      size: 500Gi
+    ## PostgreSQL Primary resource requests and limits
+    ## @param postgresql.primary.resources.requests.cpu Requested cpu for the PostgreSQL Primary containers
+    ## @param postgresql.primary.resources.requests.memory Requested memory for the PostgreSQL Primary containers
+    ## @param postgresql.primary.resources.limits Resource limits for the PostgreSQL Primary containers
+    ##
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits: {}
+## @section Opensearch Configuration Parameters
+## IMPORTANT: The Opensearch Security Plugin / TLS has not yet been configured by default
+## ref on steps required https://opensearch.org/docs/1.1/security-plugin/configuration/index/
+##
+opensearch:
+  ## @param opensearch.enabled Enables the Opensearch deployment
+  ##
+  enabled: true
+  ## @param opensearch.nameOverride Overrides the clusterName when used in the naming of resources
+  ##
+  nameOverride: dfdewey-opensearch
+  ## @param opensearch.masterService The service name used to connect to the masters
+  ##
+  masterService: dfdewey-opensearch
+  ## @param opensearch.singleNode Replicas will be forced to 1
+  ##
+  singleNode: true
+  ## @param opensearch.sysctlInit.enabled Sets optimal sysctl's through privileged initContainer
+  ##
+  sysctlInit:
+    enabled: true
+  ## @param opensearch.opensearchJavaOpts Sets the size of the Opensearch Java heap
+  ## It is recommended to use at least half the system's available ram
+  ##
+  opensearchJavaOpts: "-Xms32g -Xmx32g"
+  ## @param opensearch.config.opensearch.yml Opensearch configuration file. Can be appended for additional configuration options
+  ## Values must be YAML literal style scalar / YAML multiline string
+  ## <filename>: |
+  ##   <formatted-value(s)>
+  ##
+  config:
+    opensearch.yml: |
+      discovery:
+        type: single-node
+      plugins:
+        security:
+          disabled: true
+  extraEnvs:
+  ## @param opensearch.extraEnvs[0].name Environment variable to set the initial admin password
+  ##
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+  ## @param opensearch.extraEnvs[0].value The initial admin password
+  ##
+    value: KyfwJExU2!2MvU6j
+  ## @param opensearch.extraEnvs[1].name Environment variable to disable Opensearch Demo config
+  ##
+  - name: DISABLE_INSTALL_DEMO_CONFIG
+  ## @param opensearch.extraEnvs[1].value Disables Opensearch Demo config
+  ##
+    value: "true"
+  ## @param opensearch.extraEnvs[2].name Environment variable to disable Opensearch Security plugin given that
+  ## certificates were not setup as part of this deployment
+  ##
+  - name: DISABLE_SECURITY_PLUGIN
+  ## @param opensearch.extraEnvs[2].value Disables Opensearch Security plugin
+  ##
+    value: "true"
+  ## Opensearch persistence configuration
+  ##
+  persistence:
+    ## @param opensearch.persistence.size Opensearch Persistent Volume size
+    ##
+    size: 6Ti
+  ## Opensearch resource requests
+  ## @param opensearch.resources.requests.cpu Requested cpu for the Opensearch containers
+  ## @param opensearch.resources.requests.memory Requested memory for the Opensearch containers
+  ##
+  resources:
+    requests:
+      cpu: 8000m
+      memory: 32Gi

--- a/k8s/dfdewey/values.yaml
+++ b/k8s/dfdewey/values.yaml
@@ -1,0 +1,156 @@
+## dfDewey Helm Chart
+## This Helm chart is for deploying dfDewey alongside Turbinia to a Kubernetes environment
+##
+## @section Global parameters
+## Please note that this will override the parameters configured to use the global value
+##
+global:
+  ## Global Persistence Configuration
+  ##
+  timesketch:
+    ## @param global.timesketch.enabled Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.timesketch.servicePort Timesketch service port (overrides `timesketch.service.port`)
+    ##
+    servicePort:
+  turbinia:
+    ## @param global.turbinia.enabled Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.turbinia.servicePort Turbinia API service port (overrides `turbinia.service.port`)
+    ##
+    servicePort:
+  dfdewey:
+    ## @param global.dfdewey.enabled Enables the dfDewey datastore deployment (only used within the main OSDFIR Infrastructure and the Turbinia Helm charts)
+    ##
+    enabled: false
+  yeti:
+    ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.yeti.servicePort Yeti API service port (overrides `yeti.api.service.port`)
+    ##
+    servicePort:
+  ## @param global.existingPVC Existing claim for Turbinia persistent volume (overrides `persistent.name`)
+  ##
+  existingPVC: ""
+  ## @param global.storageClass StorageClass for the Turbinia persistent volume (overrides `persistent.storageClass`)
+  ##
+  storageClass: ""
+## @section Third Party Configuration
+## This section contains all the main configuration for third party dependencies
+## dfDewey requires to run
+##
+## @section Postgresql Configuration Parameters
+## IMPORTANT: Postgresql is deployed with Auth enabled by default
+##
+postgresql:
+  ## @param postgresql.enabled Enables the Postgresql deployment
+  ##
+  enabled: true
+  ## @param postgresql.nameOverride String to partially override common.names.fullname template
+  ##
+  nameOverride: dfdewey-postgresql
+  ## PostgreSQL Authentication parameters
+  ##
+  auth:
+    ## @param postgresql.auth.username Name for a custom user to create
+    ##
+    username: "dfdewey"
+    ## @param postgresql.auth.password Password for the custom user to create. Ignored if auth.existingSecret is provided
+    ##
+    password: "password"
+    ## @param postgresql.auth.database Name for a custom database to create
+    ##
+    database: "dfdewey"
+  ## PostgreSQL Primary configuration parameters
+  ##
+  primary:
+    ## PostgreSQL Primary persistence configuration
+    ##
+    persistence:
+      ## @param postgresql.primary.persistence.size PostgreSQL Persistent Volume size
+      ##
+      size: 8Gi
+    ## PostgreSQL Primary resource requests and limits
+    ## @param postgresql.primary.resources.requests.cpu Requested cpu for the PostgreSQL Primary containers
+    ## @param postgresql.primary.resources.requests.memory Requested memory for the PostgreSQL Primary containers
+    ## @param postgresql.primary.resources.limits Resource limits for the PostgreSQL Primary containers
+    ##
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits: {}
+## @section Opensearch Configuration Parameters
+## IMPORTANT: The Opensearch Security Plugin / TLS has not yet been configured by default
+## ref on steps required https://opensearch.org/docs/1.1/security-plugin/configuration/index/
+##
+opensearch:
+  ## @param opensearch.enabled Enables the Opensearch deployment
+  ##
+  enabled: true
+  ## @param opensearch.nameOverride Overrides the clusterName when used in the naming of resources
+  ##
+  nameOverride: dfdewey-opensearch
+  ## @param opensearch.masterService The service name used to connect to the masters
+  ##
+  masterService: dfdewey-opensearch
+  ## @param opensearch.singleNode Replicas will be forced to 1
+  ##
+  singleNode: true
+  ## @param opensearch.sysctlInit.enabled Sets optimal sysctl's through privileged initContainer
+  ##
+  sysctlInit:
+    enabled: true
+  ## @param opensearch.opensearchJavaOpts Sets the size of the Opensearch Java heap
+  ## It is recommended to use at least half the system's available ram
+  ##
+  opensearchJavaOpts: "-Xms512m -Xmx512m"
+  ## @param opensearch.config.opensearch.yml Opensearch configuration file. Can be appended for additional configuration options
+  ## Values must be YAML literal style scalar / YAML multiline string
+  ## <filename>: |
+  ##   <formatted-value(s)>
+  ##
+  config:
+    opensearch.yml: |
+      discovery:
+        type: single-node
+      plugins:
+        security:
+          disabled: true
+  extraEnvs:
+  ## @param opensearch.extraEnvs[0].name Environment variable to set the initial admin password
+  ##
+  - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+  ## @param opensearch.extraEnvs[0].value The initial admin password
+  ##
+    value: KyfwJExU2!2MvU6j
+  ## @param opensearch.extraEnvs[1].name Environment variable to disable Opensearch Demo config
+  ##
+  - name: DISABLE_INSTALL_DEMO_CONFIG
+  ## @param opensearch.extraEnvs[1].value Disables Opensearch Demo config
+  ##
+    value: "true"
+  ## @param opensearch.extraEnvs[2].name Environment variable to disable Opensearch Security plugin given that
+  ## certificates were not setup as part of this deployment
+  ##
+  - name: DISABLE_SECURITY_PLUGIN
+  ## @param opensearch.extraEnvs[2].value Disables Opensearch Security plugin
+  ##
+    value: "true"
+  ## Opensearch persistence configuration
+  ##
+  persistence:
+    ## @param opensearch.persistence.size Opensearch Persistent Volume size
+    ##
+    size: 2Gi
+  ## Opensearch resource requests
+  ## @param opensearch.resources.requests.cpu Requested cpu for the Opensearch containers
+  ## @param opensearch.resources.requests.memory Requested memory for the Opensearch containers
+  ##
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi

--- a/k8s/turbinia/.helmignore
+++ b/k8s/turbinia/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/k8s/turbinia/Chart.lock
+++ b/k8s/turbinia/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 19.3.2
+- name: oauth2-proxy
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.3.0
+- name: dfdewey
+  repository: https://google.github.io/osdfir-infrastructure/
+  version: 1.0.0
+digest: sha256:6c0c5f81d133cf28a6504d01571d17b1fed42b7908bfa3ef0b4d1a913b62fc03
+generated: "2024-09-23T10:08:20.718691-07:00"

--- a/k8s/turbinia/Chart.yaml
+++ b/k8s/turbinia/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: turbinia
+version: 1.2.0
+description: A Helm chart for Turbinia Kubernetes deployments.
+keywords:
+- turbinia
+- dfir
+- processing
+- scaling
+- security
+home: "https://github.com/google/turbinia"
+dependencies:
+- condition: redis.enabled
+  name: redis
+  version: 19.3.2
+  repository: https://charts.bitnami.com/bitnami
+- condition: oauth2proxy.enabled
+  name: oauth2-proxy
+  alias: oauth2proxy
+  version: 5.3.0
+  repository: https://charts.bitnami.com/bitnami
+- condition: global.dfdewey.enabled
+  name: dfdewey
+  repository: https://google.github.io/osdfir-infrastructure/
+  version: 1.0.0
+maintainers:
+  - name: Open Source DFIR
+    email: osdfir-maintainers@googlegroups.com
+    url: https://github.com/google/osdfir-infrastructure
+sources:
+- https://github.com/google/osdfir-infrastructure
+icon: https://raw.githubusercontent.com/google/turbinia/master/web/src/assets/turbinia-logo-mark.png
+appVersion: "20240820"
+annotations:
+  category: Security
+  licenses: Apache-2.0

--- a/k8s/turbinia/LICENSE
+++ b/k8s/turbinia/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/k8s/turbinia/README.md
+++ b/k8s/turbinia/README.md
@@ -1,0 +1,563 @@
+<!--- app-name: Turbinia -->
+# Turbinia Helm Chart
+
+Turbinia is an open-source framework for deploying, managing, and running distributed forensic workloads.
+
+[Overview of Turbinia](https://turbinia.readthedocs.io/en/latest/)
+
+[Chart Source Code](https://github.com/google/osdfir-infrastructure)
+
+## TL;DR
+
+```console
+helm repo add osdfir-charts https://google.github.io/osdfir-infrastructure/
+helm install my-release osdfir-charts/turbinia
+```
+
+> **Note**: By default, Turbinia is not externally accessible and can be
+reached via `kubectl port-forward` within the cluster.
+
+## Introduction
+
+This chart bootstraps a [Turbinia](https://github.com/google/turbinia) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+For a quick start with a local Kubernetes cluster on your desktop, check out the
+[getting started with Minikube guide](https://github.com/google/osdfir-infrastructure/blob/main/docs/getting-started.md).
+
+## Prerequisites
+
+* Kubernetes 1.23+
+* Helm 3.8.0+
+* PV provisioner support in the underlying infrastructure
+* Shared storage for clusters larger then one machine.
+
+## Installing the Chart
+
+The first step is to add the repo and then update to pick up any new changes.
+
+```console
+helm repo add osdfir-charts https://google.github.io/osdfir-infrastructure/
+helm repo update
+```
+
+To install the chart, specify any release name of your choice.
+For example, using `my-release` as the release name, run:
+
+```console
+helm install my-release osdfir-charts/turbinia
+```
+
+The command deploys Turbinia on the Kubernetes cluster in the default configuration.
+The [Parameters](#parameters) section lists the parameters that can be configured
+during installation.
+
+> **Tip**:  See the [Managing and updating the Turbinia config](#managing-and-updating-the-turbinia-config)
+section for more details on managing the Turbinia config.
+
+## Configuration and installation details
+
+### Use a different Turbinia version
+
+The Turbinia Helm chart utilizes the latest container release tags by default.
+OSDFIR Infrastructure actively monitors for new versions of the main containers
+and releases updated charts accordingly.
+
+To modify the application version used in Turbinia, specify a different version
+of the image using the `image.tag` parameter and/or a different repository using
+the `image.repository` parameter.
+
+For example, to use the most recent development
+version instead, set the following variables:
+
+```console
+turbinia.server.image.repository="us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server-dev"
+turbinia.server.image.tag="latest"
+turbinia.api.image.repository="us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server-dev"
+turbinia.api.image.tag="latest"
+turbinia.worker.image.repository="us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker-dev"
+turbinia.worker.image.tag="latest"
+```
+
+### Upgrading the Helm chart
+
+Helm chart updates can be retrieved by running `helm repo update`.
+
+To explore available charts and versions, use `helm search repo osdfir-charts/`.
+Install a specific chart version with `helm install my-release osdfir-charts/turbinia --version <version>`.
+
+A major Helm chart version change (like v1.0.0 -> v2.0.0) indicates that there
+is an incompatible breaking change needing manual actions.
+
+### Managing and updating the Turbinia config
+
+This section outlines how to deploy and manage the Turbinia configuration file
+within OSDFIR infrastructure.
+
+There are two primary methods:
+
+#### Using Default Configurations
+
+If you don't provide your own Turbinia config file during deployment,
+the Turbinia deployment will automatically retrieve the latest default configs
+from the Turbinia Github repository. This method requires no further action from you.
+
+> **NOTE:**  When using the default method, you cannot update the Turbinia config
+file directly. See the next section below for instructions on using a custom Turbinia
+config instead.
+
+#### Managing Turbinia configs externally
+
+For more advanced configuration management, you can manage the Turbinia config
+file independently of the Helm chart:
+
+1. Prepare your Config File:
+
+    Organize the Turbinia config file with your desired customizations.
+
+2. Create a ConfigMap:
+
+    ```console
+    kubectl create configmap turbinia-configs --from-file=turbinia.conf
+    ```
+
+    Replace `turbinia.conf` with the actual name of your config file.
+
+3. Install or Upgrade the Helm Chart:
+
+    ```console
+    helm install my-release osdfir-charts/turbinia --set config.existingConfigMap="turbinia-configs"
+    ```
+
+    This command instructs the Helm chart to use the `turbinia-configs` ConfigMap for
+    Turbinia's config file.
+
+To update the config changes using this method:
+
+1. Update the ConfigMap:
+
+    ```console
+    kubectl create configmap turbinia-configs --from-file=turbinia.conf --dry-run -o yaml | kubectl replace -f -
+    ```
+
+2. Restart the Turbinia deployment to apply the new configs
+
+    ```console
+    kubectl rollout restart deployment -l app.kubernetes.io/name=turbinia
+    ```
+
+### Metrics and monitoring
+
+The chart starts a metrics exporter for prometheus. The metrics endpoint (port 9200)
+is exposed in the service. Metrics can be scraped from within the cluster by either
+a Prometheus server running in your cluster or a cloud-based Prometheus service.
+Currently, Turbinia application metrics and system metrics are available.
+
+One recommended option for an integrated monitoring solution would be the
+[kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack).
+
+To setup, first add the repository containing the kube-prometheus-stack
+Helm chart:
+
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+```
+
+Create a file to disable the default selector:
+
+```console
+cat >> values-monitoring.yaml << EOF
+prometheus:
+  prometheusSpec:
+    serviceMonitorSelectorNilUsesHelmValues: false
+EOF
+```
+
+Then to install the kube prometheus chart in a namespace called `monitoring`:
+
+```console
+helm install kube-prometheus prometheus-community/kube-prometheus-stack -f values-monitoring.yaml --namespace monitoring
+```
+
+> **NOTE**: To confirm Turbinia is recording metrics, check Prometheus or Grafana for entries starting with `turbinia_`. If nothing shows up, you might need to update your Turbinia installation (helm upgrade) to apply the necessary CustomResourceDefinition (CRD).
+
+### Resource requests and limits
+
+OSDFIR Infrastructure charts allow setting resource requests and limits for all
+containers inside the chart deployment. These are inside the `resources` value
+(check parameter table). Setting requests is essential for production workloads
+and these should be adapted to your specific use case.
+
+To maximize deployment success across different environments, resources are
+minimally defined by default.
+
+### Persistence
+
+By default, the chart mounts a Persistent Volume at the `/mnt/turbiniavolume` path.
+The volume is created using dynamic volume provisioning.
+
+Configuration files can be found at the `/etc/turbinia` path of the container
+while logs can be found at `/mnt/turbiniavolume/logs/`.
+
+For clusters running more than one node or machine, the Persistent Volume will
+need to have the ability to be mounted by multiple machines, such as NFS, GCP
+Filestore, AWS EFS, and other shared file storage equivalents.
+
+## Installing Turbinia for Google Kubernetes Engine (GKE)
+
+In order to process Google Cloud Platform (GCP) disks with Turbinia, some additional
+setup steps are required.
+
+The first is to create a Turbinia GCP account using the helper script in
+`tools/create-gcp-sa.sh` prior to installing the chart.
+
+Once done, install the chart with the appropriate values to enable GCP disk
+processing for Turbinia. Using a release name such as `my-release`, run:
+
+```console
+helm install my-release osdfir-charts/turbinia \
+    --set gcp.enabled=true \
+    --set gcp.projectID=<GCP_PROJECT_ID> \
+    --set gcp.projectRegion=<GKE_CLUSTER_REGION> \
+    --set gcp.projectZone=<GKE_ClUSTER_ZONE>
+```
+
+Turbinia offers worker autoscaling based on CPU utilization. This feature can
+significantly increase the speed of task processing by automatically adjusting
+the number of active worker pods. To enable autoscaling on your existing
+deployment, run the following command:
+
+```console
+helm upgrade my-release osdfir-charts/turbinia \
+--reuse-values \
+--set autoscaling.enabled.true
+```
+
+### Enabling External Access and OIDC Authentication
+
+Follow these steps to externally expose Turbinia and enable Google Cloud OIDC
+using the Oauth2 Proxy to control user access to Turbinia.
+
+1. Create a global static IP address:
+
+    ```console
+    gcloud compute addresses create turbinia-webapps --global
+    ```
+
+2. Register a new domain or use an existing one, ensuring a DNS entry
+points to the IP created earlier.
+
+3. Create OAuth web client credentials following the
+[Google Support guide](https://support.google.com/cloud/answer/6158849). If using
+the CLI client, also create a Desktop/Native OAuth client.
+
+   * Fill in Authorized JavaScript origins with your domain as `https://<DOMAIN_NAME>.com`
+   * Fill in Authorized redirect URIs with `https://<DOMAIN_NAME>.com/oauth2/callback/`
+
+4. Generate a cookie secret:
+
+    ```console
+    openssl rand -base64 32 | head -c 32 | base64
+    ```
+
+5. Store your new OAuth credentials in a K8s secret:
+
+    ```console
+    kubectl create secret generic oauth-secrets \
+        --from-literal=client-id=<WEB_CLIENT_ID> \
+        --from-literal=client-secret=<WEB_CLIENT_SECRET> \
+        --from-literal=cookie-secret=<COOKIE_SECRET> \
+        --from-literal=client-id-native=<NATIVE_CLIENT_ID>
+    ```
+
+6. Make a list of allowed emails in a text file, one per line:
+
+    ```console
+    touch authenticated-emails.txt
+    ```
+
+7. Apply the authenticated email list as a K8s secret:
+
+    ```console
+    kubectl create secret generic authenticated-emails --from-file=authenticated-emails-list=authenticated-emails.txt
+    ```
+
+8. Then to upgrade an existing release, externally expose Turbinia through a load balancer with GCP managed certificates, and deploy the
+Oauth2 Proxy for authentication, run:
+
+    ```console
+    helm upgrade my-release osdfir-charts/turbinia \
+        --reuse-values \
+        --set ingress.enabled=true \
+        --set ingress.className="gce" \
+        --set ingress.host=<DOMAIN> \
+        --set ingress.gcp.managedCertificates=true \
+        --set ingress.gcp.staticIPName=<GCP_STATIC_IP_NAME> \
+        --set oauth2proxy.enabled=true \
+        --set oauth2proxy.configuration.existingSecret=<OAUTH_SECRET_NAME> \
+        --set oauth2proxy.configuration.authenticatedEmailsFile.existingSecret=<AUTHENTICATED_EMAILS_SECRET_NAME>
+    ```
+
+> **Warning**: Turbinia relies on the Oauth2 Proxy for authentication. If you
+plan to expose Turbinia with a public facing IP, it is highly recommended that
+the Oauth2 Proxy is deployed alongside with the command provided above. Otherwise,
+Turbinia will be accessible from anyone on the internet without authentication.
+
+## Installing Turbinia for Other Cloud Platforms
+
+Turbinia currently offers native support only for Google Cloud Disks. This means
+you can seamlessly process evidence from Google Cloud Disks. For other cloud
+providers, you'll need to manually mount the disk to your Turbinia instance or
+copy the evidence into Turbinia for processing.  We are actively working to expand
+native disk processing support for other cloud environments in the future.
+Installing the Turbinia Helm Chart remains the same regardless of your cloud provider.
+
+## Uninstalling the Chart
+
+To uninstall/delete a Helm deployment with a release name of `my-release`:
+
+```console
+helm uninstall my-release
+```
+
+> **Tip**: Please update based on the release name chosen. You can list all releases using `helm list`
+
+The command removes all the Kubernetes components but Persistent Volumes (PVC) associated with the chart and deletes the release.
+
+To delete the PVC's associated with a release name of `my-release`:
+
+```console
+kubectl delete pvc -l release=my-release
+```
+
+> **Note**: Deleting the PVC's will delete Turbinia data as well. Please be cautious before doing it.
+
+## Parameters
+
+### Global parameters
+
+| Name                            | Description                                                                                  | Value   |
+| ------------------------------- | -------------------------------------------------------------------------------------------- | ------- |
+| `global.timesketch.enabled`     | Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)   | `false` |
+| `global.timesketch.servicePort` | Timesketch service port (overrides `timesketch.service.port`)                                | `nil`   |
+| `global.turbinia.enabled`       | Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart) | `false` |
+| `global.turbinia.servicePort`   | Turbinia API service port (overrides `turbinia.service.port`)                                | `nil`   |
+| `global.dfdewey.enabled`        | Enables the dfDewey deployment along with Turbinia                                           | `false` |
+| `global.yeti.enabled`           | Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)         | `false` |
+| `global.yeti.servicePort`       | Yeti API service port (overrides `yeti.api.service.port`)                                    | `nil`   |
+| `global.ingress.enabled`        | Enable the global loadbalancer for external access                                           | `false` |
+| `global.existingPVC`            | Existing claim for Turbinia persistent volume (overrides `persistent.name`)                  | `""`    |
+| `global.storageClass`           | StorageClass for the Turbinia persistent volume (overrides `persistent.storageClass`)        | `""`    |
+
+### Turbinia configuration
+
+
+### Turbinia server configuration
+
+| Name                            | Description                                                               | Value                                                                |
+| ------------------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `server.image.repository`       | Turbinia image repository                                                 | `us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server` |
+| `server.image.pullPolicy`       | Turbinia image pull policy                                                | `IfNotPresent`                                                       |
+| `server.image.tag`              | Overrides the image tag whose default is the chart appVersion             | `20240820`                                                           |
+| `server.image.imagePullSecrets` | Specify secrets if pulling from a private repository                      | `[]`                                                                 |
+| `server.podSecurityContext`     | Holds pod-level security attributes and common server container settings  | `{}`                                                                 |
+| `server.securityContext`        | Holds security configuration that will be applied to the server container | `{}`                                                                 |
+| `server.resources.limits`       | Resource limits for the server container                                  | `{}`                                                                 |
+| `server.resources.requests`     | Requested resources for the server container                              | `{}`                                                                 |
+| `server.nodeSelector`           | Node labels for Turbinia server pods assignment                           | `{}`                                                                 |
+| `server.tolerations`            | Tolerations for Turbinia server pods assignment                           | `[]`                                                                 |
+| `server.affinity`               | Affinity for Turbinia server pods assignment                              | `{}`                                                                 |
+
+### Turbinia worker configuration
+
+| Name                                                | Description                                                                                                                                   | Value                                                                |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `worker.image.repository`                           | Turbinia image repository                                                                                                                     | `us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker` |
+| `worker.image.pullPolicy`                           | Turbinia image pull policy                                                                                                                    | `IfNotPresent`                                                       |
+| `worker.image.tag`                                  | Overrides the image tag whose default is the chart appVersion                                                                                 | `20240820`                                                           |
+| `worker.image.imagePullSecrets`                     | Specify secrets if pulling from a private repository                                                                                          | `[]`                                                                 |
+| `worker.replicaCount`                               | Number of worker pods to run at once                                                                                                          | `1`                                                                  |
+| `worker.autoscaling.enabled`                        | Enables Turbinia Worker autoscaling                                                                                                           | `false`                                                              |
+| `worker.autoscaling.minReplicas`                    | Minimum amount of worker pods to run at once                                                                                                  | `5`                                                                  |
+| `worker.autoscaling.maxReplicas`                    | Maximum amount of worker pods to run at once                                                                                                  | `500`                                                                |
+| `worker.autoscaling.targetCPUUtilizationPercentage` | CPU scaling metric workers will scale based on                                                                                                | `80`                                                                 |
+| `worker.podSecurityContext`                         | Holds pod-level security attributes and common worker container settings                                                                      | `{}`                                                                 |
+| `worker.securityContext.privileged`                 | Runs the container as priveleged. Due to Turbinia attaching and detaching disks, a priveleged container is required for the worker container. | `true`                                                               |
+| `worker.resources.limits`                           | Resources limits for the worker container                                                                                                     | `{}`                                                                 |
+| `worker.resources.requests.cpu`                     | Requested cpu for the worker container                                                                                                        | `250m`                                                               |
+| `worker.resources.requests.memory`                  | Requested memory for the worker container                                                                                                     | `256Mi`                                                              |
+| `worker.nodeSelector`                               | Node labels for Turbinia worker pods assignment                                                                                               | `{}`                                                                 |
+| `worker.tolerations`                                | Tolerations for Turbinia worker pods assignment                                                                                               | `[]`                                                                 |
+| `worker.affinity`                                   | Affinity for Turbinia worker pods assignment                                                                                                  | `{}`                                                                 |
+
+### Turbinia API / Web configuration
+
+| Name                         | Description                                                                         | Value                                                                    |
+| ---------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `api.image.repository`       | Turbinia image repository for API / Web server                                      | `us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server` |
+| `api.image.pullPolicy`       | Turbinia image pull policy                                                          | `IfNotPresent`                                                           |
+| `api.image.tag`              | Overrides the image tag whose default is the chart appVersion                       | `20240820`                                                               |
+| `api.image.imagePullSecrets` | Specify secrets if pulling from a private repository                                | `[]`                                                                     |
+| `api.podSecurityContext`     | Holds pod-level security attributes that will be applied to the API / Web container | `{}`                                                                     |
+| `api.securityContext`        | Holds security configuration that will be applied to the API / Web container        | `{}`                                                                     |
+| `api.resources.limits`       | Resource limits for the api container                                               | `{}`                                                                     |
+| `api.resources.requests`     | Requested resources for the api container                                           | `{}`                                                                     |
+| `api.nodeSelector`           | Node labels for Turbinia api pods assignment                                        | `{}`                                                                     |
+| `api.tolerations`            | Tolerations for Turbinia api pods assignment                                        | `[]`                                                                     |
+| `api.affinity`               | Affinity for Turbinia api pods assignment                                           | `{}`                                                                     |
+
+### Common Parameters
+
+| Name                              | Description                                                                                                                                                                                                          | Value                                                                                        |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `config.existingConfigMap`        | Use an existing ConfigMap as the default Turbinia config.                                                                                                                                                            | `""`                                                                                         |
+| `config.disabledJobs`             | List of Turbinia Jobs to disable. Overrides DISABLED_JOBS in the Turbinia config.                                                                                                                                    | `['BinaryExtractorJob', 'BulkExtractorJob', 'HindsightJob', 'PhotorecJob', 'VolatilityJob']` |
+| `config.existingVertexSecret`     | Name of existing secret containing Vertex API Key in order to enable the Turbinia LLM Artifacts Analyzer. The secret must contain the key `turbinia-vertexapi`                                                       | `""`                                                                                         |
+| `gcp.enabled`                     | Enables Turbinia to run within a GCP project. When enabling, please ensure you have run the supplemental script `create-gcp-sa.sh` to create a Turbinia GCP service account required for attaching persistent disks. | `false`                                                                                      |
+| `gcp.projectID`                   | GCP Project ID where your cluster is deployed. Required when `.Values.gcp.enabled` is set to `true`                                                                                                                  | `""`                                                                                         |
+| `gcp.projectRegion`               | Region where your cluster is deployed. Required when `.Values.gcp.enabled` is set to `true`                                                                                                                          | `""`                                                                                         |
+| `gcp.projectZone`                 | Zone where your cluster is deployed. Required when `.Values.gcp.enabled` is set to `true`                                                                                                                            | `""`                                                                                         |
+| `gcp.gcpLogging`                  | Enables GCP Cloud Logging                                                                                                                                                                                            | `false`                                                                                      |
+| `gcp.gcpErrorReporting`           | Enables GCP Cloud Error Reporting                                                                                                                                                                                    | `false`                                                                                      |
+| `serviceAccount.create`           | Specifies whether a service account should be created                                                                                                                                                                | `true`                                                                                       |
+| `serviceAccount.annotations`      | Annotations to add to the service account                                                                                                                                                                            | `{}`                                                                                         |
+| `serviceAccount.name`             | The name of the Kubernetes service account to use                                                                                                                                                                    | `turbinia`                                                                                   |
+| `service.type`                    | Turbinia service type                                                                                                                                                                                                | `ClusterIP`                                                                                  |
+| `service.port`                    | Turbinia api service port                                                                                                                                                                                            | `8000`                                                                                       |
+| `metrics.enabled`                 | Enables metrics scraping                                                                                                                                                                                             | `true`                                                                                       |
+| `metrics.port`                    | Port to scrape metrics from                                                                                                                                                                                          | `9200`                                                                                       |
+| `versioncheck.enabled`            | Enable Turbinia runtime version checking                                                                                                                                                                             | `true`                                                                                       |
+| `persistence.name`                | Turbinia persistent volume name                                                                                                                                                                                      | `turbiniavolume`                                                                             |
+| `persistence.size`                | Turbinia persistent volume size                                                                                                                                                                                      | `2Gi`                                                                                        |
+| `persistence.storageClass`        | PVC Storage Class for Turbinia volume                                                                                                                                                                                | `""`                                                                                         |
+| `persistence.accessModes`         | PVC Access Mode for Turbinia volume                                                                                                                                                                                  | `["ReadWriteOnce"]`                                                                          |
+| `ingress.enabled`                 | Enable the Turbinia loadbalancer for external access (only used in the main OSDFIR Infrastructure Helm chart)                                                                                                        | `false`                                                                                      |
+| `ingress.host`                    | The domain name Turbinia will be hosted under                                                                                                                                                                        | `""`                                                                                         |
+| `ingress.selfSigned`              | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                                                                                                         | `false`                                                                                      |
+| `ingress.certManager`             | Add the corresponding annotations for cert-manager integration                                                                                                                                                       | `false`                                                                                      |
+| `ingress.className`               | IngressClass that will be be used to implement the Ingress                                                                                                                                                           | `""`                                                                                         |
+| `ingress.gcp.managedCertificates` | Enabled GCP managed certificates for your domain                                                                                                                                                                     | `false`                                                                                      |
+| `ingress.gcp.staticIPName`        | Name of the static IP address you reserved in GCP                                                                                                                                                                    | `""`                                                                                         |
+| `ingress.gcp.staticIPV6Name`      | Name of the static IPV6 address you reserved. This can be optionally provided to deploy a loadbalancer with an IPV6 address in GCP.                                                                                  | `""`                                                                                         |
+
+### dfDewey PostgreSQL Configuration Parameters
+
+| Name                                                   | Description                                                                        | Value                |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------- | -------------------- |
+| `dfdewey.postgresql.enabled`                           | Enables the Postgresql deployment                                                  | `true`               |
+| `dfdewey.postgresql.nameOverride`                      | String to partially override common.names.fullname template                        | `dfdewey-postgresql` |
+| `dfdewey.postgresql.auth.username`                     | Name for a custom user to create                                                   | `dfdewey`            |
+| `dfdewey.postgresql.auth.password`                     | Password for the custom user to create. Ignored if auth.existingSecret is provided | `password`           |
+| `dfdewey.postgresql.auth.database`                     | Name for a custom database to create                                               | `dfdewey`            |
+| `dfdewey.postgresql.primary.persistence.size`          | PostgreSQL Persistent Volume size                                                  | `8Gi`                |
+| `dfdewey.postgresql.primary.resources.requests.cpu`    | Requested cpu for the PostgreSQL Primary containers                                | `250m`               |
+| `dfdewey.postgresql.primary.resources.requests.memory` | Requested memory for the PostgreSQL Primary containers                             | `256Mi`              |
+| `dfdewey.postgresql.primary.resources.limits`          | Resource limits for the PostgreSQL Primary containers                              | `{}`                 |
+
+### dfDewey Opensearch Configuration Parameters
+
+| Name                                           | Description                                                                                                 | Value                                                                                               |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `dfdewey.opensearch.enabled`                   | Enables the Opensearch deployment                                                                           | `true`                                                                                              |
+| `dfdewey.opensearch.nameOverride`              | Overrides the clusterName when used in the naming of resources                                              | `dfdewey-opensearch`                                                                                |
+| `dfdewey.opensearch.masterService`             | The service name used to connect to the masters                                                             | `dfdewey-opensearch`                                                                                |
+| `dfdewey.opensearch.singleNode`                | Replicas will be forced to 1                                                                                | `true`                                                                                              |
+| `dfdewey.opensearch.sysctlInit.enabled`        | Sets optimal sysctl's through privileged initContainer                                                      | `true`                                                                                              |
+| `dfdewey.opensearch.opensearchJavaOpts`        | Sets the size of the Opensearch Java heap                                                                   | `-Xms512m -Xmx512m`                                                                                 |
+| `dfdewey.opensearch.config.opensearch.yml`     | Opensearch configuration file. Can be appended for additional configuration options                         | `{"opensearch.yml":"discovery:\n  type: single-node\nplugins:\n  security:\n    disabled: true\n"}` |
+| `dfdewey.opensearch.extraEnvs[0].name`         | Environment variable to set the initial admin password                                                      | `OPENSEARCH_INITIAL_ADMIN_PASSWORD`                                                                 |
+| `dfdewey.opensearch.extraEnvs[0].value`        | The initial admin password                                                                                  | `KyfwJExU2!2MvU6j`                                                                                  |
+| `dfdewey.opensearch.extraEnvs[1].name`         | Environment variable to disable Opensearch Demo config                                                      | `DISABLE_INSTALL_DEMO_CONFIG`                                                                       |
+| `dfdewey.opensearch.extraEnvs[1].value`        | Disables Opensearch Demo config                                                                             | `true`                                                                                              |
+| `dfdewey.opensearch.extraEnvs[2].name`         | Environment variable to disable Opensearch Security plugin given that                                       | `DISABLE_SECURITY_PLUGIN`                                                                           |
+| `dfdewey.opensearch.extraEnvs[2].value`        | Disables Opensearch Security plugin                                                                         | `true`                                                                                              |
+| `dfdewey.opensearch.persistence.size`          | Opensearch Persistent Volume size. A persistent volume would be created for each Opensearch replica running | `2Gi`                                                                                               |
+| `dfdewey.opensearch.resources.requests.cpu`    | Requested cpu for the Opensearch containers                                                                 | `250m`                                                                                              |
+| `dfdewey.opensearch.resources.requests.memory` | Requested memory for the Opensearch containers                                                              | `512Mi`                                                                                             |
+
+### Third Party Configuration
+
+
+### Redis configuration parameters
+
+| Name                                | Description                                                                                  | Value        |
+| ----------------------------------- | -------------------------------------------------------------------------------------------- | ------------ |
+| `redis.enabled`                     | enabled Enables the Redis deployment                                                         | `true`       |
+| `redis.auth.enabled`                | Enables Redis Authentication. Disabled due to incompatibility with Turbinia                  | `false`      |
+| `redis.sentinel.enabled`            | Enables Redis Sentinel on Redis pods                                                         | `false`      |
+| `redis.architecture`                | Specifies the Redis architecture. Allowed values: `standalone` or `replication`              | `standalone` |
+| `redis.master.count`                | Number of Redis master instances to deploy (experimental, requires additional configuration) | `1`          |
+| `redis.master.service.type`         | Redis master service type                                                                    | `ClusterIP`  |
+| `redis.master.service.ports.redis`  | Redis master service port                                                                    | `6379`       |
+| `redis.master.persistence.size`     | Persistent Volume size                                                                       | `2Gi`        |
+| `redis.master.resources.limits`     | Resource limits for the Redis master containers                                              | `{}`         |
+| `redis.master.resources.requests`   | Requested resources for the Redis master containers                                          | `{}`         |
+| `redis.replica.replicaCount`        | Number of Redis replicas to deploy                                                           | `0`          |
+| `redis.replica.service.type`        | Redis replicas service type                                                                  | `ClusterIP`  |
+| `redis.replica.service.ports.redis` | Redis replicas service port                                                                  | `6379`       |
+| `redis.replica.persistence.size`    | Persistent Volume size                                                                       | `2Gi`        |
+| `redis.replica.resources.limits`    | Resources limits for the Redis replica containers                                            | `{}`         |
+| `redis.replica.resources.requests`  | Requested resources for the Redis replica containers                                         | `{}`         |
+
+### Oauth2 Proxy configuration parameters
+
+| Name                                                               | Description                                                                                                                                                           | Value                                        |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `oauth2proxy.enabled`                                              | Enables the Oauth2 Proxy deployment                                                                                                                                   | `false`                                      |
+| `oauth2proxy.containerPort`                                        | Oauth2 Proxy container port                                                                                                                                           | `4180`                                       |
+| `oauth2proxy.service.type`                                         | OAuth2 Proxy service type                                                                                                                                             | `ClusterIP`                                  |
+| `oauth2proxy.service.port`                                         | OAuth2 Proxy service HTTP port                                                                                                                                        | `8080`                                       |
+| `oauth2proxy.extraEnvVars[0].name`                                 | Name of the environment variable to pass to Oauth2 Proxy                                                                                                              | `OAUTH2_PROXY_OIDC_EXTRA_AUDIENCES`          |
+| `oauth2proxy.extraEnvVars[0].valueFrom.secretKeyRef.name`          | Name of the secret containing native client id                                                                                                                        | `{{ template "oauth2-proxy.secretName" . }}` |
+| `oauth2proxy.extraEnvVars[0].valueFrom.secretKeyRef.key`           | Name of the secret key containing native client id                                                                                                                    | `client-id-native`                           |
+| `oauth2proxy.extraEnvVars[0].valueFrom.secretKeyRef.optional`      | Set to optional if native client id is not provided                                                                                                                   | `true`                                       |
+| `oauth2proxy.configuration.turbiniaSvcPort`                        | Turbinia service port referenced from `.Values.service.port` to be used in Oauth setup                                                                                | `8000`                                       |
+| `oauth2proxy.configuration.existingSecret`                         | Secret with the client ID, client secret, client native id (optional) and cookie secret                                                                               | `""`                                         |
+| `oauth2proxy.configuration.content`                                | Oauth2 proxy configuration. Please see the [official docs](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview) for a list of configurable values | `""`                                         |
+| `oauth2proxy.configuration.authenticatedEmailsFile.enabled`        | Enable authenticated emails file                                                                                                                                      | `true`                                       |
+| `oauth2proxy.configuration.authenticatedEmailsFile.content`        | Restricted access list (one email per line). At least one email address is required for the Oauth2 Proxy to properly work                                             | `""`                                         |
+| `oauth2proxy.configuration.authenticatedEmailsFile.existingSecret` | Secret with the authenticated emails file                                                                                                                             | `""`                                         |
+| `oauth2proxy.configuration.authenticatedEmailsFile.existingSecret` | Secret with the authenticated emails file                                                                                                                             | `""`                                         |
+| `oauth2proxy.configuration.oidcIssuerUrl`                          | OpenID Connect issuer URL                                                                                                                                             | `https://accounts.google.com`                |
+| `oauth2proxy.redis.enabled`                                        | Enable Redis for OAuth Session Storage                                                                                                                                | `false`                                      |
+
+Specify each parameter using the --set key=value[,key=value] argument to helm install. For example,
+
+```console
+helm install my-release osdfir-charts/turbinia \
+--set ingress.enabled=true \
+--set ingress.host="mydomain.com" \
+--set ingress.selfSigned=true
+```
+
+The above command installs Turbinia with an attached Ingress.
+
+Alternatively, the `values.yaml` file can be directly updated if the Helm chart
+was pulled locally. For example,
+
+```console
+helm pull osdfir-charts/turbinia --untar
+```
+
+Then make changes to the downloaded `values.yaml` and once done, install the
+chart with the updated values.
+
+```console
+helm install my-release ../turbinia
+```
+
+## License
+
+Copyright &copy; 2024 OSDFIR Infrastructure
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+<http://www.apache.org/licenses/LICENSE-2.0>
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/k8s/turbinia/templates/NOTES.txt
+++ b/k8s/turbinia/templates/NOTES.txt
@@ -1,0 +1,36 @@
+Thank you for installing {{ .Chart.Name }}:{{ .Chart.Version }}
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+  $ kubectl get pods
+
+To connect to the Turbinia URL, run:
+  {{- if and (.Values.ingress.enabled) (.Values.ingress.host) }}
+  $ echo "Visit https://{{ .Values.ingress.host }} to access Turbinia externally"
+  {{- end }}
+  {{- if .Values.oauth2proxy.enabled }}
+  $ kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ .Release.Name }}-oauth2proxy {{ .Values.oauth2proxy.service.port }}:{{ .Values.oauth2proxy.service.port }}
+  $ echo "Visit http://127.0.0.1:{{ .Values.oauth2proxy.service.port }} to access Turbinia through port-forwarding"
+  {{- else }}
+  $ kubectl --namespace {{ .Release.Namespace }} port-forward service/{{ .Release.Name }}-turbinia {{ include "turbinia.service.port" . }}:{{ include "turbinia.service.port" . }}
+  $ echo "Visit http://127.0.0.1:{{ include "turbinia.service.port" . }} to access Turbinia through port-forwarding"
+  {{- end }}
+
+To install the Turbinia client, run:
+  $ pip3 install turbinia-client
+  $ kubectl get secret --namespace {{ .Release.Namespace }} {{ include "turbinia.fullname" . }}-secret -o jsonpath="{.data.turbinia-secret}" | base64 -d > ~/.turbinia_api_config.json
+
+Run the following commands on your workstation to orchestrate collection and processing of forensic data with dfTimewolf:
+  $ git clone https://github.com/log2timeline/dftimewolf && cd dftimewolf
+  $ pip3 install poetry
+  $ poetry install && poetry shell
+  $ dftimewolf -h
+  {{- if and .Values.oauth2proxy.enabled .Values.oauth2proxy.configuration.existingSecret }}
+  $ If using Turbinia with the Oauth2 Proxy, use the command below to generate the necessary config
+    $ kubectl get secret --namespace {{ .Release.Namespace }} {{ include "turbinia.fullname" . }}-secret -o jsonpath="{.data.dftimewolf-secret}" | base64 -d > ~/.dftimewolf_turbinia_secrets.json
+    $ Replace `client_secret` in `~/.dftimewolf_turbinia_secrets.json` with the secret from your configured native or desktop OAuth app.
+  {{- end }}

--- a/k8s/turbinia/templates/_helpers.tpl
+++ b/k8s/turbinia/templates/_helpers.tpl
@@ -1,0 +1,175 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "turbinia.name" -}}
+{{- default .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "turbinia.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name "turbinia" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "turbinia.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "turbinia.labels" -}}
+helm.sh/chart: {{ include "turbinia.chart" . }}
+{{ include "turbinia.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+date: "{{ now | htmlDate }}"
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "turbinia.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "turbinia.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "turbinia.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "turbinia.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper persistence volume claim name
+*/}}
+{{- define "turbinia.pvc.name" -}}
+{{- $pvcName := .Values.persistence.name -}}
+{{- if and .Values.global .Values.global.existingPVC -}}
+{{- printf "%s-%s" .Values.global.existingPVC "claim" }}
+{{- else -}}
+{{- printf "%s-%s-claim" .Release.Name $pvcName }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper Storage Class
+*/}}
+{{- define "turbinia.storage.class" -}}
+{{- $storageClass := .Values.persistence.storageClass -}}
+{{- if .Values.global -}}
+    {{- if .Values.global.storageClass -}}
+        {{- $storageClass = .Values.global.storageClass -}}
+    {{- end -}}
+{{- end -}}
+{{- if $storageClass -}}
+  {{- if (eq "-" $storageClass) -}}
+      {{- printf "storageClassName: \"\"" -}}
+  {{- else }}
+      {{- printf "storageClassName: %s" $storageClass -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+GCP Project ID validation
+*/}}
+{{- define "turbinia.gcp.project" -}}
+{{- if and .Values.gcp.projectID .Values.gcp.enabled -}}
+{{- printf "%s" .Values.gcp.projectID -}}
+{{- else -}}
+{{ fail "A valid .Values.gcp.projectID entry is required!" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+GCP Project region validation
+*/}}
+{{- define "turbinia.gcp.region" -}}
+{{- if and .Values.gcp.projectRegion .Values.gcp.enabled -}}
+{{- printf "%s" .Values.gcp.projectRegion -}}
+{{- else -}}
+{{ fail "A valid .Values.gcp.projectRegion entry is required!" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+GCP Project zone validation
+*/}}
+{{- define "turbinia.gcp.zone" -}}
+{{- if and .Values.gcp.projectZone .Values.gcp.enabled -}}
+{{- printf "%s" .Values.gcp.projectZone -}}
+{{- else -}}
+{{ fail "A valid .Values.gcp.projectZone entry is required!" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis subcharts connection url
+*/}}
+{{- define "turbinia.redis.url" -}}
+{{- if .Values.redis.enabled -}}
+{{- $name := include "common.names.fullname" (dict "Chart" (dict "Name" "redis") "Release" .Release "Values" .Values.redis) -}}
+{{- $port := .Values.redis.master.service.ports.redis -}}
+{{- if .Values.redis.auth.enabled -}}
+{{- printf "redis://default:'$REDIS_PASSWORD'@%s-master:%.0f" $name $port -}}
+{{- else -}}
+{{- printf "redis://%s-master:%.0f" $name $port -}}
+{{- end -}}
+{{- else -}}
+{{ fail "Attempting to use Redis, but the subchart is not enabled. This will lead to misconfiguration" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Redis subcharts host url
+*/}}
+{{- define "turbinia.redis.url.noport" -}}
+{{- if .Values.redis.enabled -}}
+{{- $name := include "common.names.fullname" (dict "Chart" (dict "Name" "redis") "Release" .Release "Values" .Values.redis) -}}
+{{- if .Values.redis.auth.enabled -}}
+{{- printf "%s-master" $name -}}
+{{- else -}}
+{{- printf "%s-master" $name -}}
+{{- end -}}
+{{- else -}}
+{{ fail "Attempting to use Redis, but the subchart is not enabled. This will lead to misconfiguration" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Turbinia service port
+*/}}
+{{- define "turbinia.service.port" -}}
+{{- if .Values.global.turbinia.servicePort -}}
+{{ .Values.global.turbinia.servicePort }}
+{{- else -}}
+{{ .Values.service.port }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Turbinia config map
+*/}}
+{{- define "turbinia.configmap" -}}
+{{- if .Values.config.existingConfigMap -}}
+{{ .Values.config.existingConfigMap }}
+{{- else -}}
+{{ include "turbinia.fullname" . }}-configmap
+{{- end -}}
+{{- end -}}

--- a/k8s/turbinia/templates/_initContainer.tpl
+++ b/k8s/turbinia/templates/_initContainer.tpl
@@ -1,0 +1,35 @@
+{{/*
+Init Container for when a Turbinia pod starts. To prevent duplicate code,
+this file has been created which then applies to both the Turbinia Server, API,
+and Worker pod upon startup.
+*/}}
+{{- define "turbinia.initContainer" -}}
+- name: init-turbinia
+  image: alpine
+  command: ['sh', '-c', '/init/init-turbinia.sh']
+  env:
+    {{- if and .Values.redis.enabled .Values.redis.auth.enabled }}
+    - name: REDIS_PASSWORD
+      valueFrom:
+        # Referencing from charts/redis/templates/_helpers.tpl
+        secretKeyRef:
+          name: {{ include "redis.secretName" .Subcharts.redis }}
+          key: {{ include "redis.secretPasswordKey" .Subcharts.redis }}
+    {{- end }}
+    {{- if and .Values.config.existingVertexSecret .Values.gcp.enabled }}
+    - name: VERTEX_APIKEY
+      valueFrom:
+        secretKeyRef:
+          name: {{ .Values.config.existingVertexSecret }}
+          key: "turbinia-vertexapi"
+    {{- end }}
+  volumeMounts:
+    - mountPath: /mnt/turbiniavolume
+      name: turbiniavolume
+    - mountPath: /init
+      name: init-turbinia
+    - mountPath: /etc/turbinia
+      name: turbinia-configs
+    - mountPath: /tmp/turbinia
+      name: user-configs
+{{- end }}

--- a/k8s/turbinia/templates/api-deployment.yaml
+++ b/k8s/turbinia/templates/api-deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ include "turbinia.fullname" . }}-api
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: api
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api
+      {{- include "turbinia.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Restart pod if values.yaml parameters that affect the config were changed
+        checksum/config: {{  include (print $.Template.BasePath "/init-configmap.yaml") . | sha256sum }}
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        prometheus.io/scrape: "true"
+        {{- end }}
+      labels:
+        app.kubernetes.io/component: api
+        {{- include "turbinia.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "turbinia.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "turbinia.initContainer" . | nindent 8 }} 
+      containers:
+        - name: api
+          securityContext:
+              {{- toYaml .Values.api.securityContext | nindent 12 }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command: ['sh', '-c', "ps aux | grep api_server | grep -v grep"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          env:
+            - name: TURBINIA_EXTRA_ARGS
+              value: "-d"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /var/log
+              name: logs
+            - mountPath: /mnt/turbiniavolume
+              name: turbiniavolume
+            - mountPath: /etc/turbinia
+              name: turbinia-configs
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.metrics.port }}
+            {{- end }}
+            - containerPort: 8000
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+      volumes:
+        - name: turbiniavolume
+          persistentVolumeClaim:
+            claimName: {{ include "turbinia.pvc.name"  . }}
+            readOnly: false
+        - name: logs
+          emptyDir: {}
+        - name: init-turbinia
+          configMap:
+            name: {{ include "turbinia.fullname" . }}-init-configmap
+            defaultMode: 0777
+        - name: turbinia-configs
+          emptyDir: {}
+        - name: user-configs
+          configMap:
+            name: {{ include "turbinia.configmap" . }}
+            optional: true
+      {{- with .Values.api.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.api.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/turbinia/templates/certs/cert-manager-issuer.yaml
+++ b/k8s/turbinia/templates/certs/cert-manager-issuer.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.ingress.enabled .Values.ingress.certManager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "turbinia.fullname" . }}-letsencrypt-production
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: "pre-install"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: {{ include "turbinia.fullname" . }}-letsencrypt-production
+    solvers:
+    - http01:
+        ingress:
+          name: {{ include "turbinia.fullname" . }}-ingress
+{{- end }}

--- a/k8s/turbinia/templates/certs/tls-secrets.yaml
+++ b/k8s/turbinia/templates/certs/tls-secrets.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.ingress.enabled (or .Values.ingress.selfSigned .Values.ingress.certManager) }}
+{{- $ca := genCA "turbinia-ca" 365 }}
+{{- $cert := genSignedCert "turbinia-apps" nil (list .Values.ingress.host) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "turbinia.fullname" . }}-tls
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    helm.sh/hook: "pre-install"
+    helm.sh/hook-delete-policy: "before-hook-creation"
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+{{- end }}

--- a/k8s/turbinia/templates/crds/servicemonitor.yaml
+++ b/k8s/turbinia/templates/crds/servicemonitor.yaml
@@ -1,0 +1,12 @@
+{{ if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ printf "%s-%s" .Release.Name "turbinia-metrics-servicemonitor" }}
+spec:
+  selector:
+    matchLabels:
+      monitoring: enabled
+  endpoints:
+  - port: http-metrics
+{{ end -}}

--- a/k8s/turbinia/templates/gcp/backendconfig.yaml
+++ b/k8s/turbinia/templates/gcp/backendconfig.yaml
@@ -1,0 +1,24 @@
+{{- if or (and (.Values.ingress.enabled) (eq .Values.ingress.className "gce") (not .Values.oauth2proxy.enabled)) (and (.Values.global.ingress.enabled) (eq .Values.global.ingress.className "gce") (not .Values.oauth2proxy.enabled)) }}
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: "{{ .Release.Name }}-backend-config"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  timeoutSec: 900
+  healthCheck:
+    checkIntervalSec: 5
+    timeoutSec: 5
+    healthyThreshold: 2
+    unhealthyThreshold: 2
+    type: HTTP
+    {{- if .Values.oauth2proxy.enabled }}
+    requestPath: /ping
+    port: 4180
+    {{- else }}
+    requestPath: /web
+    port: 8000
+    {{- end }}
+{{- end }}

--- a/k8s/turbinia/templates/gcp/frontendconfig.yaml
+++ b/k8s/turbinia/templates/gcp/frontendconfig.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.ingress.enabled) (eq .Values.ingress.className "gce") }}
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: {{ include "turbinia.fullname" . }}-frontend-config
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  redirectToHttps:
+    enabled: true
+{{- end }}

--- a/k8s/turbinia/templates/gcp/managedcertificate.yaml
+++ b/k8s/turbinia/templates/gcp/managedcertificate.yaml
@@ -1,0 +1,12 @@
+{{- if and (.Values.ingress.enabled) (.Values.ingress.gcp.managedCertificates) }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ include "turbinia.fullname" . }}-managed-ssl
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  domains: 
+    - {{ required "A valid .Values.ingress.host entry is required!" .Values.ingress.host }}
+{{- end }}

--- a/k8s/turbinia/templates/hpa.yaml
+++ b/k8s/turbinia/templates/hpa.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.worker.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "turbinia.fullname" . }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "turbinia.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/k8s/turbinia/templates/ingress.yaml
+++ b/k8s/turbinia/templates/ingress.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name:  {{ include "turbinia.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingressClassName: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.gcp.managedCertificates }}
+    networking.gke.io/managed-certificates: {{ include "turbinia.fullname" . }}-managed-ssl
+    {{- end }}
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/issuer: {{ include "turbinia.fullname" . }}-letsencrypt-production
+    {{- end }}
+    {{- if (eq .Values.ingress.className "gce") }}
+    {{- if .Values.ingress.gcp.staticIPName }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.staticIPName }}
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "turbinia.fullname" . }}-frontend-config
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if or .Values.ingress.selfSigned .Values.ingress.certManager }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ include "turbinia.fullname" . }}-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                {{- if .Values.oauth2proxy.enabled }}
+                name: {{ .Release.Name }}-oauth2proxy
+                port:
+                  number: {{ .Values.oauth2proxy.service.port }}
+                {{- else }}
+                name: {{ include "turbinia.fullname" . }}
+                port:
+                  number: {{ include "turbinia.service.port" . }}
+                {{- end }}
+  defaultBackend:
+    service:
+      {{- if .Values.oauth2proxy.enabled }} 
+      name: {{ .Release.Name }}-oauth2proxy # Name of the Service targeted by the Ingress
+      port:
+        number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
+      {{- else }}
+      name: {{ include "turbinia.fullname" . }}
+      port:
+        number: {{ include "turbinia.service.port" . }}
+      {{- end }}
+{{- end }}
+{{- if and .Values.ingress.enabled .Values.ingress.gcp.staticIPV6Name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name:  {{ include "turbinia.fullname" . }}-ingress-ipv6
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingressClassName: {{ .Values.ingress.className }}
+    {{- if .Values.ingress.gcp.managedCertificates }}
+    networking.gke.io/managed-certificates: {{ include "turbinia.fullname" . }}-managed-ssl
+    networking.gke.io/v1beta1.FrontendConfig: {{ include "turbinia.fullname" . }}-frontend-config
+    {{- end }}
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    cert-manager.io/issuer: {{ include "turbinia.fullname" . }}-letsencrypt-production
+    {{- end }}
+    {{- if .Values.ingress.gcp.staticIPV6Name }}
+    kubernetes.io/ingress.global-static-ip-name: {{ .Values.ingress.gcp.staticIPV6Name }}
+    {{- end }}
+spec:
+  {{- if or .Values.ingress.selfSigned .Values.ingress.certManager }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ include "turbinia.fullname" . }}-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                {{- if .Values.oauth2proxy.enabled }}
+                name: {{ .Release.Name }}-oauth2proxy
+                port:
+                  number: {{ .Values.oauth2proxy.service.port }}
+                {{- else }}
+                name: {{ include "turbinia.fullname" . }}
+                port:
+                  number: {{ include "turbinia.service.port" . }}
+                {{- end }}
+  defaultBackend:
+    service:
+      {{- if .Values.oauth2proxy.enabled }} 
+      name: {{ .Release.Name }}-oauth2proxy # Name of the Service targeted by the Ingress
+      port:
+        number: {{ .Values.oauth2proxy.service.port }} # Should match the port used by the Service
+      {{- else }}
+      name: {{ include "turbinia.fullname" . }}
+      port:
+        number: {{ include "turbinia.service.port" . }}
+      {{- end }}
+{{- end }}

--- a/k8s/turbinia/templates/init-configmap.yaml
+++ b/k8s/turbinia/templates/init-configmap.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "turbinia.fullname" . }}-init-configmap
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+data:
+  init-turbinia.sh: |
+    #!/bin/sh
+    set -e
+    apk add jq
+
+    # Fix Filestore permissions
+    chmod go+w /mnt/turbiniavolume
+
+    # Create turbinia config directory
+    mkdir -p /etc/turbinia
+    cd /etc/turbinia
+
+    if [  $(ls /tmp/turbinia/ | wc -l) -gt 0 ]; then
+      echo "Using exisiting configuration file provided."
+      cp /tmp/turbinia/* /etc/turbinia/turbinia.conf
+    else
+      # Pull default config if one is not already provided
+      echo -n "* Fetching the latest Turbinia configuration file..." 
+      wget "https://raw.githubusercontent.com/google/turbinia/master/turbinia/config/turbinia_config_tmpl.py" -O turbinia.conf
+      echo "OK"
+    fi
+
+    # Set up the Redis connection
+    sed -i -e "s/^TASK_MANAGER = .*$/TASK_MANAGER = 'Celery'/g" turbinia.conf
+    sed -i -e "s/^STATE_MANAGER = .*$/STATE_MANAGER = 'Redis'/g" turbinia.conf
+    sed -i -e 's#^REDIS_HOST =.*#REDIS_HOST = {{ (include "turbinia.redis.url.noport" .) | quote }}#' turbinia.conf 
+    sed -i -e 's#^CELERY_BROKER =.*#CELERY_BROKER = {{ (include "turbinia.redis.url" .) | quote }}#' turbinia.conf
+    sed -i -e 's#^CELERY_BACKEND =.*#CELERY_BACKEND = {{ (include "turbinia.redis.url" .) | quote }}#' turbinia.conf
+    sed -i -e "s/^DEBUG_TASKS = .*$/DEBUG_TASKS = True/g" turbinia.conf
+    
+    {{- if .Values.gcp.enabled }}
+    # Set up Cloud provider (only supported option is GCP)
+    sed -i -e "s/^CLOUD_PROVIDER = .*$/CLOUD_PROVIDER = 'GCP'/g" turbinia.conf
+    sed -i -e "s/^TURBINIA_PROJECT = .*$/TURBINIA_PROJECT = '{{ include "turbinia.gcp.project" . }}'/g" turbinia.conf
+    sed -i -e "s/^TURBINIA_ZONE = .*$/TURBINIA_ZONE = '{{ include "turbinia.gcp.zone" . }}'/g" turbinia.conf
+    sed -i -e "s/^TURBINIA_REGION = .*$/TURBINIA_REGION = '{{ include "turbinia.gcp.region" . }}'/g" turbinia.conf
+    {{- end }}
+
+    {{- if .Values.global.dfdewey.enabled }}
+    # Set up dfDewey config
+    sed -i -e "s/^DFDEWEY_PG_HOST = .*$/DFDEWEY_PG_HOST = \'{{- printf "%s-%s" .Release.Name .Values.dfdewey.postgresql.nameOverride -}}\'/g" turbinia.conf
+    sed -i -e "s/^DFDEWEY_OS_HOST = .*$/DFDEWEY_OS_HOST = \'{{ .Values.dfdewey.opensearch.masterService }}\'/g" turbinia.conf
+    {{- end}}
+    
+    # Setup logging, mount, and output paths
+    sed -i -e "s/^SHARED_FILESYSTEM = .*$/SHARED_FILESYSTEM = True/g" turbinia.conf
+    sed -i -e "s/^LOG_DIR = .*$/LOG_DIR = '\/mnt\/{{ .Values.persistence.name }}\/logs'/g" turbinia.conf
+    sed -i -e "s/^MOUNT_DIR_PREFIX = .*$/MOUNT_DIR_PREFIX = '\/mnt\/turbinia'/g" turbinia.conf
+    sed -i -e "s/^OUTPUT_DIR = .*$/OUTPUT_DIR = '\/mnt\/{{ .Values.persistence.name }}\/output'/g" turbinia.conf
+    sed -i -e "s/^API_EVIDENCE_UPLOAD_DIR = .*$/API_EVIDENCE_UPLOAD_DIR = '\/mnt\/{{ .Values.persistence.name }}\/upload'/g" turbinia.conf
+    
+    # Disable Turbinia Jobs
+    sed -i -e "s/^DISABLED_JOBS = .*$/DISABLED_JOBS = {{ .Values.config.disabledJobs }}/g" turbinia.conf
+
+    {{- if .Values.metrics.enabled }}
+    # Set up Prometheus metrics
+    sed -i -e "s/^PROMETHEUS_ENABLED = .*$/PROMETHEUS_ENABLED = True/g" turbinia.conf
+    {{- end }}
+
+    {{- if not .Values.versioncheck.enabled }}
+    # Set up Turbinia server/worker version runtime check
+    sed -i -e "s/^VERSION_CHECK = .*$/VERSION_CHECK = False/g" turbinia.conf
+    {{- end }}
+    
+    {{- if and .Values.gcp.gcpLogging .Values.gcp.enabled }}
+    # Set up GCP Stackdriver Logging
+    sed -i -e "s/^STACKDRIVER_LOGGING = .*$/STACKDRIVER_LOGGING = True/g" turbinia.conf
+    {{- end }}
+    {{- if and .Values.gcp.gcpErrorReporting .Values.gcp.enabled }}
+    # Set up GCP Stackdriver Traceback
+    sed -i -e "s/^STACKDRIVER_TRACEBACK = .*$/STACKDRIVER_TRACEBACK = True/g" turbinia.conf
+    {{- end }}
+
+    {{- if and .Values.config.existingVertexSecret .Values.gcp.enabled }}
+    # Set up VertexAI API key from secret key reference
+    sed -i -e "s/^GCP_GENERATIVE_LANGUAGE_API_KEY = .*$/GCP_GENERATIVE_LANGUAGE_API_KEY = '$VERTEX_APIKEY'/g" turbinia.conf
+    {{- end -}}

--- a/k8s/turbinia/templates/metrics/server-metrics-service.yaml
+++ b/k8s/turbinia/templates/metrics/server-metrics-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metrics.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "turbinia.fullname" . }}-server-metrics
+  labels:
+    monitoring: enabled
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+      protocol: TCP
+      name: http-metrics
+  selector:
+    app.kubernetes.io/component: server
+    {{- include "turbinia.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/turbinia/templates/metrics/worker-metrics-service.yaml
+++ b/k8s/turbinia/templates/metrics/worker-metrics-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metrics.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "turbinia.fullname" . }}-worker-metrics
+  labels:
+    monitoring: enabled
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.metrics.port }}
+      targetPort: {{ .Values.metrics.port }}
+      protocol: TCP
+      name: http-metrics
+  selector:
+    app.kubernetes.io/component: worker
+    {{- include "turbinia.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/k8s/turbinia/templates/pvc.yaml
+++ b/k8s/turbinia/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if not (.Values.global.existingPVC) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations: 
+    helm.sh/resource-policy: keep
+  name: {{ include "turbinia.pvc.name"  . }}
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  {{- include "turbinia.storage.class" . | nindent 2 }}
+  accessModes:
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end }}

--- a/k8s/turbinia/templates/secret.yaml
+++ b/k8s/turbinia/templates/secret.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "turbinia.fullname" . }}-secret
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+stringData:
+  {{- if and .Values.oauth2proxy.enabled .Values.oauth2proxy.configuration.existingSecret }}
+  dftimewolf-secret: |
+    {
+      installed:
+        {
+            "client_id": "{{ index (lookup "v1" "Secret" .Release.Namespace .Values.oauth2proxy.configuration.existingSecret).data "client-id-native" | b64dec }}",
+            "client_secret": "",
+            "redirect_uris": [ "https://{{ .Values.ingress.host }}.com/oauth2/callback" ],
+            "project_id": "{{ .Values.gcp.projectID }}",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs"
+        }
+    }
+  {{- end }}
+  turbinia-secret: |
+    {
+        "default": {
+            "description": "This file is used by turbinia-client to determine the location of the API server and if authentication will be used. These options should match your Turbinia deployment.",
+            "comments": "By default, the credentials and client secrets files are located in the user's home directory.",
+            "API_SERVER_ADDRESS": "http://localhost",
+            "API_SERVER_PORT": 8000,
+            "API_AUTHENTICATION_ENABLED": false,
+            "CLIENT_SECRETS_FILENAME": ".client_secrets.json",
+            "CREDENTIALS_FILENAME": ".credentials_default.json"
+        }
+    }

--- a/k8s/turbinia/templates/server-deployment.yaml
+++ b/k8s/turbinia/templates/server-deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ include "turbinia.fullname" . }}-server
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: server
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: server
+      {{- include "turbinia.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Restart pod if values.yaml parameters that affect the config were changed the config
+        checksum/config: {{  include (print $.Template.BasePath "/init-configmap.yaml") . | sha256sum }}
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        prometheus.io/scrape: "true"
+        {{- end }}
+      labels:
+        app.kubernetes.io/component: server
+        {{- include "turbinia.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "turbinia.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.server.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "turbinia.initContainer" . | nindent 8 }} 
+      containers:
+        - name: server
+          securityContext:
+              {{- toYaml .Values.server.securityContext | nindent 12 }}
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          env:
+            - name: TURBINIA_EXTRA_ARGS
+              value: "-d"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /mnt/turbiniavolume
+              name: turbiniavolume
+            - mountPath: /etc/turbinia
+              name: turbinia-configs
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.metrics.port }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.server.resources | nindent 12 }}
+      volumes:
+        - name: turbiniavolume
+          persistentVolumeClaim:
+            claimName: {{ include "turbinia.pvc.name"  . }}
+            readOnly: false
+        - name: init-turbinia
+          configMap:
+            name: {{ include "turbinia.fullname" . }}-init-configmap
+            defaultMode: 0744
+        - name: turbinia-configs
+          emptyDir: {}
+        - name: user-configs
+          configMap:
+            name: {{ include "turbinia.configmap" . }}
+            optional: true
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/k8s/turbinia/templates/service.yaml
+++ b/k8s/turbinia/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-turbinia
+  {{- if or (and (.Values.ingress.enabled) (eq .Values.ingress.className "gce") (not .Values.oauth2proxy.enabled)) (and (.Values.global.ingress.enabled) (eq .Values.global.ingress.className "gce") (not .Values.oauth2proxy.enabled)) }}
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"ports": {"8000": "{{ .Release.Name }}-backend-config"}}'
+  {{- end }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ include "turbinia.service.port" . }}
+      protocol: TCP
+      targetPort: 8000
+  selector:
+    app.kubernetes.io/component: api
+    {{- include "turbinia.selectorLabels" . | nindent 4 }}

--- a/k8s/turbinia/templates/serviceaccount.yaml
+++ b/k8s/turbinia/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+{{- if not (lookup "v1" "ServiceAccount" .Release.Namespace .Values.serviceAccount.name) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "turbinia.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "turbinia.labels" . | nindent 4 }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+  {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/k8s/turbinia/templates/worker-deployment.yaml
+++ b/k8s/turbinia/templates/worker-deployment.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name:  {{ include "turbinia.fullname" . }}-worker
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/component: worker
+    {{- include "turbinia.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.worker.autoscaling.enabled }}
+  replicas: {{ .Values.worker.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: worker
+      {{- include "turbinia.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Restart pod if values.yaml parameters that affect the config were changed
+        checksum/config: {{  include (print $.Template.BasePath "/init-configmap.yaml") . | sha256sum }}
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        prometheus.io/scrape: "true"
+        {{- end }}
+      labels:
+        app.kubernetes.io/component: worker
+        {{- include "turbinia.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "turbinia.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.worker.podSecurityContext | nindent 8 }}
+      initContainers:
+      {{- include "turbinia.initContainer" . | nindent 8 }} 
+      # The grace period needs to be set to the largest task timeout as
+      # set in the turbinia configuration file plus five seconds.
+      terminationGracePeriodSeconds: 86405
+      containers:
+        - name: worker
+          securityContext:
+              {{- toYaml .Values.worker.securityContext | nindent 12 }}
+          image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "touch /tmp/turbinia-to-scaledown.lock && sleep 5 && /usr/bin/python3 /home/turbinia/check-lockfile.py"
+          env:
+            - name: TURBINIA_EXTRA_ARGS
+              value: "-d"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            {{- if .Values.gcp.enabled }}
+            - mountPath: "/dev"
+              name: dev
+              readOnly: true
+            - mountPath: "/var/run/lock"
+              name: lockfolder
+              readOnly: false
+            {{- end }}
+            - mountPath: /mnt/turbiniavolume
+              name: turbiniavolume
+            - mountPath: /etc/turbinia
+              name: turbinia-configs
+          ports:
+            {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.metrics.port }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.gcp.enabled }}
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: lockfolder
+          hostPath:
+            path: /var/run/lock
+        {{- end }}
+        - name: turbiniavolume
+          persistentVolumeClaim:
+            claimName: {{ include "turbinia.pvc.name"  . }}
+            readOnly: false
+        - name: init-turbinia
+          configMap:
+            name: {{ include "turbinia.fullname" . }}-init-configmap
+            defaultMode: 0744
+        - name: turbinia-configs
+          emptyDir: {}
+        - name: user-configs
+          configMap:
+            name: {{ include "turbinia.configmap" . }}
+            optional: true
+      {{- with .Values.worker.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/k8s/turbinia/values.yaml
+++ b/k8s/turbinia/values.yaml
@@ -1,0 +1,704 @@
+## Turbinia Helm Chart
+## Please use this Helm chart for deploying Turbinia to a Kubernetes environment
+##
+## @section Global parameters
+## Please, note that this will override the parameters configured to use the global value
+##
+global:
+  ## Global Persistence Configuration
+  ##
+  timesketch:
+    ## @param global.timesketch.enabled Enables the Timesketch deployment (only used in the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.timesketch.servicePort Timesketch service port (overrides `timesketch.service.port`)
+    ##
+    servicePort:
+  turbinia:
+    ## @param global.turbinia.enabled Enables the Turbinia deployment (only used within the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.turbinia.servicePort Turbinia API service port (overrides `turbinia.service.port`)
+    ##
+    servicePort:
+  dfdewey:
+    ## @param global.dfdewey.enabled Enables the dfDewey deployment along with Turbinia
+    ##
+    enabled: false
+  yeti:
+    ## @param global.yeti.enabled Enables the Yeti deployment (only used in the main OSDFIR Infrastructure Helm chart)
+    ##
+    enabled: false
+    ## @param global.yeti.servicePort Yeti API service port (overrides `yeti.api.service.port`)
+    ##
+    servicePort:
+  ## Global ingress parameters used to configure Turbinia, Timesketch, Yeti under a single loadbalancer
+  ##
+  ingress:
+    ## @param global.ingress.enabled Enable the global loadbalancer for external access
+    ##
+    enabled: false
+  ## @param global.existingPVC Existing claim for Turbinia persistent volume (overrides `persistent.name`)
+  ##
+  existingPVC: ""
+  ## @param global.storageClass StorageClass for the Turbinia persistent volume (overrides `persistent.storageClass`)
+  ##
+  storageClass: ""
+## @section Turbinia configuration
+## The following section covers configuration parameters for Turbinia
+##
+## @section Turbinia server configuration
+##
+server:
+  image:
+    ## @param server.image.repository Turbinia image repository
+    ##
+    repository: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-server
+    ## @param server.image.pullPolicy Turbinia image pull policy
+    ## ref https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    ##
+    pullPolicy: IfNotPresent
+    ## @param server.image.tag Overrides the image tag whose default is the chart appVersion
+    ##
+    tag: "20240820"
+    ## @param server.image.imagePullSecrets Specify secrets if pulling from a private repository
+    ## ref https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g.
+    ## imagePullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    imagePullSecrets: []
+  ## @param server.podSecurityContext Holds pod-level security attributes and common server container settings
+  ## Some fields are also present in container.securityContext. Field values of container.securityContext take precedence over field values of PodSecurityContext
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core
+  ## e.g.
+  ## fsgroup: 2000
+  ##
+  podSecurityContext: {}
+  ## @param server.securityContext Holds security configuration that will be applied to the server container
+  ## Some fields are present in both SecurityContext and PodSecurityContext. When both are set, the values in SecurityContext take precedence
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core
+  ## e.g.
+  ## capabilities
+  ##   drop:
+  ##   - ALL
+  ## readOnlyRootFilesystem: true
+  ## runAsNonRoot: true
+  ## runAsUser: 1000
+  ##
+  securityContext: {}
+  ## Turbinia Server resource requests and limits
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## We leave the default resources as a choice for the user in order to increase
+  ## the chances charts run on environments with little resources, such as Minikube.
+  ## If you want to specify resources, uncomment the following lines, adjust them as
+  ## necessary, and remove the curly braces after 'resources:'.
+  ## @param server.resources.limits Resource limits for the server container
+  ## @param server.resources.requests Requested resources for the server container
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    ## Example:
+    ## requests:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    requests: {}
+  ## @param server.nodeSelector Node labels for Turbinia server pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param server.tolerations Tolerations for Turbinia server pods assignment
+  ## ref https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param server.affinity Affinity for Turbinia server pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+## @section Turbinia worker configuration
+##
+worker:
+  image:
+    ## @param worker.image.repository Turbinia image repository
+    ##
+    repository: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-worker
+    ## @param worker.image.pullPolicy Turbinia image pull policy
+    ## ref https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    ##
+    pullPolicy: IfNotPresent
+    ## @param worker.image.tag Overrides the image tag whose default is the chart appVersion
+    ##
+    tag: "20240820"
+    ## @param worker.image.imagePullSecrets Specify secrets if pulling from a private repository
+    ## ref https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g.
+    ## imagePullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    imagePullSecrets: []
+  ## @param worker.replicaCount Number of worker pods to run at once
+  ## Disabled if the value worker.autoscaling.enabled is enabled.
+  replicaCount: 1
+  ## Worker autoscaler configuration
+  ## ref https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+  ##
+  autoscaling:
+    ## @param worker.autoscaling.enabled Enables Turbinia Worker autoscaling
+    ##
+    enabled: false
+    ## @param worker.autoscaling.minReplicas Minimum amount of worker pods to run at once
+    ##
+    minReplicas: 5
+    ## @param worker.autoscaling.maxReplicas Maximum amount of worker pods to run at once
+    ##
+    maxReplicas: 500
+    ## @param worker.autoscaling.targetCPUUtilizationPercentage CPU scaling metric workers will scale based on
+    ##
+    targetCPUUtilizationPercentage: 80
+  ## @param worker.podSecurityContext Holds pod-level security attributes and common worker container settings
+  ## Some fields are also present in container.securityContext. Field values of container.securityContext take precedence over field values of PodSecurityContext
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core
+  ## e.g.
+  ## fsgroup: 2000
+  ##
+  podSecurityContext: {}
+  ## Worker Security Context Configuration
+  ## Some fields are present in both SecurityContext and PodSecurityContext. When both are set, the values in SecurityContext take precedence
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core
+  ##
+  securityContext:
+    ## @param worker.securityContext.privileged Runs the container as priveleged. Due to Turbinia attaching and detaching disks, a priveleged container is required for the worker container.
+    ##
+    privileged: true
+  ## Turbinia Worker resource requests and limits
+  ## @param worker.resources.limits Resources limits for the worker container
+  ## @param worker.resources.requests.cpu Requested cpu for the worker container
+  ## @param worker.resources.requests.memory Requested memory for the worker container
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    requests:
+      cpu: 250m
+      memory: 256Mi
+  ## @param worker.nodeSelector Node labels for Turbinia worker pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param worker.tolerations Tolerations for Turbinia worker pods assignment
+  ## ref https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param worker.affinity Affinity for Turbinia worker pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+## @section Turbinia API / Web configuration
+##
+api:
+  image:
+    ## @param api.image.repository Turbinia image repository for API / Web server
+    ##
+    repository: us-docker.pkg.dev/osdfir-registry/turbinia/release/turbinia-api-server
+    ## @param api.image.pullPolicy Turbinia image pull policy
+    ## ref https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
+    ##
+    pullPolicy: IfNotPresent
+    ## @param api.image.tag Overrides the image tag whose default is the chart appVersion
+    ##
+    tag: "20240820"
+    ## @param api.image.imagePullSecrets Specify secrets if pulling from a private repository
+    ## ref https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g.
+    ## imagePullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    imagePullSecrets: []
+  ## @param api.podSecurityContext Holds pod-level security attributes that will be applied to the API / Web container
+  ## Some fields are also present in container.securityContext. Field values of container.securityContext take precedence over field values of PodSecurityContext
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#podsecuritycontext-v1-core
+  ## e.g.
+  ## fsgroup: 2000
+  ##
+  podSecurityContext: {}
+  ## @param api.securityContext Holds security configuration that will be applied to the API / Web container
+  ## Some fields are present in both SecurityContext and PodSecurityContext. When both are set, the values in SecurityContext take precedence
+  ## ref https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#securitycontext-v1-core
+  ## e.g.
+  ## capabilities
+  ##   drop:
+  ##   - ALL
+  ## readOnlyRootFilesystem: true
+  ## runAsNonRoot: true
+  ## runAsUser: 1000
+  ##
+  securityContext: {}
+  ## Turbinia API / Web resource requests and limits
+  ## @param api.resources.limits Resource limits for the api container
+  ## @param api.resources.requests Requested resources for the api container
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    limits: {}
+    ## Example:
+    ## requests:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    requests: {}
+  ## @param api.nodeSelector Node labels for Turbinia api pods assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param api.tolerations Tolerations for Turbinia api pods assignment
+  ## ref https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  ##
+  tolerations: []
+  ## @param api.affinity Affinity for Turbinia api pods assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+## @section Common Parameters
+##
+## Turbinia configuration parameters
+## ref: https://github.com/google/turbinia/blob/master/turbinia/config/turbinia_config_tmpl.py
+##
+config:
+  ## @param config.existingConfigMap Use an existing ConfigMap as the default Turbinia config.
+  ## Please ensure that the ConfigMap has been created prior to deployment
+  ## (e.g. kubectl create configmap turbinia-config --from-file=turbinia.conf)
+  ##
+  existingConfigMap: ""
+  ## @param config.disabledJobs List of Turbinia Jobs to disable. Overrides DISABLED_JOBS in the Turbinia config.
+  ##
+  disabledJobs: "['BinaryExtractorJob', 'BulkExtractorJob', 'HindsightJob', 'PhotorecJob', 'VolatilityJob']"
+  ## @param config.existingVertexSecret Name of existing secret containing Vertex API Key in order to enable the Turbinia LLM Artifacts Analyzer. The secret must contain the key `turbinia-vertexapi`
+  ## Please see https://ai.google.dev/tutorials/setup to generate your own API key.
+  ## e.g. kubectl create secret generic turbinia-vertexapi-secret --from-literal=turbinia-vertexapi=VERTEX_API_KEY
+  ##
+  existingVertexSecret: ""
+## GCP configuration parameters
+## IMPORTANT: Enable GCP when running Turbinia in a GKE cluster
+##
+gcp:
+  ## @param gcp.enabled Enables Turbinia to run within a GCP project. When enabling, please ensure you have run the supplemental script `create-gcp-sa.sh` to create a Turbinia GCP service account required for attaching persistent disks.
+  ##
+  enabled: false
+  ## @param gcp.projectID GCP Project ID where your cluster is deployed. Required when `.Values.gcp.enabled` is set to `true`
+  ##
+  projectID: ""
+  ## @param gcp.projectRegion Region where your cluster is deployed. Required when `.Values.gcp.enabled` is set to `true`
+  ##
+  projectRegion: ""
+  ## @param gcp.projectZone Zone where your cluster is deployed. Required when `.Values.gcp.enabled` is set to `true`
+  ##
+  projectZone: ""
+  ## @param gcp.gcpLogging Enables GCP Cloud Logging
+  ## ref https://cloud.google.com/logging
+  ##
+  gcpLogging: false
+  ## @param gcp.gcpErrorReporting Enables GCP Cloud Error Reporting
+  ## ref https://cloud.google.com/error-reporting/docs/grouping-errors
+  ##
+  gcpErrorReporting: false
+## Turbinia service account parameters
+##
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  ##
+  create: true
+  ## @param serviceAccount.annotations Annotations to add to the service account
+  ##
+  annotations: {}
+  ## @param serviceAccount.name The name of the Kubernetes service account to use
+  ## If not set and create is true, a name is generated using the fullname template
+  ##
+  name: "turbinia"
+## Turbinia service parameters
+##
+service:
+  ## @param service.type Turbinia service type
+  ##
+  type: ClusterIP
+  ## @param service.port Turbinia api service port
+  ##
+  port: &turbiniaSvcPort 8000
+## Turbinia metrics parameters
+## IMPORTANT: Turbinia can scrape metrics through Prometheus annotations or through the Prometheus operator using a ServiceMonitor CRD
+## Please ensure the Prometheus server is also installed to the cluster for metrics to scrape properly
+##
+metrics:
+  ## @param metrics.enabled Enables metrics scraping
+  ##
+  enabled: true
+  ## @param metrics.port Port to scrape metrics from
+  ##
+  port: 9200
+versioncheck:
+  ## @param versioncheck.enabled Enable Turbinia runtime version checking
+  ##
+  enabled: true
+## Turbinia persistence storage parameters
+##
+persistence:
+  ## @param persistence.name Turbinia persistent volume name
+  ##
+  name: turbiniavolume
+  ## @param persistence.size Turbinia persistent volume size
+  ##
+  size: 2Gi
+  ## @param persistence.storageClass PVC Storage Class for Turbinia volume
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ## ref https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/#using-dynamic-provisioning
+  ##
+  storageClass: ""
+  ## @param persistence.accessModes PVC Access Mode for Turbinia volume
+  ## Access mode may need to be updated based on the StorageClass
+  ## ref https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+## Turbinia ingress parameters
+##
+ingress:
+  ## @param ingress.enabled Enable the Turbinia loadbalancer for external access (only used in the main OSDFIR Infrastructure Helm chart)
+  ##
+  enabled: false
+  ## @param ingress.host The domain name Turbinia will be hosted under
+  ## Please ensure this value is set when enabling Ingress. If using "gce" for
+  ## ingress.className, please ensure you have a DNS record set for the IP address
+  ## registered under ingress.gcp.staticIPName
+  ##
+  host: ""
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.certManager Add the corresponding annotations for cert-manager integration
+  ##
+  certManager: false
+  ## @param ingress.className IngressClass that will be be used to implement the Ingress
+  ## ref https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
+  ##
+  className: ""
+  ## GCP ingress configuration
+  ##
+  gcp:
+    ## @param ingress.gcp.managedCertificates Enabled GCP managed certificates for your domain
+    ## ref https://cloud.google.com/load-balancing/docs/ssl-certificates/google-managed-certs
+    ##
+    managedCertificates: false
+    ## @param ingress.gcp.staticIPName Name of the static IP address you reserved in GCP
+    ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+    ##
+    staticIPName: ""
+    ## @param ingress.gcp.staticIPV6Name Name of the static IPV6 address you reserved. This can be optionally provided to deploy a loadbalancer with an IPV6 address in GCP.
+    ## ref https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address
+    ##
+    staticIPV6Name: ""
+## Turbinia dfDewey parameters
+##
+dfdewey:
+  ## @section dfDewey PostgreSQL Configuration Parameters
+  ##
+  postgresql:
+    ## @param dfdewey.postgresql.enabled Enables the Postgresql deployment
+    ##
+    enabled: true
+    ## @param dfdewey.postgresql.nameOverride String to partially override common.names.fullname template
+    ##
+    nameOverride: dfdewey-postgresql
+    ## PostgreSQL Authentication parameters
+    ##
+    auth:
+      ## @param dfdewey.postgresql.auth.username Name for a custom user to create
+      ##
+      username: "dfdewey"
+      ## @param dfdewey.postgresql.auth.password Password for the custom user to create. Ignored if auth.existingSecret is provided
+      ##
+      password: "password"
+      ## @param dfdewey.postgresql.auth.database Name for a custom database to create
+      ##
+      database: "dfdewey"
+    ## PostgreSQL Primary configuration parameters
+    ##
+    primary:
+      ## PostgreSQL Primary persistence configuration
+      ##
+      persistence:
+        ## @param dfdewey.postgresql.primary.persistence.size PostgreSQL Persistent Volume size
+        ##
+        size: 8Gi
+      ## PostgreSQL Primary resource requests and limits
+      ## @param dfdewey.postgresql.primary.resources.requests.cpu Requested cpu for the PostgreSQL Primary containers
+      ## @param dfdewey.postgresql.primary.resources.requests.memory Requested memory for the PostgreSQL Primary containers
+      ## @param dfdewey.postgresql.primary.resources.limits Resource limits for the PostgreSQL Primary containers
+      ##
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits: {}
+  ## @section dfDewey Opensearch Configuration Parameters
+  ## IMPORTANT: The Opensearch Security Plugin / TLS has not yet been configured by default
+  ## ref on steps required https://opensearch.org/docs/1.1/security-plugin/configuration/index/
+  ##
+  opensearch:
+    ## @param dfdewey.opensearch.enabled Enables the Opensearch deployment
+    ##
+    enabled: true
+    ## @param dfdewey.opensearch.nameOverride Overrides the clusterName when used in the naming of resources
+    ##
+    nameOverride: dfdewey-opensearch
+    ## @param dfdewey.opensearch.masterService The service name used to connect to the masters
+    ##
+    masterService: dfdewey-opensearch
+    ## @param dfdewey.opensearch.singleNode Replicas will be forced to 1
+    ##
+    singleNode: true
+    ## @param dfdewey.opensearch.sysctlInit.enabled Sets optimal sysctl's through privileged initContainer
+    ##
+    sysctlInit:
+      enabled: true
+    ## @param dfdewey.opensearch.opensearchJavaOpts Sets the size of the Opensearch Java heap
+    ## It is recommended to use at least half the system's available ram
+    ##
+    opensearchJavaOpts: "-Xms512m -Xmx512m"
+    ## @param dfdewey.opensearch.config.opensearch.yml Opensearch configuration file. Can be appended for additional configuration options
+    ## Values must be YAML literal style scalar / YAML multiline string
+    ## <filename>: |
+    ##   <formatted-value(s)>
+    ##
+    config:
+      opensearch.yml: |
+        discovery:
+          type: single-node
+        plugins:
+          security:
+            disabled: true
+    extraEnvs:
+    ## @param dfdewey.opensearch.extraEnvs[0].name Environment variable to set the initial admin password
+    ##
+    - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
+    ## @param dfdewey.opensearch.extraEnvs[0].value The initial admin password
+    ##
+      value: KyfwJExU2!2MvU6j
+    ## @param dfdewey.opensearch.extraEnvs[1].name Environment variable to disable Opensearch Demo config
+    ##
+    - name: DISABLE_INSTALL_DEMO_CONFIG
+    ## @param dfdewey.opensearch.extraEnvs[1].value Disables Opensearch Demo config
+    ##
+      value: "true"
+    ## @param dfdewey.opensearch.extraEnvs[2].name Environment variable to disable Opensearch Security plugin given that
+    ## certificates were not setup as part of this deployment
+    ##
+    - name: DISABLE_SECURITY_PLUGIN
+    ## @param dfdewey.opensearch.extraEnvs[2].value Disables Opensearch Security plugin
+    ##
+      value: "true"
+    ## Opensearch persistence configuration
+    ##
+    persistence:
+      ## @param dfdewey.opensearch.persistence.size Opensearch Persistent Volume size. A persistent volume would be created for each Opensearch replica running
+      ##
+      size: 2Gi
+    ## Opensearch resource requests
+    ## @param dfdewey.opensearch.resources.requests.cpu Requested cpu for the Opensearch containers
+    ## @param dfdewey.opensearch.resources.requests.memory Requested memory for the Opensearch containers
+    ##
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+## @section Third Party Configuration
+##
+## @section Redis configuration parameters
+## IMPORTANT: Redis is deployed with Auth enabled by default
+## To see a full list of available values, run helm show values charts/redis*
+##
+redis:
+  ## @param redis.enabled enabled Enables the Redis deployment
+  ##
+  enabled: true
+  ## Redis Authentication parameters
+  ##
+  auth:
+    ## @param redis.auth.enabled Enables Redis Authentication. Disabled due to incompatibility with Turbinia
+    ##
+    enabled: false
+  ## @param redis.sentinel.enabled Enables Redis Sentinel on Redis pods
+  ## IMPORTANT: This has not been tested for Turbinia so would leave this disabled
+  ##
+  sentinel:
+    enabled: false
+  ## @param redis.architecture Specifies the Redis architecture. Allowed values: `standalone` or `replication`
+  ##
+  architecture: standalone
+  ## Master Redis Service configuration
+  ##
+  master:
+    ## @param redis.master.count Number of Redis master instances to deploy (experimental, requires additional configuration)
+    ##
+    count: 1
+    ## Redis master service parameters
+    ##
+    service:
+      ## @param redis.master.service.type Redis master service type
+      ##
+      type: ClusterIP
+      ## @param redis.master.service.ports.redis Redis master service port
+      ##
+      ports:
+        redis: 6379
+    ## Redis master persistence configuration
+    ##
+    persistence:
+      ## @param redis.master.persistence.size Persistent Volume size
+      ##
+      size: 2Gi
+    ## Redis master resource requests and limits
+    ## @param redis.master.resources.limits Resource limits for the Redis master containers
+    ## @param redis.master.resources.requests Requested resources for the Redis master containers
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 500m
+      ##    memory: 1Gi
+      limits: {}
+      ## Example:
+      ## requests:
+      ##    cpu: 500m
+      ##    memory: 1Gi
+      requests: {}
+  ## Redis replicas configuration parameters
+  ##
+  replica:
+    ## @param redis.replica.replicaCount Number of Redis replicas to deploy
+    ##
+    replicaCount: 0
+    ## Redis replicas service parameters
+    ##
+    service:
+      ## @param redis.replica.service.type Redis replicas service type
+      ##
+      type: ClusterIP
+      ## @param redis.replica.service.ports.redis Redis replicas service port
+      ##
+      ports:
+        redis: 6379
+    ## Redis replicas persistence configuration
+    ##
+    persistence:
+      ## @param redis.replica.persistence.size Persistent Volume size
+      ##
+      size: 2Gi
+    ## Redis Replica resource requests and limits
+    ## @param redis.replica.resources.limits Resources limits for the Redis replica containers
+    ## @param redis.replica.resources.requests Requested resources for the Redis replica containers
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 500m
+      ##    memory: 1Gi
+      limits: {}
+      ## Example:
+      ## requests:
+      ##    cpu: 500m
+      ##    memory: 1Gi
+      requests: {}
+## @section Oauth2 Proxy configuration parameters
+## To see a full list of available values, run helm show values charts/oauth2-proxy*
+##
+oauth2proxy:
+  ## @param oauth2proxy.enabled Enables the Oauth2 Proxy deployment
+  ##
+  enabled: false
+  ## @param oauth2proxy.containerPort Oauth2 Proxy container port
+  ##
+  containerPort: 4180
+  ## OAuth2 Proxy service parameters
+  ##
+  service:
+    ## @param oauth2proxy.service.type OAuth2 Proxy service type
+    ##
+    type: ClusterIP
+    ## @param oauth2proxy.service.port OAuth2 Proxy service HTTP port
+    ##
+    port: 8080
+  ## Used to pass OIDC desktop client to deployment
+  ## @param oauth2proxy.extraEnvVars[0].name Name of the environment variable to pass to Oauth2 Proxy
+  ## @param oauth2proxy.extraEnvVars[0].valueFrom.secretKeyRef.name Name of the secret containing native client id
+  ## @param oauth2proxy.extraEnvVars[0].valueFrom.secretKeyRef.key Name of the secret key containing native client id
+  ## @param oauth2proxy.extraEnvVars[0].valueFrom.secretKeyRef.optional Set to optional if native client id is not provided
+  ##
+  extraEnvVars:
+    - name: OAUTH2_PROXY_OIDC_EXTRA_AUDIENCES
+      valueFrom:
+        secretKeyRef:
+          name: '{{ template "oauth2-proxy.secretName" . }}'
+          key: client-id-native
+          optional: true
+  ## Configuration section
+  ##
+  configuration:
+    ## @param oauth2proxy.configuration.turbiniaSvcPort Turbinia service port referenced from `.Values.service.port` to be used in Oauth setup
+    ##
+    turbiniaSvcPort: *turbiniaSvcPort
+    ## @param oauth2proxy.configuration.existingSecret Secret with the client ID, client secret, client native id (optional) and cookie secret
+    ##
+    existingSecret: ""
+    ## Custom configuration file: oauth2_proxy.cfg
+    ## content: |
+    ##   pass_basic_auth = false
+    ##   pass_access_token = true
+    ##
+    ## @param oauth2proxy.configuration.content [string] Oauth2 proxy configuration. Please see the [official docs](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview) for a list of configurable values
+    ##
+    content: |
+      provider="oidc"
+      oidc_jwks_url="https://accounts.google.com/.well-known/openid-configuration"
+      scope="https://www.googleapis.com/auth/userinfo.email"
+      skip_jwt_bearer_tokens=true
+      force_code_challenge_method='S256'
+      logging_filename = "/tmp/oauth2proxy.log"
+      standard_logging = true
+      request_logging = true
+      auth_logging = true
+      show_debug_on_error=true
+      upstreams=["http://{{ .Release.Name }}-turbinia:{{ .Values.configuration.turbiniaSvcPort }}"]
+    ## Authorize individual email addresses
+    ## @param oauth2proxy.configuration.authenticatedEmailsFile.enabled Enable authenticated emails file
+    ## @param oauth2proxy.configuration.authenticatedEmailsFile.content Restricted access list (one email per line). At least one email address is required for the Oauth2 Proxy to properly work
+    ## @param oauth2proxy.configuration.authenticatedEmailsFile.existingSecret Secret with the authenticated emails file
+    ##
+    authenticatedEmailsFile:
+      enabled: true
+      ## One email per line
+      ## e.g:
+      ## content: |-
+      ##   name1@domain
+      ##   name2@domain
+      ## If you override the config with restricted_access it will configure a user list within this chart what takes care of the configmap
+      ##
+      content: ""
+      ## @param oauth2proxy.configuration.authenticatedEmailsFile.existingSecret Secret with the authenticated emails file
+      ##
+      existingSecret: ""
+    ## @param oauth2proxy.configuration.oidcIssuerUrl OpenID Connect issuer URL
+    ##
+    oidcIssuerUrl: "https://accounts.google.com"
+  ## Oauth2 Proxy Redis Subchart
+  ##
+  redis:
+    ## @param oauth2proxy.redis.enabled Enable Redis for OAuth Session Storage
+    ##
+    enabled: false


### PR DESCRIPTION
### Description of the change

<!-- Describe what the change does. -->

Move Turbinia and dfDewey helm charts to Turbinia repo for archiving purposes. This is because these helm charts will be removed from the OSDFIR Infrastructure helm chart, but we should still save these somewhere. Included dfdewey as Turbinia utilizes dfDewey as one of its workers.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] All tests were successful.
