### PR TITLE
Extend Redis analysis task #1032 to detect CVE-2022-0543

### DIFF
--- a/turbinia/jobs/redis.py
+++ b/turbinia/jobs/redis.py
@@ -50,9 +50,11 @@ class RedisExtractionJob(interface.TurbiniaJob):
     Returns:
         A list of tasks to schedule.
     """
-    tasks = [
-        artifact.FileArtifactExtractionTask('RedisConfigFile') for _ in evidence
-    ]
+    tasks = []
+    for _ in evidence:
+      tasks.append(artifact.FileArtifactExtractionTask('RedisConfigFile'))
+      tasks.append(artifact.FileArtifactExtractionTask('RedisConfigurationFile'))
+      tasks.append(artifact.FileArtifactExtractionTask('RedisLogFiles'))
     return tasks
 
 
@@ -75,7 +77,8 @@ class RedisAnalysisJob(interface.TurbiniaJob):
     """
     tasks = []
     for evidence_item in evidence:
-      if evidence_item.artifact_name == 'RedisConfigFile':
+      if evidence_item.artifact_name in (
+          'RedisConfigFile', 'RedisConfigurationFile', 'RedisLogFiles'):
         tasks.append(redis.RedisAnalysisTask())
     return tasks
 

--- a/turbinia/jobs/redis.py
+++ b/turbinia/jobs/redis.py
@@ -53,7 +53,8 @@ class RedisExtractionJob(interface.TurbiniaJob):
     tasks = []
     for _ in evidence:
       tasks.append(artifact.FileArtifactExtractionTask('RedisConfigFile'))
-      tasks.append(artifact.FileArtifactExtractionTask('RedisConfigurationFile'))
+      tasks.append(
+          artifact.FileArtifactExtractionTask('RedisConfigurationFile'))
       tasks.append(artifact.FileArtifactExtractionTask('RedisLogFiles'))
     return tasks
 
@@ -77,8 +78,9 @@ class RedisAnalysisJob(interface.TurbiniaJob):
     """
     tasks = []
     for evidence_item in evidence:
-      if evidence_item.artifact_name in (
-          'RedisConfigFile', 'RedisConfigurationFile', 'RedisLogFiles'):
+      if evidence_item.artifact_name in ('RedisConfigFile',
+                                         'RedisConfigurationFile',
+                                         'RedisLogFiles'):
         tasks.append(redis.RedisAnalysisTask())
     return tasks
 

--- a/turbinia/workers/analysis/redis.py
+++ b/turbinia/workers/analysis/redis.py
@@ -47,10 +47,10 @@ class RedisAnalysisTask(TurbiniaTask):
     output_evidence = ReportText(source_path=output_file_path)
 
     # Read the input file
-    with open(evidence.local_path, 'r') as input_file:
-      redis_config = input_file.read()
+    with open(evidence.local_path, 'r', errors='ignore') as input_file:
+      redis_data = input_file.read()
 
-    (report, priority, summary) = self.analyse_redis_config(redis_config)
+    (report, priority, summary) = self.analyse_redis(redis_data)
     output_evidence.text_data = report
     result.report_priority = priority
     result.report_data = report
@@ -64,8 +64,8 @@ class RedisAnalysisTask(TurbiniaTask):
     result.close(self, success=True, status=summary)
     return result
 
-  def analyse_redis_config(self, config):
-    """Analyses a Redis configuration.
+  def analyse_redis(self, config):
+    """Analyses a Redis configuration or log file.
 
     Args:
       config (str): configuration file content.
@@ -80,12 +80,22 @@ class RedisAnalysisTask(TurbiniaTask):
     findings = []
     bind_everywhere_re = re.compile(
         r'^\s*bind[\s"]*0\.0\.0\.0', re.IGNORECASE | re.MULTILINE)
+    
+    # CVE-2022-0543 Lua sandbox escape indicators
+    lua_sandbox_escape_re = re.compile(
+        r'(package\.loadlib|os\.execute|io\.popen)', re.IGNORECASE)
 
     if re.search(bind_everywhere_re, config):
       findings.append(fmt.bullet('Redis listening on every IP'))
 
+    if re.search(lua_sandbox_escape_re, config):
+      findings.append(
+          fmt.bullet(
+              'Redis Lua sandbox escape (CVE-2022-0543) exploitation indicators '
+              'found (e.g. package.loadlib, os.execute)'))
+
     if findings:
-      summary = 'Insecure Redis configuration found.'
+      summary = 'Redis analysis found potential issues.'
       findings.insert(0, fmt.heading4(fmt.bold(summary)))
       report = '\n'.join(findings)
       return (report, Priority.HIGH, summary)

--- a/turbinia/workers/analysis/redis.py
+++ b/turbinia/workers/analysis/redis.py
@@ -80,7 +80,7 @@ class RedisAnalysisTask(TurbiniaTask):
     findings = []
     bind_everywhere_re = re.compile(
         r'^\s*bind[\s"]*0\.0\.0\.0', re.IGNORECASE | re.MULTILINE)
-    
+
     # CVE-2022-0543 Lua sandbox escape indicators
     lua_sandbox_escape_re = re.compile(
         r'(package\.loadlib|os\.execute|io\.popen)', re.IGNORECASE)

--- a/turbinia/workers/analysis/redis_test.py
+++ b/turbinia/workers/analysis/redis_test.py
@@ -28,9 +28,9 @@ port 6379
 bind 0.0.0.0 ::1
 """
 
-  REDIS_BIND_EVERYWHERE_SUMMARY = """Insecure Redis configuration found."""
+  REDIS_BIND_EVERYWHERE_SUMMARY = """Redis analysis found potential issues."""
 
-  REDIS_BIND_EVERYWHERE_REPORT = """#### **Insecure Redis configuration found.**
+  REDIS_BIND_EVERYWHERE_REPORT = """#### **Redis analysis found potential issues.**
 * Redis listening on every IP"""
 
   REDIS_BIND_NOWHERE = """# If port 0 is specified Redis will not listen
@@ -38,19 +38,33 @@ port 6379
 """
   REDIS_BIND_NOWHERE_REPORT = 'No issues found in Redis configuration'
 
-  def test_analyse_redis_config(self):
-    """Tests the analyze_redis_config method."""
+  REDIS_EXPLOIT_LOG = (
+      '123:M 12 Mar 2022 10:00:00.000 * Background rewriting started\n'
+      '456:C 12 Mar 2022 10:00:01.000 * eval "package.loadlib(\'lib\', \'io\')" 0\n'
+  )
+  REDIS_EXPLOIT_REPORT = (
+      '#### **Redis analysis found potential issues.**\n'
+      '* Redis Lua sandbox escape (CVE-2022-0543) exploitation indicators '
+      'found (e.g. package.loadlib, os.execute)')
+
+  def test_analyse_redis(self):
+    """Tests the analyse_redis method."""
     config.LoadConfig()
     task = redis.RedisAnalysisTask()
 
-    (report, priority, summary) = task.analyse_redis_config(
-        self.REDIS_BIND_EVERYWHERE)
+    (report, priority, summary) = task.analyse_redis(self.REDIS_BIND_EVERYWHERE)
     self.assertEqual(report, self.REDIS_BIND_EVERYWHERE_REPORT)
     self.assertEqual(priority, 20)
     self.assertEqual(summary, self.REDIS_BIND_EVERYWHERE_SUMMARY)
 
-    report = task.analyse_redis_config(self.REDIS_BIND_NOWHERE)[0]
+    report = task.analyse_redis(self.REDIS_BIND_NOWHERE)[0]
     self.assertEqual(report, self.REDIS_BIND_NOWHERE_REPORT)
+
+    # Test exploitation log
+    (report, priority, summary) = task.analyse_redis(self.REDIS_EXPLOIT_LOG)
+    self.assertEqual(report, self.REDIS_EXPLOIT_REPORT)
+    self.assertEqual(priority, 20)
+    self.assertEqual(summary, self.REDIS_BIND_EVERYWHERE_SUMMARY)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Description of the change

This pull request extends the `RedisAnalysisTask` to detect signs of exploitation for the Redis Lua Sandbox Escape vulnerability (**CVE-2022-0543**), which is frequently utilized by the Muhstik botnet.

Changes include:
*   **Artifact Extraction Updates**: Updated `RedisExtractionJob` and `RedisAnalysisJob` in `turbinia/jobs/redis.py` to correctly extract and process `RedisLogFiles` and `RedisConfigurationFile` artifacts.
*   **Exploitation Detection Logic**: Added regular expressions to `turbinia/workers/analysis/redis.py` that look for known exploit patterns, primarily targeting malicious Lua payloads containing `package.loadlib`, `os.execute`, or `io.popen`.
*   **Robust Decoding**: The file reader in the analysis task now ignores text encoding errors to prevent crashes if it encounters non-UTF-8 characters in payloads or binary data within AOF caches/logs.
*   **Tests**: Updated and expanded `turbinia/workers/analysis/redis_test.py` to verify the detection logic using a mocked exploitation log sample.

### Applicable issues

- fixes #1032

### Additional information

The payload signatures specifically target the execution of arbitrary operating system commands originating from within malicious Lua scripts via `eval` wrappers, which is the most common manifestation of this vulnerability.

### Checklist

- [X] All tests were successful.
- [X] Unit tests added.
- [ ] Documentation updated. 
